### PR TITLE
Add information about || and && to grammar describing `while let`.

### DIFF
--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -123,26 +123,7 @@ while let Some(v @ 1) | Some(v @ 2) = vals.pop() {
 }
 ```
 
-The expression cannot be a [lazy boolean operator expression][_LazyBooleanOperatorExpression_].
-Use of a lazy boolean operator is ambiguous with a planned feature change
-of the language (the implementation of if-let chains - see [eRFC 2947][_eRFCIfLetChain_]).
-When lazy boolean operator expression is desired, this can be achieved
-by using parenthesis as below:
-
-<!-- ignore: psuedo code -->
-```rust,ignore
-// Before...
-while let PAT = EXPR && EXPR { .. }
-
-// After...
-while let PAT = ( EXPR && EXPR ) { .. }
-
-// Before...
-while let PAT = EXPR || EXPR { .. }
-
-// After...
-while let PAT = ( EXPR || EXPR ) { .. }
-```
+As is the case in [`if let` expressions], the scrutinee cannot be a [lazy boolean operator expression][_LazyBooleanOperatorExpression_].
 
 ## Iterator loops
 
@@ -315,3 +296,5 @@ expression `()`.
 [`match` expression]: match-expr.md
 [scrutinee]: ../glossary.md#scrutinee
 [temporary values]: ../expressions.md#temporary-lifetimes
+[_LazyBooleanOperatorExpression_]: operator-expr.md#lazy-boolean-operators
+[`if let` expressions]: if-expr.md#if-let-expressions

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -45,7 +45,7 @@ have type compatible with the value of the `break` expression(s).
 
 > **<sup>Syntax</sup>**\
 > _PredicateLoopExpression_ :\
-> &nbsp;&nbsp; `while` [_Expression_]<sub>except struct expression</sub> [_BlockExpression_]
+> &nbsp;&nbsp; `while` [_Expression_]<sub>_except struct expression_</sub> [_BlockExpression_]
 
 A `while` loop begins by evaluating the boolean loop conditional expression. If
 the loop conditional expression evaluates to `true`, the loop body block
@@ -67,7 +67,7 @@ while i < 10 {
 
 > **<sup>Syntax</sup>**\
 > [_PredicatePatternLoopExpression_] :\
-> &nbsp;&nbsp; `while` `let` [_MatchArmPatterns_] `=` [_Expression_]<sub>except struct expression</sub>
+> &nbsp;&nbsp; `while` `let` [_MatchArmPatterns_] `=` [_Expression_]<sub>_except struct or lazy boolean operator expression_</sub>
 >              [_BlockExpression_]
 
 A `while let` loop is semantically similar to a `while` loop but in place of a
@@ -123,11 +123,32 @@ while let Some(v @ 1) | Some(v @ 2) = vals.pop() {
 }
 ```
 
+The expression cannot be a [lazy boolean operator expression][_LazyBooleanOperatorExpression_].
+Use of a lazy boolean operator is ambiguous with a planned feature change
+of the language (the implementation of if-let chains - see [eRFC 2947][_eRFCIfLetChain_]).
+When lazy boolean operator expression is desired, this can be achieved
+by using parenthesis as below:
+
+<!-- ignore: psuedo code -->
+```rust,ignore
+// Before...
+while let PAT = EXPR && EXPR { .. }
+
+// After...
+while let PAT = ( EXPR && EXPR ) { .. }
+
+// Before...
+while let PAT = EXPR || EXPR { .. }
+
+// After...
+while let PAT = ( EXPR || EXPR ) { .. }
+```
+
 ## Iterator loops
 
 > **<sup>Syntax</sup>**\
 > _IteratorLoopExpression_ :\
-> &nbsp;&nbsp; `for` [_Pattern_] `in` [_Expression_]<sub>except struct expression</sub>
+> &nbsp;&nbsp; `for` [_Pattern_] `in` [_Expression_]<sub>_except struct expression_</sub>
 >              [_BlockExpression_]
 
 A `for` expression is a syntactic construct for looping over elements provided


### PR DESCRIPTION
Also fix italics to be consistent with other pages.
See #771. I also copied and adapted the corresponding paragraph from the `if let` page.
_Edit: Instead of copying the paragraph from `if let` mentioning the unstable `if-let chains` feature, now the copy as well as the original paragraph are removed._