### PR TITLE
Update tuple index token.

### DIFF
--- a/src/expressions/enum-variant-expr.md
+++ b/src/expressions/enum-variant-expr.md
@@ -41,7 +41,7 @@ Enum variant expressions have the same syntax, behavior, and restrictions as [st
 expressions][structs], except they do not support base update with the `..` syntax.
 
 [IDENTIFIER]: ../identifiers.md
-[TUPLE_INDEX]: ../tokens.md#integer-literals
+[TUPLE_INDEX]: ../tokens.md#tuple-index
 [_Expression_]: ../expressions.md
 [_PathInExpression_]: ../paths.md#paths-in-expressions
 [structs]: struct-expr.md

--- a/src/expressions/struct-expr.md
+++ b/src/expressions/struct-expr.md
@@ -140,7 +140,7 @@ expressions].
 
 [IDENTIFIER]: ../identifiers.md
 [Inner attributes]: ../attributes.md
-[TUPLE_INDEX]: ../tokens.md#integer-literals
+[TUPLE_INDEX]: ../tokens.md#tuple-index
 [_Expression_]: ../expressions.md
 [_InnerAttribute_]: ../attributes.md
 [_PathInExpression_]: ../paths.md#paths-in-expressions

--- a/src/expressions/tuple-expr.md
+++ b/src/expressions/tuple-expr.md
@@ -55,7 +55,7 @@ assert_eq!(unit_x.0, 1.0);
 ```
 
 [Inner attributes]: ../attributes.md
-[TUPLE_INDEX]: ../tokens.md#integer-literals
+[TUPLE_INDEX]: ../tokens.md#tuple-index
 [_Expression_]: ../expressions.md
 [_InnerAttribute_]: ../attributes.md
 [attributes on block expressions]: block-expr.md#attributes-on-block-expressions

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -481,7 +481,7 @@ Reference patterns are always irrefutable.
 > &nbsp;&nbsp; `..`
 
 [_OuterAttribute_]: attributes.md
-[TUPLE_INDEX]: tokens.md#integer-literals
+[TUPLE_INDEX]: tokens.md#tuple-index
 
 Struct patterns match struct values that match all criteria defined by its subpatterns.
 They are also used to [destructure](#destructuring) a struct.

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -329,10 +329,6 @@ literal_. The grammar for recognizing the two kinds of literals is mixed.
 > DEC_LITERAL :\
 > &nbsp;&nbsp; DEC_DIGIT (DEC_DIGIT|`_`)<sup>\*</sup>
 >
-> TUPLE_INDEX :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `0`
-> &nbsp;&nbsp; | NON_ZERO_DEC_DIGIT DEC_DIGIT<sup>\*</sup>
->
 > BIN_LITERAL :\
 > &nbsp;&nbsp; `0b` (BIN_DIGIT|`_`)<sup>\*</sup> BIN_DIGIT (BIN_DIGIT|`_`)<sup>\*</sup>
 >
@@ -348,8 +344,6 @@ literal_. The grammar for recognizing the two kinds of literals is mixed.
 >
 > DEC_DIGIT : [`0`-`9`]
 >
-> NON_ZERO_DEC_DIGIT : [`1`-`9`]
->
 > HEX_DIGIT : [`0`-`9` `a`-`f` `A`-`F`]
 >
 > INTEGER_SUFFIX :\
@@ -360,9 +354,6 @@ An _integer literal_ has one of four forms:
 
 * A _decimal literal_ starts with a *decimal digit* and continues with any
   mixture of *decimal digits* and _underscores_.
-* A _tuple index_ is either `0`, or starts with a *non-zero decimal digit* and
-  continues with zero or more decimal digits. Tuple indexes are used to refer
-  to the fields of [tuples], [tuple structs], and [tuple variants].
 * A _hex literal_ starts with the character sequence `U+0030` `U+0078`
   (`0x`) and continues as any mixture (with at least one digit) of hex digits
   and underscores.
@@ -441,6 +432,33 @@ operator] to an integer literal `1i8`, rather than
 a single integer literal.
 
 [unary minus operator]: expressions/operator-expr.md#negation-operators
+
+#### Tuple index
+
+> **<sup>Lexer</sup>**\
+> TUPLE_INDEX: \
+> &nbsp;&nbsp; INTEGER_LITERAL
+
+A tuple index is used to refer to the fields of [tuples], [tuple structs], and
+[tuple variants].
+
+Tuple indices are compared with the literal token directly. Tuple indices
+start with `0` and each successive index increments the value by `1` as a
+decimal value. Thus, only decimal values will match, and the value must not
+have any extra `0` prefix characters.
+
+```rust,compile_fail
+let example = ("dog", "cat", "horse");
+let dog = example.0;
+let cat = example.1;
+// The following examples are invalid.
+let cat = example.01;  // ERROR no field named `01`
+let horse = example.0b10;  // ERROR no field named `0b10`
+```
+
+> **Note**: The tuple index may include an `INTEGER_SUFFIX`, but this is not
+> intended to be valid, and may be removed in a future version. See
+> <https://github.com/rust-lang/rust/issues/60210> for more information.
 
 #### Floating-point literals
 


### PR DESCRIPTION
The tuple index is not a distinct token lexically, so don't treat it as such.

Also, add a note about the future-compatibility issue with suffixes.

Closes #735