### PR TITLE
Attributes are now allowed on `if` and `if let`

### DIFF
--- a/src/expressions.md
+++ b/src/expressions.md
@@ -272,11 +272,10 @@ a few specific cases:
         https://github.com/rust-lang/rust/issues/15701
   -->
 * The tail expression of [block expressions].
+* [`if`][_IfExpression_] and [`if let`][_IfLetExpression_] expressions.
 <!-- Keep list in sync with block-expr.md -->
 
 They are never allowed before:
-
-* [`if`][_IfExpression_] and [`if let`][_IfLetExpression_] expressions.
 * [Range][_RangeExpression_] expressions.
 * Binary operator expressions ([_ArithmeticOrLogicalExpression_],
   [_ComparisonExpression_], [_LazyBooleanExpression_], [_TypeCastExpression_],

--- a/src/expressions.md
+++ b/src/expressions.md
@@ -272,7 +272,6 @@ a few specific cases:
         https://github.com/rust-lang/rust/issues/15701
   -->
 * The tail expression of [block expressions].
-* [`if`][_IfExpression_] and [`if let`][_IfLetExpression_] expressions.
 <!-- Keep list in sync with block-expr.md -->
 
 They are never allowed before:


### PR DESCRIPTION
This became possible with https://github.com/rust-lang/rust/pull/69201