### PR TITLE
introduce feature gate into never-type test

### DIFF
--- a/src/types/never.md
+++ b/src/types/never.md
@@ -8,7 +8,15 @@ computations that never complete. Expressions of type `!` can be coerced into
 any other type.
 
 ```rust,should_panic
+#![feature(never_type)]
 let x: ! = panic!();
 // Can be coerced into any type.
 let y: u32 = x;
 ```
+
+**NB.** The never type was expected to be stabilized in 1.41, but due
+to some last minute regressions detected the stabilization was
+temporarily reverted. The `!` type can only appear in function return
+types presently. See [the tracking
+issue](https://github.com/rust-lang/rust/issues/35121) for more
+details.


### PR DESCRIPTION
Given that we are rolling back stabilization of the never type, this example needs a feature gate. The test was added only recently, by @ehuss -- I think that ordinarily we don't document unstable features, but given that this section of the book seems to be older, and that `!` can appear in some places, and that we hope to get `!` stabilized very soon, I opted not to remove it.

This needs to land semi-urgently so that https://github.com/rust-lang/rust/pull/67224 can land.