### PR TITLE
Fix grammar for tuple struct patterns.

### DIFF
--- a/src/patterns.md
+++ b/src/patterns.md
@@ -556,7 +556,7 @@ A struct pattern is refutable when one of its subpatterns is refutable.
 
 > **<sup>Syntax</sup>**\
 > _TupleStructPattern_ :\
-> &nbsp;&nbsp; [_PathInExpression_] `(` _TupleStructItems_ `)`
+> &nbsp;&nbsp; [_PathInExpression_] `(` _TupleStructItems_<sup>?</sup> `)`
 >
 > _TupleStructItems_ :\
 > &nbsp;&nbsp; &nbsp;&nbsp; [_Pattern_]&nbsp;( `,` [_Pattern_] )<sup>\*</sup> `,`<sup>?</sup>\


### PR DESCRIPTION
Obviously, a tuple struct pattern allows leaving out the `TupleStructItems` [[playground example]](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=2d1633b13083df14a945ac00c0b59cdb).