### PR TITLE
Fix some typos, misformattings and small mistakes in the lexical structure reference.

### DIFF
--- a/src/comments.md
+++ b/src/comments.md
@@ -2,7 +2,7 @@
 
 > **<sup>Lexer</sup>**\
 > LINE_COMMENT :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `//` (~[`/` `!`] | `//`) ~`\n`<sup>\*</sup>\
+> &nbsp;&nbsp; &nbsp;&nbsp; `//` (~[`/` `!` \\n] | `//`) ~\\n<sup>\*</sup>\
 > &nbsp;&nbsp; | `//`
 >
 > BLOCK_COMMENT :\
@@ -12,16 +12,16 @@
 > &nbsp;&nbsp; | `/***/`
 >
 > INNER_LINE_DOC :\
-> &nbsp;&nbsp; `//!` ~[`\n` _IsolatedCR_]<sup>\*</sup>
+> &nbsp;&nbsp; `//!` ~[\\n _IsolatedCR_]<sup>\*</sup>
 >
 > INNER_BLOCK_DOC :\
 > &nbsp;&nbsp; `/*!` ( _BlockCommentOrDoc_ | ~[`*/` _IsolatedCR_] )<sup>\*</sup> `*/`
 >
 > OUTER_LINE_DOC :\
-> &nbsp;&nbsp; `///` (~`/` ~[`\n` _IsolatedCR_]<sup>\*</sup>)<sup>?</sup>
+> &nbsp;&nbsp; `///` (~[`/` \\n _IsolatedCR_] ~[\\n _IsolatedCR_]<sup>\*</sup>)<sup>?</sup>
 >
 > OUTER_BLOCK_DOC :\
-> &nbsp;&nbsp; `/**` (~`*` | _BlockCommentOrDoc_ )
+> &nbsp;&nbsp; `/**` (~[`*` _IsolatedCR_] | _BlockCommentOrDoc_ )
 >              (_BlockCommentOrDoc_ | ~[`*/` _IsolatedCR_])<sup>\*</sup> `*/`
 >
 > _BlockCommentOrDoc_ :\
@@ -30,7 +30,7 @@
 > &nbsp;&nbsp; | INNER_BLOCK_DOC
 >
 > _IsolatedCR_ :\
-> &nbsp;&nbsp; _A `\r` not followed by a `\n`_
+> &nbsp;&nbsp; _A_ \\r _not followed by a_ \\n
 
 ## Non-doc comments
 

--- a/src/identifiers.md
+++ b/src/identifiers.md
@@ -5,9 +5,9 @@
 > &nbsp;&nbsp; &nbsp;&nbsp; [`a`-`z` `A`-`Z`]&nbsp;[`a`-`z` `A`-`Z` `0`-`9` `_`]<sup>\*</sup>\
 > &nbsp;&nbsp; | `_` [`a`-`z` `A`-`Z` `0`-`9` `_`]<sup>+</sup>
 >
-> RAW_IDENTIFIER : `r#` IDENTIFIER_OR_KEYWORD <sub>*Except `crate`, `self`, `super`, `Self`*</sub>
+> RAW_IDENTIFIER : `r#` IDENTIFIER_OR_KEYWORD <sub>_except_ `crate`, `self`, `super`, `Self`</sub>
 >
-> NON_KEYWORD_IDENTIFIER : IDENTIFIER_OR_KEYWORD <sub>*Except a [strict] or [reserved] keyword*</sub>
+> NON_KEYWORD_IDENTIFIER : IDENTIFIER_OR_KEYWORD <sub>_except a [strict] or [reserved] keyword_</sub>
 >
 > IDENTIFIER :\
 > NON_KEYWORD_IDENTIFIER | RAW_IDENTIFIER

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -37,7 +37,7 @@ evaluated (primarily) at compile time.
 | [Byte string](#byte-string-literals)         | `b"hello"`      | 0           | All ASCII   | [Quote](#quote-escapes) & [Byte](#byte-escapes)                               |
 | [Raw byte string](#raw-byte-string-literals) | `br#"hello"#`   | 0 or more\* | All ASCII   | `N/A`                                                      |
 
-\* The number of `#`s on each side of the same literal must be equivalent
+\* The number of `#`s on each side of the same literal must be equal.
 
 #### ASCII escapes
 
@@ -231,7 +231,7 @@ r##"foo #"# bar"##;                // foo #"# bar
 > &nbsp;&nbsp; `b'` ( ASCII_FOR_CHAR | BYTE_ESCAPE )  `'`
 >
 > ASCII_FOR_CHAR :\
-> &nbsp;&nbsp; _any ASCII (i.e. 0x00 to 0x7F), except_ `'`, `\`, \\n, \\r or \\t
+> &nbsp;&nbsp; _any ASCII (i.e. 0x00 to 0x7F), except_ `'`, `\`, \\n, \\r _or_ \\t
 >
 > BYTE_ESCAPE :\
 > &nbsp;&nbsp; &nbsp;&nbsp; `\x` HEX_DIGIT HEX_DIGIT\
@@ -283,7 +283,7 @@ following forms:
 >
 > RAW_BYTE_STRING_CONTENT :\
 > &nbsp;&nbsp; &nbsp;&nbsp; `"` ASCII<sup>* (non-greedy)</sup> `"`\
-> &nbsp;&nbsp; | `#` RAW_STRING_CONTENT `#`
+> &nbsp;&nbsp; | `#` RAW_BYTE_STRING_CONTENT `#`
 >
 > ASCII :\
 > &nbsp;&nbsp; _any ASCII (i.e. 0x00 to 0x7F)_


### PR DESCRIPTION
Multiple unrelated things in one commit since they’re each very small corrections.
Next to typos and bad formatting, this PR changes a word (“equivalent” ⟶ “equal”) and adds (more precisely, disallows) “\n” in a few obvious places in comments’ lexical structure.