### PR TITLE
Update rustc-guide to rustc-dev-guide

### DIFF
--- a/src/types/inferred.md
+++ b/src/types/inferred.md
@@ -13,6 +13,6 @@ let x: Vec<_> = (0..10).collect();
 
 <!--
   What else should be said here?
-  The only documentation I am aware of is https://rust-lang.github.io/rustc-dev-guide/type-inference.html
+  The only documentation I am aware of is https://rustc-dev-guide.rust-lang.org/type-inference.html
   There should be a broader discussion of type inference somewhere.
 -->

--- a/src/types/inferred.md
+++ b/src/types/inferred.md
@@ -13,6 +13,6 @@ let x: Vec<_> = (0..10).collect();
 
 <!--
   What else should be said here?
-  The only documentation I am aware of is https://rust-lang.github.io/rustc-guide/type-inference.html
+  The only documentation I am aware of is https://rust-lang.github.io/rustc-dev-guide/type-inference.html
   There should be a broader discussion of type inference somewhere.
 -->


### PR DESCRIPTION
The `rustc-guide` is being renamed to the `rustc-dev-guide`. The discussion is in rust-lang/rustc-guide#470.

This PR revises `rustc-guide` to `rustc-dev-guide` in a Markdown file.

Transition tracker: rust-lang/rustc-guide#602