### PR TITLE
Document try expressions

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -69,6 +69,7 @@
         - [Match expressions](expressions/match-expr.md)
         - [Return expressions](expressions/return-expr.md)
         - [Await expressions](expressions/await-expr.md)
+        - [Try expressions](expressions/try-expr.md)
 
 - [Patterns](patterns.md)
 

--- a/src/expressions.md
+++ b/src/expressions.md
@@ -40,6 +40,7 @@
 > &nbsp;&nbsp; &nbsp;&nbsp; | [_IfExpression_]\
 > &nbsp;&nbsp; &nbsp;&nbsp; | [_IfLetExpression_]\
 > &nbsp;&nbsp; &nbsp;&nbsp; | [_MatchExpression_]\
+> &nbsp;&nbsp; &nbsp;&nbsp; | [_TryExpression_]\
 > &nbsp;&nbsp; )
 
 An expression may have two roles: it always produces a *value*, and it may have
@@ -354,6 +355,7 @@ They are never allowed before:
 [_RangeExpression_]:              expressions/range-expr.md
 [_ReturnExpression_]:             expressions/return-expr.md
 [_StructExpression_]:             expressions/struct-expr.md
+[_TryExpression_]:                expressions/try-expr.md
 [_TupleExpression_]:              expressions/tuple-expr.md
 [_TupleIndexingExpression_]:      expressions/tuple-expr.md#tuple-indexing-expressions
 [_TypeCastExpression_]:           expressions/operator-expr.md#type-cast-expressions

--- a/src/expressions/try-expr.md
+++ b/src/expressions/try-expr.md
@@ -10,15 +10,15 @@ The effect of this can be seen in the following example:
 
 ```rust,edition2018
 fn some_two() -> Option<u8> {
-	Some(2)
+    Some(2)
 }
 
 fn some_three() -> Option<u8> {
-	Some(3)
+    Some(3)
 }
 
 let sum: Option<u8> = try {
-	some_two()? + some_three()?
+    some_two()? + some_three()?
 };
 
 assert_eq!(sum, Some(5));
@@ -28,7 +28,7 @@ This is useful when you want to coalesce multiple potential `Err` values into a 
 
 ```rust,edition2018,ignore
 let result = try {
-	foo()?.bar()?.baz()?
+    foo()?.bar()?.baz()?
 };
 ```
 

--- a/src/expressions/try-expr.md
+++ b/src/expressions/try-expr.md
@@ -1,0 +1,36 @@
+# `try` expressions
+
+> **<sup>Syntax</sup>**\
+> _TryExpression_ :\
+> &nbsp;&nbsp; `try` _BlockExpression_
+
+A *try expression* executes its associated block while limiting the effect of the [question mark operator](./operator-expr.md#the-question-mark-operator) to itself.
+
+The effect of this can be seen in the following example:
+
+```rust,edition2018
+fn some_two() -> Option<u8> {
+	Some(2)
+}
+
+fn some_three() -> Option<u8> {
+	Some(3)
+}
+
+let sum: Option<u8> = try {
+	some_two()? + some_three()?
+};
+
+assert_eq!(sum, Some(5));
+```
+
+This is useful when you want to coalesce multiple potential `Err` values into a single `Result`, or multiple `None` values into a single `Option`.
+
+```rust,edition2018,ignore
+let result = try {
+	foo()?.bar()?.baz()?
+};
+```
+
+> **Edition differences**: Try expressions are only available beginning with
+> Rust 2018.


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/31436

I am not sure if I am expected to fix the error relating to try blocks being unstable, part of the stabilizing process is to write documentation for the reference? Or is stabilization and documentation meant to happen at the same time? I'm unsure...