### PR TITLE
Fix incorrect pseudocode for #[repr(C)] struct alignment

### DIFF
--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -197,6 +197,8 @@ Here is this algorithm described in pseudocode.
 
 <!-- ignore: pseudocode -->
 ```rust,ignore
+/// Returns the amount of padding needed after `offset` to ensure that the
+/// following address will be aligned to `alignment`.
 fn padding_needed_for(offset: usize, alignment: usize) -> usize {
     let misalignment = offset % alignment;
     if misalignment > 0 {

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -197,6 +197,17 @@ Here is this algorithm described in pseudocode.
 
 <!-- ignore: pseudocode -->
 ```rust,ignore
+fn padding_needed_for(offset: usize, alignment: usize) -> usize {
+    let misalignment = offset % alignment;
+    if misalignment > 0 {
+        // round up to next multiple of `alignment`
+        alignment - misalignment
+    } else {
+        // already a multiple of `alignment`
+        0
+    }
+}
+
 struct.alignment = struct.fields().map(|field| field.alignment).max();
 
 let current_offset = 0;
@@ -205,10 +216,6 @@ for field in struct.fields_in_declaration_order() {
     // Increase the current offset so that it's a multiple of the alignment
     // of this field. For the first field, this will always be zero.
     // The skipped bytes are called padding bytes.
-    //
-    // padding_needed_for() is equivalent to
-    // std::alloc::Layout::padding_needed_for(), but takes an integer rather
-    // than a Layout as the first argument.
     current_offset += padding_needed_for(current_offset, field.alignment);
 
     struct[field].offset = current_offset;

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -226,6 +226,14 @@ for field in struct.fields_in_declaration_order() {
 struct.size = current_offset + padding_needed_for(current_offset, struct.alignment);
 ```
 
+<div class="warning">
+
+Warning: This pseudocode uses a naive algorithm that ignores overflow issues for
+the sake of clarity. To perform memory layout computations in actual code, use
+[`Layout`].
+
+</div>
+
 > Note: This algorithm can produce zero-sized structs. This differs from
 > C where structs without data still have a size of one byte.
 
@@ -374,3 +382,4 @@ used with any other representation.
 [`C`]: #the-c-representation
 [primitive representations]: #primitive-representations
 [`transparent`]: #the-transparent-representation
+[`Layout`]: ../std/alloc/struct.Layout.html

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -205,14 +205,18 @@ for field in struct.fields_in_declaration_order() {
     // Increase the current offset so that it's a multiple of the alignment
     // of this field. For the first field, this will always be zero.
     // The skipped bytes are called padding bytes.
-    current_offset += field.alignment % current_offset;
+    //
+    // padding_needed_for() is equivalent to
+    // std::alloc::Layout::padding_needed_for(), but takes an integer rather
+    // than a Layout as the first argument.
+    current_offset += padding_needed_for(current_offset, field.alignment);
 
     struct[field].offset = current_offset;
 
     current_offset += field.size;
 }
 
-struct.size = current_offset + current_offset % struct.alignment;
+struct.size = current_offset + padding_needed_for(current_offset, struct.alignment);
 ```
 
 > Note: This algorithm can produce zero-sized structs. This differs from


### PR DESCRIPTION
Alternative to #559 incorporating some suggested changes to that PR.

@RalfJung I felt like your pseudocode approached actual code too much, and sorta requires understanding what's going on with `Layout` in order to follow, so I just took the route of making the padding calculation into an implicit function per other suggestions.