### PR TITLE
Replace incorrect term "parent modules" with "ancestor modules".

### DIFF
--- a/src/visibility-and-privacy.md
+++ b/src/visibility-and-privacy.md
@@ -48,7 +48,7 @@ With the notion of an item being either public or private, Rust allows item
 accesses in two cases:
 
 1. If an item is public, then it can be accessed externally from some module
-   `m` if you can access all the item's parent modules from `m`. You can
+   `m` if you can access all the item's ancestor modules from `m`. You can
    also potentially be able to name the item through re-exports. See below.
 2. If an item is private, it may be accessed by the current module and its
    descendants.

--- a/src/visibility-and-privacy.md
+++ b/src/visibility-and-privacy.md
@@ -148,7 +148,7 @@ In addition to public and private, Rust allows users to declare an item as
 visible only within a given scope. The rules for `pub` restrictions are as
 follows:
 - `pub(in path)` makes an item visible within the provided `path`. `path` must
-be a parent module of the item whose visibility is being declared.
+be an ancestor module of the item whose visibility is being declared.
 - `pub(crate)` makes an item visible within the current crate.
 - `pub(super)` makes an item visible to the parent module. This is equivalent
   to `pub(in super)`.


### PR DESCRIPTION
"Parent" means the first level above, "ancestors" means all the levels above.