### PR TITLE
remove language-level UB for non-UTF-8 str

### DIFF
--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -51,7 +51,6 @@ code.
       `Trait` that matches the actual dynamic trait the pointer or reference points to.
     * Slice metadata is invalid if the length is not a valid `usize`
       (i.e., it must not be read from uninitialized memory).
-  * Non-UTF-8 byte sequences in a `str`.
   * Invalid values for a type with a custom definition of invalid values.
     In the standard library, this affects [`NonNull<T>`] and [`NonZero*`].
 
@@ -63,8 +62,8 @@ points to are part of the same allocation (so in particular they all have to be
 part of *some* allocation). The span of bytes it points to is determined by the
 pointer value and the size of the pointee type (using `size_of_val`). As a
 consequence, if the span is empty, "dangling" is the same as "non-null". Note
-that slices point to their entire range, so it is important that the length
-metadata is never too large. In particular, allocations and therefore slices
+that slices and strings point to their entire range, so it is important that the length
+metadata is never too large. In particular, allocations and therefore slices and strings
 cannot be bigger than `isize::MAX` bytes.
 
 > **Note**: Undefined behavior affects the entire program. For example, calling

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -44,7 +44,7 @@ code.
   * A value in a `char` which is a surrogate or above `char::MAX`.
   * A `!` (all values are invalid for this type).
   * An integer (`i*`/`u*`), floating point value (`f*`), or raw pointer obtained
-    from [uninitialized memory][undef].
+    from [uninitialized memory][undef], or uninitialized memory in a `str`.
   * A reference or `Box<T>` that is dangling, unaligned, or points to an invalid value.
   * Invalid metadata in a wide reference, `Box<T>`, or raw pointer:
     * `dyn Trait` metadata is invalid if it is not a pointer to a vtable for


### PR DESCRIPTION
Ever [since Rust 1.0](https://doc.rust-lang.org/1.0.0/reference.html#behavior-considered-undefined), the reference said that a non-UTF-8 `str` causes immediate UB. In terms of [today's terminology](https://www.ralfj.de/blog/2018/08/22/two-kinds-of-invariants.html), that means that `str` has a validity invariant of being valid UTF-8.

However, that seems unnecessary: the compiler does not actually exploit this, nor is there any clear way it could exploit this. Making UTF-8 a library-level *safety invariant* is more than enough for everything `str` does. Most likely, it was made a validity invariant because we had not yet properly teased apart those two concepts when the document was initially written. 

This is also the conclusion that the UCG WG arrived at in https://github.com/rust-lang/unsafe-code-guidelines/issues/78.

I therefore propose we remove the UTF-8 clause from the language spec, so that `str` will have the same validity invariant as `[u8]`. @Centril suggested I open this a PR here to put this through FCP, so here we go.

Fixes https://github.com/rust-lang/rust/issues/71033