### PR TITLE
Define free parameters and concrete

### DIFF
--- a/src/glossary.md
+++ b/src/glossary.md
@@ -91,7 +91,12 @@ A variable is initialized if it has been assigned a value and hasn't since been
 moved from. All other memory locations are assumed to be uninitialized. Only
 unsafe Rust can create such a memory without initializing it.
 
-### Nominal types
+### Monomorphization
+
+The act of substituting free variables in an item or type for [concrete] types
+and lifetimes.
+
+### Nominal Types
 
 Types that can be referred to by a path directly. Specifically [enums],
 [structs], [unions], and [trait objects].

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -42,6 +42,12 @@ Combinators are higher-order functions that apply only functions and
 earlier defined combinators to provide a result from its arguments.
 They can be used to manage control flow in a modular fashion.
 
+### Concrete
+
+Concrete items and types are those without free type or lifetime parameters.
+
+[More][concrete].
+
 ### Dispatch
 
 Dispatch is the mechanism to determine which specific version of code is actually
@@ -64,6 +70,17 @@ For example, `2 + (3 * 4)` is an expression that returns the value 14.
 
 An [item] that is not a member of an [implementation], such as a *free
 function* or a *free const*. Contrast to an [associated item].
+
+### Free parameters
+
+Free parameters are those that refer to a generically declared type or lifetime
+parameter.
+
+[More][concrete].
+
+### Ground type
+
+See [concrete](#concrete).
 
 ### Inherent implementation
 
@@ -161,6 +178,7 @@ or unintended computation; or platform-specific results.
 
 [alignment]: type-layout.html#size-and-alignment
 [associated item]: #associated-item
+[concrete]: generics.html#free-parameters-and-concrete-items-and-types
 [enums]: items/enumerations.html
 [free item]: #free-item
 [function]: items/functions.html

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -44,7 +44,7 @@ They can be used to manage control flow in a modular fashion.
 
 ### Concrete
 
-Concrete items and types are those without free type or lifetime parameters.
+Concrete items and types are those without free type or lifetime variables.
 
 [More][concrete].
 
@@ -71,9 +71,9 @@ For example, `2 + (3 * 4)` is an expression that returns the value 14.
 An [item] that is not a member of an [implementation], such as a *free
 function* or a *free const*. Contrast to an [associated item].
 
-### Free parameters
+### Free variables
 
-Free parameters are those that refer to a generically declared type or lifetime
+Free variables are those that refer to a generically declared type or lifetime
 parameter.
 
 [More][concrete].

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -44,7 +44,7 @@ They can be used to manage control flow in a modular fashion.
 
 ### Concrete
 
-Concrete items and types are those without free type or lifetime variables.
+Concrete things are those without free type or lifetime variables.
 
 [More][concrete]. [Wikipedia][concrete wikipedia].
 
@@ -176,7 +176,7 @@ or unintended computation; or platform-specific results.
 
 [alignment]: type-layout.html#size-and-alignment
 [associated item]: #associated-item
-[concrete]: items/generics.html#free-variables-and-concrete-items-and-types
+[concrete]: items/generics.html#formulae-and-free-variables
 [concrete wikipedia]: https://en.wikipedia.org/wiki/Free_variables_and_bound_variables
 [enums]: items/enumerations.html
 [free item]: #free-item

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -46,7 +46,7 @@ They can be used to manage control flow in a modular fashion.
 
 Concrete items and types are those without free type or lifetime variables.
 
-[More][concrete].
+[More][concrete]. [Wikipedia][concrete wikipedia].
 
 ### Dispatch
 
@@ -70,13 +70,6 @@ For example, `2 + (3 * 4)` is an expression that returns the value 14.
 
 An [item] that is not a member of an [implementation], such as a *free
 function* or a *free const*. Contrast to an [associated item].
-
-### Free variables
-
-Free variables are those that refer to a generically declared type or lifetime
-parameter.
-
-[More][concrete].
 
 ### Ground type
 
@@ -179,6 +172,7 @@ or unintended computation; or platform-specific results.
 [alignment]: type-layout.html#size-and-alignment
 [associated item]: #associated-item
 [concrete]: generics.html#free-parameters-and-concrete-items-and-types
+[concrete wikipedia]: https://en.wikipedia.org/wiki/Free_variables_and_bound_variables
 [enums]: items/enumerations.html
 [free item]: #free-item
 [function]: items/functions.html

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -176,7 +176,7 @@ or unintended computation; or platform-specific results.
 
 [alignment]: type-layout.html#size-and-alignment
 [associated item]: #associated-item
-[concrete]: generics.html#free-parameters-and-concrete-items-and-types
+[concrete]: items/generics.html#free-variables-and-concrete-items-and-types
 [concrete wikipedia]: https://en.wikipedia.org/wiki/Free_variables_and_bound_variables
 [enums]: items/enumerations.html
 [free item]: #free-item

--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -22,11 +22,11 @@
 
 Functions, type aliases, structs, enumerations, unions, traits and
 implementations may be *parameterized* by types and lifetimes. These parameters
-are listed in angle <span class="parenthetical">brackets (`<...>`)</span>,
+are declared in angle <span class="parenthetical">brackets (`<...>`)</span>,
 usually immediately after the name of the item and before its definition. For
-implementations, which don't have a name, they come directly after `impl`.
-Lifetime parameters must be declared before type parameters. Some examples of
-items with type and lifetime parameters:
+implementations, which don't have a name, they are declared directly after the
+`impl` keyword. Lifetime parameters must be declared before type parameters.
+Some examples of items with type and lifetime parameters:
 
 ```rust
 fn foo<'a, T>() {}
@@ -82,6 +82,54 @@ where
     f: T,
 }
 ```
+
+## Free parameters and concrete items and types
+
+The *free parameters* of an item or type are the type and lifetime paremeters
+that refer to a generically declared parameter. A *concrete item* or *concrete
+type* is one that does not have any free parameters.
+
+For example, consider this trait:
+
+```rust
+# struct SomeStruct;
+#
+trait Example<A> {
+    fn foo(a: A)
+
+    fn bar<'b'>(a: A, b: &'b SomeStruct)
+
+    fn baz()
+
+    fn quux(a: i32, b: Option<i32>)
+}
+```
+
+In it, the trait `Example` has a free variable `A` because it declares it
+itself. Furthermore, `foo` has `A` as a free variable because it uses it as the
+type of its first argument. `baz` has both `A` and `B` as free type parameters,
+getting `A` from the trait's parameters and defining `B` itself. Both `baz` and
+`quux` have no free type parameters and are thusly concrete.
+
+For another example, the function `for<'a> fn foo(a: &'a i32>` is concrete.
+
+For another example, the following table shows the free type parameters of
+various types. Types without free parmaeters show "concrete" instead of "none".
+Assume `A`, `E`, and `'a` are defined as generic parameters.
+
+| Type | Free Parameters |
+| `i32` | concrete | 
+| `&'a i32` | `'a` |
+| `&'static i32` | concrete |
+| `UserDefinedType` | concrete |
+| `GenericDefinedType<A>` | `A` |
+| `GenericDefinedType<i32>` | concrete |
+| `GenericDefinedType<Option<A>>` | `A` |
+| `GenericDefinedType<Result<&'a A, E>` | `'a`, `A`, `E` |
+| `GenericDefinedType<Option<UserDefinedType>` | concrete |
+
+> Note: In some programming languages and in type theory, concrete types are
+> called *ground types*.
 
 ## Attributes
 

--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -87,7 +87,8 @@ where
 
 The *free variables* of an item or type are the type and lifetime variables
 that refer to a generically declared parameter. A *concrete item* or *concrete
-type* is one that does not have any free variables.
+type* is one that does not have any free variables. See [Wikipeida][concrete
+wikipedia] for more.
 
 For example, consider this trait:
 
@@ -159,6 +160,7 @@ generic parameter.
 [_TypeParamBounds_]: trait-bounds.html
 
 [arrays]: types/array.html
+[concrete wikipedia]: https://en.wikipedia.org/wiki/Free_variables_and_bound_variables
 [function pointers]: types/function-pointer.html
 [references]: types/pointer.html#shared-references-
 [raw pointers]: types/pointer.html#raw-pointers-const-and-mut

--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -83,11 +83,11 @@ where
 }
 ```
 
-## Free parameters and concrete items and types
+## Free variables and concrete items and types
 
-The *free parameters* of an item or type are the type and lifetime paremeters
+The *free variables* of an item or type are the type and lifetime variables
 that refer to a generically declared parameter. A *concrete item* or *concrete
-type* is one that does not have any free parameters.
+type* is one that does not have any free variables.
 
 For example, consider this trait:
 
@@ -107,17 +107,18 @@ trait Example<A> {
 
 In it, the trait `Example` has a free variable `A` because it declares it
 itself. Furthermore, `foo` has `A` as a free variable because it uses it as the
-type of its first argument. `baz` has both `A` and `B` as free type parameters,
-getting `A` from the trait's parameters and defining `B` itself. Both `baz` and
-`quux` have no free type parameters and are thusly concrete.
+type of its first argument. `baz` has both `A` and `B` as free type variables,
+getting `A` from the trait's generic parameters and defining `B` as a generic
+parmaeter itself. Both `baz` and `quux` have no free type variables and are
+thusly concrete.
 
 For another example, the function `for<'a> fn foo(a: &'a i32>` is concrete.
 
-For another example, the following table shows the free type parameters of
+For another example, the following table shows the free type variables of
 various types. Types without free parmaeters show "concrete" instead of "none".
 Assume `A`, `E`, and `'a` are defined as generic parameters.
 
-| Type | Free Parameters |
+| Type | Free Variables |
 | `i32` | concrete | 
 | `&'a i32` | `'a` |
 | `&'static i32` | concrete |

--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -86,8 +86,8 @@ where
 ## Free variables and concrete items and types
 
 The *free variables* of an item or type are the type and lifetime variables
-that refer to a generically declared parameter. A *concrete item* or *concrete
-type* is one that does not have any free variables. See [Wikipeida][concrete
+not bound therein. These variables may be substituted for other types or lifetimes. A *concrete item* or *concrete
+type* is one without free variables. See [Wikipeida][concrete
 wikipedia] for more.
 
 For example, consider this trait:
@@ -108,16 +108,16 @@ trait Example<A> {
 
 In it, the trait `Example` has a free variable `A` because it declares it
 itself. Furthermore, `foo` has `A` as a free variable because it uses it as the
-type of its first argument. `baz` has both `A` and `B` as free type variables,
-getting `A` from the trait's generic parameters and defining `B` as a generic
+type of its first argument. The function `bar` has `A` as a free type variable,
+getting `A` from the trait's generic parameters. However, the lifetime `'b` is bound in `baz` but is free in `&'b SomeStruct`.
 parmaeter itself. Both `baz` and `quux` have no free type variables and are
-thusly concrete.
+thus concrete.
 
-For another example, the function `for<'a> fn foo(a: &'a i32>` is concrete.
+For another example, the function `for<'a> fn foo(a: &'a i32>` is concrete but in `&'a i32`, `'a` is a free variable.
 
 For another example, the following table shows the free type variables of
-various types. Types without free parmaeters show "concrete" instead of "none".
-Assume `A`, `E`, and `'a` are defined as generic parameters.
+various types. Types without free parameters show "concrete" instead of "none".
+Assume that `A`, `E`, and `'a` are defined as generic parameters.
 
 | Type | Free Variables |
 | `i32` | concrete | 

--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -95,13 +95,13 @@ For example, consider this trait:
 # struct SomeStruct;
 #
 trait Example<A> {
-    fn foo(a: A)
+    fn foo(a: A);
 
-    fn bar<'b'>(a: A, b: &'b SomeStruct)
+    fn bar<'b'>(a: A, b: &'b SomeStruct);
 
-    fn baz()
+    fn baz();
 
-    fn quux(a: i32, b: Option<i32>)
+    fn quux(a: i32, b: Option<i32>);
 }
 ```
 

--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -98,7 +98,7 @@ For example, consider this trait:
 trait Example<A> {
     fn foo(a: A);
 
-    fn bar<'b'>(a: A, b: &'b SomeStruct);
+    fn bar<'b>(a: A, b: &'b SomeStruct);
 
     fn baz();
 

--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -83,14 +83,50 @@ where
 }
 ```
 
-## Free variables and concrete items and types
+## Formulae and Free Variables
 
-The *free variables* of an item or type are the type and lifetime variables
-not bound therein. These variables may be substituted for other types or lifetimes. A *concrete item* or *concrete
-type* is one without free variables. See [Wikipeida][concrete
-wikipedia] for more.
+The syntatic locations a *variable* is allowed is a *formulae*. Formulae for
+type and lifetime variables are:
 
-For example, consider this trait:
+* [Types]
+* Type constructors (for example, `Option` in `enum Option<T> { ... }`)
+* Lifetimes (only lifetime variables)
+* [Items]
+* Item constructors (for example, `Into` in `trait Into<T>`)
+* [Associated Items]
+* [Trait Bounds]
+* [Expressions] \(through path expressions with generics)
+
+The free variables of a formulae are those not referenced (*bound*) by a generic
+binder in the formulae.
+
+These free variables may be substituted for other types or lifetimes.
+A formulae is *concrete*, or *closed*, if there are no free variables in it.
+See [Wikipedia][wikipedia free variables] for more.
+
+Examples of generic binders for type and lifetime variables are:
+
+* `for<'a>` in `for<'a> fn(&'a u8)`
+* `<T>` in `fn identity<T>(x: T) -> T { x }` for item constructors
+* [Traits] and [implementations] implicitly bind `Self`
+
+All type and lifetimes are unbound at the boundaries of items.
+
+Formulae nest. For example, in a function item, the entire function item is a
+formulae but so are the types of the parameters of the function. A type or
+lifetime variable may be free in one formulae but bound in a containing
+formulae. For example, in the function prototype `for<'a> fn foo(a: &'a i32>`,
+`'a` is bound by the `for<'a>` but in the formulae of the type
+`&'a i32`, `'a` is a free variable.
+
+Furthermore, the same syntax may have free variables when looked at as one
+formulae while having no free variables when looked at as another formulae. Most
+commonly, the type or item will have a free variable when the type or item
+constructor does not. For example, `Option<T>` as a type has `T` as a free
+variable but as a type constructor, has no free variables.
+
+For example of free variables and concrete formulae, consider this trait and
+function:
 
 ```rust
 # struct SomeStruct;
@@ -101,29 +137,31 @@ trait Example<A> {
     fn bar<'b>(a: A, b: &'b SomeStruct);
 
     fn baz();
+}
 
-    fn quux(a: i32, b: Option<i32>);
+fn quux(a: i32, b: Option<i32>) {
+#    unimplemented!("")
+    // ...
 }
 ```
 
-In it, the trait `Example` has a free variable `A` because it declares it
+In it, the trait `Example<A>` has a free variable `A` since it declares it
 itself. Furthermore, `foo` has `A` as a free variable because it uses it as the
 type of its first argument. The function `bar` has `A` as a free type variable,
-getting `A` from the trait's generic parameters. However, the lifetime `'b` is
-bound in `baz` but is free in tye type `&'b SomeStruct`. Both `baz` and `quux`
-have no free type variables and are thus concrete.
-
-For another example, the function `for<'a> fn foo(a: &'a i32>` is concrete but
-in the type `&'a i32`, `'a` is a free variable.
+getting `A` from the trait's generic parameters. The lifetime `'b` is bound in
+the function constructor `bar` but is free in the type `&'b SomeStruct`. All of
+these trait functions also have `Self` as a free variable despite not being
+explicitly quantified. The function `quux` is concrete.
 
 For another example, the following table shows the free type variables of
 various types. Types without free parameters show "concrete" instead of "none".
 Assume that `A`, `E`, and `'a` are defined as generic parameters.
 
 | Type | Free Variables |
+| - | - |
 | `i32` | concrete |
 | `&'a i32` | `'a` |
-| `&i32` | *anonymous lifetime of reference* |
+| `&i32` | *anonymous inferred lifetime of reference* |
 | `&'static i32` | concrete |
 | `UserDefinedType` | concrete |
 | `GenericDefinedType<A>` | `A` |
@@ -132,8 +170,10 @@ Assume that `A`, `E`, and `'a` are defined as generic parameters.
 | `GenericDefinedType<Result<&'a A, E>` | `'a`, `A`, `E` |
 | `GenericDefinedType<Option<UserDefinedType>` | concrete |
 
+
 > Note: In some programming languages and in type theory, concrete types are
-> called *ground types*.
+> called *ground types*. In mathematical logic, these are called ground
+> expressions. See [Wikipedia][wikipedia ground expression] for more.
 
 ## Attributes
 
@@ -162,13 +202,21 @@ generic parameter.
 [_TypeParamBounds_]: trait-bounds.html
 
 [arrays]: types/array.html
-[concrete wikipedia]: https://en.wikipedia.org/wiki/Free_variables_and_bound_variables
+[associated items]: items/associated-items.html
+[attributes]: attributes.html
+[expressions]: expression.html
 [function pointers]: types/function-pointer.html
+[implementations]: items/implementations.html
+[items]: items.html
 [references]: types/pointer.html#shared-references-
 [raw pointers]: types/pointer.html#raw-pointers-const-and-mut
+[trait bounds]: trait-bound.html
+[trait object]: types/trait-object.html
+[traits]: items/traitshtml
+[tuples]: types/tuple.html
+[types]: types.html
+[wikipedia free variables]: https://en.wikipedia.org/wiki/Free_variables_and_bound_variables
+[wikipedia ground expression]: https://en.wikipedia.org/wiki/Ground_expression
 [`Clone`]: special-types-and-traits.html#clone
 [`Copy`]: special-types-and-traits.html#copy
 [`Sized`]: special-types-and-traits.html#sized
-[tuples]: types/tuple.html
-[trait object]: types/trait-object.html
-[attributes]: attributes.html

--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -109,19 +109,21 @@ trait Example<A> {
 In it, the trait `Example` has a free variable `A` because it declares it
 itself. Furthermore, `foo` has `A` as a free variable because it uses it as the
 type of its first argument. The function `bar` has `A` as a free type variable,
-getting `A` from the trait's generic parameters. However, the lifetime `'b` is bound in `baz` but is free in `&'b SomeStruct`.
-parmaeter itself. Both `baz` and `quux` have no free type variables and are
-thus concrete.
+getting `A` from the trait's generic parameters. However, the lifetime `'b` is
+bound in `baz` but is free in tye type `&'b SomeStruct`. Both `baz` and `quux`
+have no free type variables and are thus concrete.
 
-For another example, the function `for<'a> fn foo(a: &'a i32>` is concrete but in `&'a i32`, `'a` is a free variable.
+For another example, the function `for<'a> fn foo(a: &'a i32>` is concrete but
+in the type `&'a i32`, `'a` is a free variable.
 
 For another example, the following table shows the free type variables of
 various types. Types without free parameters show "concrete" instead of "none".
 Assume that `A`, `E`, and `'a` are defined as generic parameters.
 
 | Type | Free Variables |
-| `i32` | concrete | 
+| `i32` | concrete |
 | `&'a i32` | `'a` |
+| `&i32` | *anonymous lifetime of reference* |
 | `&'static i32` | concrete |
 | `UserDefinedType` | concrete |
 | `GenericDefinedType<A>` | `A` |

--- a/src/types.md
+++ b/src/types.md
@@ -5,7 +5,7 @@ Every variable, item and value in a Rust program has a type. The _type_ of a
 *value* defines the interpretation of the memory holding it and the operations
 that may be performed on the value.
 
-Built-in types are tightly integrated into the language, in nontrivial ways
+Built-in types are tightly integrated into the language in nontrivial ways
 that are not possible to emulate in user-defined types. User-defined types have
 limited capabilities.
 

--- a/src/types/impl-trait.md
+++ b/src/types/impl-trait.md
@@ -27,7 +27,7 @@ They are written as `impl` followed by a set of trait bounds.
 > Note: This is often called "impl Trait in return position".
 
 Functions, except for associated trait functions, can return an abstract
-return type. These  types stand in for another concrete type where the
+return type. These  types stand in for another [concrete type] where the
 use-site may only use the trait methods declared by the trait bounds of the
 type.
 
@@ -35,3 +35,4 @@ They are written as `impl` followed by a set of trait bounds.
 
 [_TraitBound_]: trait-bounds.html
 [_TypeParamBounds_]: trait-bounds.html
+[concrete type]: generics.html#free-parameters-and-concrete-items-and-types

--- a/src/types/impl-trait.md
+++ b/src/types/impl-trait.md
@@ -35,4 +35,4 @@ They are written as `impl` followed by a set of trait bounds.
 
 [_TraitBound_]: trait-bounds.html
 [_TypeParamBounds_]: trait-bounds.html
-[concrete type]: generics.html#free-parameters-and-concrete-items-and-types
+[concrete type]: items/generics.html#free-variables-and-concrete-items-and-types

--- a/src/types/impl-trait.md
+++ b/src/types/impl-trait.md
@@ -35,4 +35,4 @@ They are written as `impl` followed by a set of trait bounds.
 
 [_TraitBound_]: trait-bounds.html
 [_TypeParamBounds_]: trait-bounds.html
-[concrete type]: items/generics.html#free-variables-and-concrete-items-and-types
+[concrete type]: items/generics.html#formulae-and-free-variables

--- a/src/types/trait-object.md
+++ b/src/types/trait-object.md
@@ -57,8 +57,8 @@ is the same, if the base traits differ, the type is different. For example,
 
 </div>
 
-Due to the opaqueness of which concrete type the value is of, trait objects are
-[dynamically sized types]. Like all
+Due to the opaqueness of which [concrete type] the value is of, trait objects
+are [dynamically sized types]. Like all
 <abbr title="dynamically sized types">DSTs</abbr>, trait objects are used
 behind some type of pointer; for example `&dyn SomeTrait` or
 `Box<dyn SomeTrait>`. Each instance of a pointer to a trait object includes:
@@ -107,6 +107,7 @@ inferred with a sensible choice.
 [_TraitBound_]: trait-bounds.html
 [_TypeParamBounds_]: types.html#type-expressions
 [auto traits]: special-types-and-traits.html#auto-traits
+[concrete type]: generics.html#free-parameters-and-concrete-items-and-types
 [defaults]: lifetime-elision.html#default-trait-object-lifetimes
 [dynamically sized types]: dynamically-sized-types.html
 [issue 33140]: https://github.com/rust-lang/rust/issues/33140

--- a/src/types/trait-object.md
+++ b/src/types/trait-object.md
@@ -107,7 +107,7 @@ inferred with a sensible choice.
 [_TraitBound_]: trait-bounds.html
 [_TypeParamBounds_]: types.html#type-expressions
 [auto traits]: special-types-and-traits.html#auto-traits
-[concrete type]: generics.html#free-parameters-and-concrete-items-and-types
+[concrete type]: items/generics.html#free-variables-and-concrete-items-and-types
 [defaults]: lifetime-elision.html#default-trait-object-lifetimes
 [dynamically sized types]: dynamically-sized-types.html
 [issue 33140]: https://github.com/rust-lang/rust/issues/33140

--- a/src/types/trait-object.md
+++ b/src/types/trait-object.md
@@ -107,7 +107,7 @@ inferred with a sensible choice.
 [_TraitBound_]: trait-bounds.html
 [_TypeParamBounds_]: types.html#type-expressions
 [auto traits]: special-types-and-traits.html#auto-traits
-[concrete type]: items/generics.html#free-variables-and-concrete-items-and-types
+[concrete type]: items/generics.html#formulae-and-free-variables
 [defaults]: lifetime-elision.html#default-trait-object-lifetimes
 [dynamically sized types]: dynamically-sized-types.html
 [issue 33140]: https://github.com/rust-lang/rust/issues/33140


### PR DESCRIPTION
Fixes #548 

I'm dissatisfied by just having two definitions and then mostly showing examples. But still better than nothing.

And while they're called "free variables" elsewhere, while we say they're generic parameters, I'd also like to call them "free parameters". I'd be willing to change `generic parameter` -> `generic variable`.