### PR TITLE
Fix expression and statement grammar.

### DIFF
--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -28,9 +28,6 @@ a following semicolon except if its outer expression is a flow control
 expression. Furthermore, extra semicolons between statements are allowed, but
 these semicolons do not affect semantics.
 
-> Note: The semicolon following a statement is not a part of the statement
-> itself. They are invalid when using the `stmt` macro matcher.
-
 When evaluating a block expression, each statement, except for item declaration
 statements, is executed sequentially. Then the final expression is executed,
 if given.

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -9,10 +9,10 @@
 >
 > _MatchArms_ :\
 > &nbsp;&nbsp; ( _MatchArm_ `=>`
->                             ( [_BlockExpression_] `,`<sup>?</sup>
->                             | [_Expression_] `,` )
+>                             ( [_ExpressionWithoutBlock_][_Expression_] `,`
+>                             | [_ExpressionWithBlock_][_Expression_] `,`<sup>?</sup> )
 >                           )<sup>\*</sup>\
-> &nbsp;&nbsp; _MatchArm_ `=>` ( [_BlockExpression_] | [_Expression_] ) `,`<sup>?</sup>
+> &nbsp;&nbsp; _MatchArm_ `=>` [_Expression_] `,`<sup>?</sup>
 >
 > _MatchArm_ :\
 > &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> _MatchArmPatterns_ _MatchArmGuard_<sup>?</sup>
@@ -146,7 +146,6 @@ expression in the same expression contexts as [attributes on block
 expressions].
 
 [_Expression_]: ../expressions.md
-[_BlockExpression_]: block-expr.md#block-expressions
 [place expression]: ../expressions.md#place-expressions-and-value-expressions
 [value expression]: ../expressions.md#place-expressions-and-value-expressions
 [_InnerAttribute_]: ../attributes.md

--- a/src/statements.md
+++ b/src/statements.md
@@ -69,7 +69,7 @@ from the point of declaration until the end of the enclosing block scope.
 > **<sup>Syntax</sup>**\
 > _ExpressionStatement_ :\
 > &nbsp;&nbsp; &nbsp;&nbsp; [_ExpressionWithoutBlock_][expression] `;`\
-> &nbsp;&nbsp; | [_ExpressionWithBlock_][expression]
+> &nbsp;&nbsp; | [_ExpressionWithBlock_][expression] `;`<sup>?</sup>
 
 An *expression statement* is one that evaluates an [expression] and ignores its
 result. As a rule, an expression statement's purpose is to trigger the effects


### PR DESCRIPTION
Semicolon or comma in expression statements or match arms, respectively, are optional, but part of the statement / match arm.
Also remove a note about proc-macros from the page about BlockExpression.
Closes #773 and closes #774.