### PR TITLE
github action doesn't use the nursery

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install mdbook
       run: |
         mkdir bin
-        curl -sSL https://github.com/rust-lang-nursery/mdBook/releases/download/v0.3.4/mdbook-v0.3.4-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
+        curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.3.4/mdbook-v0.3.4-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
         echo "##[add-path]$(pwd)/bin"
     - name: Report versions
       run: |


### PR DESCRIPTION
... ironic that in porting the reference away from rust-lang-nursery, we accidentally depending on mdbook still being in the nursery