### PR TITLE
Replace "Field-Less" with "Fieldless"

### DIFF
--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -73,7 +73,7 @@ A _const context_ is one of the following:
 [constants]:            items/constant-items.md
 [dereference operator]: expressions/operator-expr.md#the-dereference-operator
 [destructors]:          destructors.md
-[enum discriminants]:   items/enumerations.md#custom-discriminant-values-for-field-less-enumerations
+[enum discriminants]:   items/enumerations.md#custom-discriminant-values-for-fieldless-enumerations
 [enum variant]:         expressions/enum-variant-expr.md
 [expression statements]: statements.md#expression-statements
 [expressions]:          expressions.md

--- a/src/items/enumerations.md
+++ b/src/items/enumerations.md
@@ -61,7 +61,7 @@ integer associated to it that is used to determine which variant it holds. An
 opaque reference to this discriminant can be obtained with the
 [`mem::discriminant`] function.
 
-## Custom Discriminant Values for Field-Less Enumerations
+## Custom Discriminant Values for Fieldless Enumerations
 
 If there is no data attached to *any* of the variants of an enumeration,
 then the discriminant can be directly chosen and accessed.

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -354,7 +354,7 @@ used with any other representation.
 [`size_of`]: ../std/mem/fn.size_of.html
 [`Sized`]: ../std/marker/trait.Sized.html
 [dynamically sized types]: dynamically-sized-types.md
-[C-like enumerations]:  items/enumerations.md#custom-discriminant-values-for-field-less-enumerations
+[C-like enumerations]:  items/enumerations.md#custom-discriminant-values-for-fieldless-enumerations
 [zero-variant enumerations]: items/enumerations.md#zero-variant-enums
 [undefined behavior]: behavior-considered-undefined.md
 [27060]: https://github.com/rust-lang/rust/issues/27060


### PR DESCRIPTION
"-less" is not a suffix that is generally hyphenated, and "field-less" looks odd compared to "fieldless". There's precedent for this choice in https://rust-lang.github.io/unsafe-code-guidelines/layout/enums.html.