### PR TITLE
Document the `automatically_derived` attribute.

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -185,6 +185,8 @@ The following is an index of all built-in attributes.
   - [`should_panic`] — Indicates a test should generate a panic.
 - Derive
   - [`derive`] — Automatic trait implementations.
+  - [`automatically_derived`] — Marker for implementations created by
+    `derive`.
 - Macros
   - [`macro_export`] — Exports a `macro_rules` macro for cross-crate usage.
   - [`macro_use`] — Expands macro visibility, or imports macros from other
@@ -250,6 +252,7 @@ The following is an index of all built-in attributes.
 [_LiteralExpression_]: expressions/literal-expr.md
 [_SimplePath_]: paths.md#simple-paths
 [`allow`]: attributes/diagnostics.md#lint-check-attributes
+[`automatically_derived`]: attributes/derive.md#the-automatically_derived-attribute
 [`cfg_attr`]: conditional-compilation.md#the-cfg_attr-attribute
 [`cfg`]: conditional-compilation.md#the-cfg-attribute
 [`cold`]: attributes/codegen.md#the-cold-attribute

--- a/src/attributes/derive.md
+++ b/src/attributes/derive.md
@@ -33,10 +33,19 @@ impl<T: PartialEq> PartialEq for Foo<T> {
 
 You can implement `derive` for your own traits through [procedural macros].
 
+## The `automatically_derived` attribute
+
+The *`automatically_derived` attribute* is automatically added to
+[implementations] created by the `derive` attribute for built-in traits. It
+has no direct effect, but it may be used by tools and diagnostic lints to
+detect these automatically generated implementations.
+
 [_MetaListPaths_]: ../attributes.md#meta-item-attribute-syntax
 [`Clone`]: ../../std/clone/trait.Clone.html
 [`PartialEq`]: ../../std/cmp/trait.PartialEq.html
 [`impl` item]: ../items/implementations.md
 [items]: ../items.md
 [derive macros]: ../procedural-macros.md#derive-macros
+[implementations]: ../items/implementations.md
+[items]: ../items.md
 [procedural macros]: ../procedural-macros.md#derive-macros


### PR DESCRIPTION
It's not clear if this *should* be documented. Alternatively, it could be deprecated if usage in stable is really not desired. Not sure who can make this call.

Implemented in: https://github.com/rust-lang/rust/pull/12929

CC #532
