### PR TITLE
Improve visibility and privacy page

### DIFF
--- a/src/visibility-and-privacy.md
+++ b/src/visibility-and-privacy.md
@@ -8,85 +8,84 @@
 > &nbsp;&nbsp; | `pub` `(` `super` `)`\
 > &nbsp;&nbsp; | `pub` `(` `in` [_SimplePath_] `)`
 
-These two terms are often used interchangeably, and what they are attempting to
-convey is the answer to the question "Can this item be used at this location?"
+The terms "visibility" and "privacy" are complimentary words used to convey the
+question, "Can this item be used at this location?"
 
-Rust's name resolution operates on a global hierarchy of namespaces. Each level
-in the hierarchy can be thought of as some item. The items are one of those
-mentioned above, but also include external crates. Declaring or defining a new
-module can be thought of as inserting a new tree into the hierarchy at the
-location of the definition.
+Using an item means referencing any item in any way such as invoking a
+function, creating a struct or adding a `use` statement. The "location" of an
+item generally means, "What crate is the item in? And (sometimes) what module,
+or path of modules, within the crate?" But sometimes there is more to it. For
+example, the location of a struct field is, obviously, within some struct. Or,
+since a struct may be declared inside of a function, the location of a struct
+may be within a function.
 
-To control whether interfaces can be used across modules, Rust checks each use
-of an item to see whether it should be allowed or not. This is where privacy
-warnings are generated, or otherwise "you used a private item of another module
-and weren't allowed to."
+The Rust compiler does a "privacy check" on every item usage to ensure that the
+item is visible to that location. If you use an item where it cannot be used,
+you will get a privacy error such as, "function \`function\_name\` is private".
 
-By default, everything in Rust is *private*, with two exceptions: Associated
-items in a `pub` Trait are public by default; Enum variants
-in a `pub` enum are also public by default. When an item is declared as `pub`,
-it can be thought of as being accessible to the outside world. For example:
+By default, everything in Rust is private, with two exceptions: Associated
+items in a Trait and Enum variants. Items declared as `pub` are considered
+public. For example:
 
 ```rust
 # fn main() {}
-// Declare a private struct
+// private struct
 struct Foo;
 
-// Declare a public struct with a private field
+// public struct
 pub struct Bar {
-    field: i32,
+    // public field
+    pub field_a: i32,
+    // private field
+    field_b: i32,
 }
 
-// Declare a public enum with two public variants
+// public enum
 pub enum State {
+    // public enum variants
     PubliclyAccessibleState,
     PubliclyAccessibleState2,
 }
 ```
 
-With the notion of an item being either public or private, Rust allows item
-accesses in two cases:
+The visibility rules for private and public items are as follows:
 
-1. If an item is public, then it can be accessed externally from some module
-   `m` if you can access all the item's ancestor modules from `m`. You can
-   also potentially be able to name the item through re-exports. See below.
-2. If an item is private, it may be accessed by the current module and its
+1. If an item is private, it may be accessed by the current module and its
    descendants.
+2. If an item is public, then it can be accessed from some module `m` if you
+   can access all the item's ancestor modules from `m`. You may also be able to
+   access the item through re-exports. See below.
 
-These two cases are surprisingly powerful for creating module hierarchies
-exposing public APIs while hiding internal implementation details. To help
-explain, here's a few use cases and what they would entail:
+---
 
-* A library developer needs to expose functionality to crates which link
-  against their library. As a consequence of the first case, this means that
-  anything which is usable externally must be `pub` from the root down to the
-  destination item. Any private item in the chain will disallow external
-  accesses.
+Here are a few scenarios to demonstrate how you might apply these rules.
 
-* A crate needs a global available "helper module" to itself, but it doesn't
-  want to expose the helper module as a public API. To accomplish this, the
-  root of the crate's hierarchy would have a private module which then
-  internally has a "public API". Because the entire crate is a descendant of
-  the root, then the entire local crate can access this private module through
-  the second case.
+***I am developing a library, so I need a public API with hidden implementation details***
 
-* When writing unit tests for a module, it's often a common idiom to have an
-  immediate child of the module to-be-tested named `mod test`. This module
-  could access any items of the parent module through the second case, meaning
-  that internal implementation details could also be seamlessly tested from the
-  child module.
+Anything you want exposed as part of your library's public API must be `pub`
+from the root down to the item. Any private item in the chain will disallow
+external accesses.
 
-In the second case, it mentions that a private item "can be accessed" by the
-current module and its descendants, but the exact meaning of accessing an item
-depends on what the item is. Accessing a module, for example, would mean
-looking inside of it (to import more items). On the other hand, accessing a
-function would mean that it is invoked. Additionally, path expressions and
-import statements are considered to access an item in the sense that the
-import/expression is only valid if the destination is in the current visibility
-scope.
+***I need a "helper module" with items that are only visible to the crate***
 
-Here's an example of a program which exemplifies the three cases outlined
-above:
+Create a private module at the root of the crate. Within that module, create a
+"public API" by marking some items with `pub`. Since everything in the crate is
+a descendant of the root, the entire crate will have access to this private
+module.
+
+> **Note:** Consider marking items with `pub(crate)` to ensure that they are
+> not re-exported (see below).
+
+***I am writing unit tests***
+
+When writing unit tests for a module, a common idiom is to have an immediate
+child of the module with tests named `mod test`. This module could access any
+items of the parent module through the second case, meaning that internal
+implementation details could also be seamlessly tested from the child module.
+
+---
+
+Here is an example program to exemplify the three scenarios outlined above:
 
 ```rust
 // This module is private, meaning that no external crate can access this
@@ -137,10 +136,6 @@ pub mod submodule {
 
 # fn main() {}
 ```
-
-For a Rust program to pass the privacy checking pass, all paths must be valid
-accesses given the two rules above. This includes all use statements,
-expressions, types, etc.
 
 ## `pub(in path)`, `pub(crate)`, `pub(super)`, and `pub(self)`
 


### PR DESCRIPTION
My main reason for making changes to this page was to add to this note in the part about "helper modules":

> Note: Consider marking items with pub(crate) to ensure that they are not re-exported (see below).

You can see my Stack Overflow [question](https://stackoverflow.com/questions/62205451/where-is-my-private-code-exposed-as-public) for background.

But then I found some other things to tweak just to improve readability. Some phrases I just removed that seemed irrelevant or redundant. If any of these changes seem ill-justified, I can reverse them.