### PR TITLE
Add a link to the definition of Pattern_White_Space.

### DIFF
--- a/src/whitespace.md
+++ b/src/whitespace.md
@@ -1,7 +1,7 @@
 # Whitespace
 
 Whitespace is any non-empty string containing only characters that have the
-`Pattern_White_Space` Unicode property, namely:
+[`Pattern_White_Space`] Unicode property, namely:
 
 - `U+0009` (horizontal tab, `'\t'`)
 - `U+000A` (line feed, `'\n'`)
@@ -20,3 +20,5 @@ to separate _tokens_ in the grammar, and have no semantic significance.
 
 A Rust program has identical meaning if each whitespace element is replaced
 with any other legal whitespace element, such as a single space character.
+
+[`Pattern_White_Space`]: https://www.unicode.org/reports/tr31/


### PR DESCRIPTION
Just a minor thing. Not sure if it is really helpful, since the actual property is defined in the bowels of the unicode character database.
 