### PR TITLE
clarify note re. leading `::` in 2018

### DIFF
--- a/src/paths.md
+++ b/src/paths.md
@@ -175,7 +175,8 @@ mod a {
 }
 mod b {
     pub fn foo() {
-        ::a::foo(); // call a's foo function
+        ::a::foo(); // call `a`'s foo function
+        // In Rust 2018, `::a` would be interpreted as the crate `a`.
     }
 }
 # fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/reference/issues/746.

r? @ehuss 