### PR TITLE
Fix and clarify section on re-export

### DIFF
--- a/src/items/use-declarations.md
+++ b/src/items/use-declarations.md
@@ -60,20 +60,25 @@ default. Also like items, a `use` declaration can be public, if qualified by
 the `pub` keyword. Such a `use` declaration serves to _re-export_ a name. A
 public `use` declaration can therefore _redirect_ some public name to a
 different target definition: even a definition with a private canonical path,
-inside a different module. If a sequence of such redirections form a cycle or
-cannot be resolved unambiguously, they represent a compile-time error.
+inside a different module. This allows to present an external interface to a 
+user of the crate that is different from the internal organization of the code. 
+If a sequence of such redirections form a cycle or cannot be resolved unambiguously, 
+they represent a compile-time error.
 
 An example of re-exporting:
 
 ```rust
-# fn main() { }
 mod quux {
-    pub use quux::foo::{bar, baz};
-
+    pub use self::foo::{bar, baz};
     pub mod foo {
-        pub fn bar() { }
-        pub fn baz() { }
+        pub fn bar() {}
+        pub fn baz() {}
     }
+}
+
+fn main() {
+    quux::bar();
+    quux::baz();
 }
 ```
 

--- a/src/items/use-declarations.md
+++ b/src/items/use-declarations.md
@@ -60,10 +60,8 @@ default. Also like items, a `use` declaration can be public, if qualified by
 the `pub` keyword. Such a `use` declaration serves to _re-export_ a name. A
 public `use` declaration can therefore _redirect_ some public name to a
 different target definition: even a definition with a private canonical path,
-inside a different module. This allows to present an external interface to a 
-user of the crate that is different from the internal organization of the code. 
-If a sequence of such redirections form a cycle or cannot be resolved unambiguously, 
-they represent a compile-time error.
+inside a different module. If a sequence of such redirections form a cycle or
+cannot be resolved unambiguously, they represent a compile-time error.
 
 An example of re-exporting:
 


### PR DESCRIPTION
Section on use-visibility fixed to compile under Rust 2018, since they are not absolute paths by default anymore.