### PR TITLE
Undocument `use` paths.

### DIFF
--- a/src/items/use-declarations.md
+++ b/src/items/use-declarations.md
@@ -82,13 +82,9 @@ In this example, the module `quux` re-exports two public names defined in
 
 ## `use` Paths
 
-Paths in `use` items must start with a crate name or one of the [path
-qualifiers] `crate`, `self`, `super`, or `::`. `crate` refers to the current
-crate. `self` refers to the current module. `super` refers to the parent
-module. `::` can be used to explicitly refer to a crate, requiring an extern
-crate name to follow.
+> **Note**: This section is incomplete.
 
-An example of what will and will not work for `use` items:
+Some examples of what will and will not work for `use` items:
 <!-- Note: This example works as-is in either 2015 or 2018. -->
 
 ```rust


### PR DESCRIPTION
The current documentation is woefully out of date and incomplete.  I've been trying off and on to study the resolver to begin #568, which will be required to finish this, but I probably won't be able to finish for a long while.
