### PR TITLE
Minor never type additions.

### DIFF
--- a/src/items/enumerations.md
+++ b/src/items/enumerations.md
@@ -131,6 +131,15 @@ no valid values, they cannot be instantiated.
 enum ZeroVariants {}
 ```
 
+Zero-variant enums are equivalent to the [never type], but they cannot be
+coerced into other types.
+
+```rust,compile_fail
+# enum ZeroVariants {}
+let x: ZeroVariants = panic!();
+let y: u32 = x; // mismatched type error
+```
+
 [IDENTIFIER]: ../identifiers.md
 [_Generics_]: generics.md
 [_WhereClause_]: generics.md#where-clauses
@@ -139,6 +148,7 @@ enum ZeroVariants {}
 [_StructFields_]: structs.md
 [enumerated type]: ../types/enum.md
 [`mem::discriminant`]: ../../std/mem/fn.discriminant.html
+[never type]: ../types/never.md
 [numeric cast]: ../expressions/operator-expr.md#semantics
 [constant expression]: ../const_eval.md#constant-expressions
 [default representation]: ../type-layout.md#the-default-representation

--- a/src/types/never.md
+++ b/src/types/never.md
@@ -6,3 +6,9 @@
 The never type `!` is a type with no values, representing the result of
 computations that never complete. Expressions of type `!` can be coerced into
 any other type.
+
+```rust,should_panic
+let x: ! = panic!();
+// Can be coerced into any type.
+let y: u32 = x;
+```


### PR DESCRIPTION
- Add example of never type coercion.
- Mention equivalence to zero-variant enums.

I decided not to mention anything about type inference fallback, since it doesn't seem to really fit on the never type page, and there isn't any discussion about type inference elsewhere (#594).
