### PR TITLE
Make Rust 2018 primary and use "Edition Differences" for Rust 2015

### DIFF
--- a/src/items/traits.md
+++ b/src/items/traits.md
@@ -171,21 +171,12 @@ The [trait implementation] must also begin with the `unsafe` keyword.
 
 ## Parameter patterns
 
-Function or method declarations without a body only allow [IDENTIFIER] or
-`_` [wild card][WildcardPattern] patterns. `mut` [IDENTIFIER] is currently
-allowed, but it is deprecated and will become a hard error in the future.
-<!-- https://github.com/rust-lang/rust/issues/35203 -->
+In function and method declarations, the parameter pattern is required.
 
-In the 2015 edition, the pattern for a trait function or method parameter is
-optional:
+If the function or method has a body, any irrefutable pattern is allowed.
 
-```rust
-trait T {
-    fn f(i32);  // Parameter identifiers are not required.
-}
-```
-
-The kinds of patterns for parameters is limited to one of the following:
+If the function or method has no body, the pattern must have one of the
+following forms:
 
 * [IDENTIFIER]
 * `mut` [IDENTIFIER]
@@ -193,16 +184,28 @@ The kinds of patterns for parameters is limited to one of the following:
 * `&` [IDENTIFIER]
 * `&&` [IDENTIFIER]
 
-Beginning in the 2018 edition, function or method parameter patterns are no
-longer optional. Also, all irrefutable patterns are allowed as long as there
-is a body. Without a body, the limitations listed above are still in effect.
-
 ```rust,edition2018
 trait T {
     fn f1((a, b): (i32, i32)) {}
     fn f2(_: (i32, i32));  // Cannot use tuple pattern without a body.
 }
 ```
+
+`mut` [IDENTIFIER] is deprecated and will become a hard error in the future.
+<!-- https://github.com/rust-lang/rust/issues/35203 -->
+
+> **Edition Differences**: In the 2015 edition, the pattern for a trait
+> function or method parameter is optional:
+>
+> ```rust,edition2015
+> trait T {
+>     fn f(i32);  // Parameter identifiers are not required.
+> }
+> ```
+>
+> Further, the limitations on the pattern for functions or methods without a
+> body also apply to functions or methods with a body.
+
 
 [IDENTIFIER]: ../identifiers.md
 [WildcardPattern]: ../patterns.md#wildcard-pattern

--- a/src/keywords.md
+++ b/src/keywords.md
@@ -22,10 +22,13 @@ be used as the names of:
 
 > **<sup>Lexer:<sup>**\
 > KW_AS             : `as`\
+> KW_ASYNC          : `async`\
+> KW_AWAIT          : `await`\
 > KW_BREAK          : `break`\
 > KW_CONST          : `const`\
 > KW_CONTINUE       : `continue`\
 > KW_CRATE          : `crate`\
+> KW_DYN            : `dyn` \
 > KW_ELSE           : `else`\
 > KW_ENUM           : `enum`\
 > KW_EXTERN         : `extern`\
@@ -57,12 +60,9 @@ be used as the names of:
 > KW_WHERE          : `where`\
 > KW_WHILE          : `while`
 
-The following keywords were added beginning in the 2018 edition.
+> **Edition Differences**: In the 2015 edition, `async` and `await` are not
+> keywords, and `dyn` is not a strict keyword.
 
-> **<sup>Lexer 2018+</sup>**\
-> KW_ASYNC          : `async`\
-> KW_AWAIT          : `await`\
-> KW_DYN            : `dyn`
 
 ## Reserved keywords
 
@@ -80,15 +80,15 @@ them to use these keywords.
 > KW_MACRO          : `macro`\
 > KW_OVERRIDE       : `override`\
 > KW_PRIV           : `priv`\
+> KW_TRY            : `try`\
 > KW_TYPEOF         : `typeof`\
 > KW_UNSIZED        : `unsized`\
 > KW_VIRTUAL        : `virtual`\
 > KW_YIELD          : `yield`
 
-The following keywords are reserved beginning in the 2018 edition.
+> **Edition Differences**: In the 2015 edition, `try` is not a (reserved)
+> keyword.
 
-> **<sup>Lexer 2018+</sup>**\
-> KW_TRY   : `try`
 
 ## Weak keywords
 
@@ -104,17 +104,16 @@ is possible to declare a variable or method with the name `union`.
   // error[E0262]: invalid lifetime parameter name: `'static`
   fn invalid_lifetime_parameter<'static>(s: &'static str) -> &'static str { s }
   ```
-* In the 2015 edition, [`dyn`] is a keyword when used in a type position
-  followed by a path that does not start with `::`.
-
-  Beginning in the 2018 edition, `dyn` has been promoted to a strict keyword.
 
 > **<sup>Lexer</sup>**\
 > KW_UNION          : `union`\
 > KW_STATICLIFETIME : `'static`
 >
-> **<sup>Lexer 2015</sup>**\
-> KW_DYN            : `dyn`
+
+> **Edition Differences**: In the 2015 edition, [`dyn`] is an additional weak
+> keyword: it is a keyword when used in a type position followed by a path
+> that does not start with `::`.
+
 
 [items]: items.md
 [Variables]: variables.md

--- a/src/visibility-and-privacy.md
+++ b/src/visibility-and-privacy.md
@@ -147,16 +147,17 @@ expressions, types, etc.
 In addition to public and private, Rust allows users to declare an item as
 visible within a given scope. The rules for `pub` restrictions are as follows:
 - `pub(in path)` makes an item visible within the provided `path`. `path` must
-be a parent module of the item whose visibility is being declared.
+  begin with `crate`, `self`, or `super`, and must resolve to a parent module
+  of the item whose visibility is being declared.
 - `pub(crate)` makes an item visible within the current crate.
 - `pub(super)` makes an item visible to the parent module. This is equivalent
   to `pub(in super)`.
 - `pub(self)` makes an item visible to the current module. This is equivalent
 to `pub(in self)`.
 
-> **Edition Differences**: Starting with the 2018 edition, paths for
-> `pub(in path)` must start with `crate`, `self`, or `super`. The 2015 edition
-> may also use paths starting with `::` or modules from the crate root.
+> **Edition Differences**: In the 2015 edition, the path for `pub(in path)`
+> may also start with `::` or an identifier; in either case it is resolved
+> from the crate root.
 
 Here's an example:
 


### PR DESCRIPTION
At present, some "Edition Differences" sections describe Rust 2018 additions to Rust 2015, some describe Rust 2015 limitations, and some are a mixture.

These commits attempt to make things consistent by putting the Rust 2018 description in the main text and information about Rust 2015 in the "Edition Differences" sections.

I've updated all the sections I could find, except for use-declarations.md
which needs more work (see #697).
