### PR TITLE
fix out of date info on type aliases

### DIFF
--- a/src/items/type-aliases.md
+++ b/src/items/type-aliases.md
@@ -20,9 +20,9 @@ type Point = (u8, u8);
 let p: Point = (41, 68);
 ```
 
-A type alias to an tuple-struct type cannot be used to qualify the constructors:
+A type alias to a tuple-struct or unit-struct cannot be used to qualify that type's constructor:
 
-```rust
+```rust,edition2018,compile_fail
 pub struct MyStruct(u32);
 
 pub use self::MyStruct as PubUse;
@@ -30,7 +30,7 @@ pub type PubType = MyStruct;
 
 fn main() {
     let _ = PubUse(5); // OK
-    // let _ = PubType(5); // Doesn't work
+    let _ = PubType(5); // Doesn't work
 }
 ```
 

--- a/src/items/type-aliases.md
+++ b/src/items/type-aliases.md
@@ -23,15 +23,13 @@ let p: Point = (41, 68);
 A type alias to a tuple-struct or unit-struct cannot be used to qualify that type's constructor:
 
 ```rust,edition2018,compile_fail
-pub struct MyStruct(u32);
+struct MyStruct(u32);
 
-pub use self::MyStruct as PubUse;
-pub type PubType = MyStruct;
+use self::MyStruct as PubUse;
+type PubType = MyStruct;
 
-fn main() {
-    let _ = PubUse(5); // OK
-    let _ = PubType(5); // Doesn't work
-}
+let _ = PubUse(5); // OK
+let _ = PubType(5); // Doesn't work
 ```
 
 [IDENTIFIER]: ../identifiers.md

--- a/src/items/type-aliases.md
+++ b/src/items/type-aliases.md
@@ -20,13 +20,18 @@ type Point = (u8, u8);
 let p: Point = (41, 68);
 ```
 
-A type alias to an enum type cannot be used to qualify the constructors:
+A type alias to an tuple-struct type cannot be used to qualify the constructors:
 
 ```rust
-enum E { A }
-type F = E;
-let _: F = E::A;  // OK
-// let _: F = F::A;  // Doesn't work
+pub struct MyStruct(u32);
+
+pub use self::MyStruct as PubUse;
+pub type PubType = MyStruct;
+
+fn main() {
+    let _ = PubUse(5); // OK
+    // let _ = PubType(5); // Doesn't work
+}
 ```
 
 [IDENTIFIER]: ../identifiers.md

--- a/src/items/type-aliases.md
+++ b/src/items/type-aliases.md
@@ -25,11 +25,11 @@ A type alias to a tuple-struct or unit-struct cannot be used to qualify that typ
 ```rust,edition2018,compile_fail
 struct MyStruct(u32);
 
-use self::MyStruct as PubUse;
-type PubType = MyStruct;
+use MyStruct as UseAlias;
+type TypeAlias = MyStruct;
 
-let _ = PubUse(5); // OK
-let _ = PubType(5); // Doesn't work
+let _ = UseAlias(5); // OK
+let _ = TypeAlias(5); // Doesn't work
 ```
 
 [IDENTIFIER]: ../identifiers.md


### PR DESCRIPTION
The current version of the reference for `type-aliases` currently claims that you cannot qualify constructors for enums through type aliases, but this is no longer true. AFAIK the only type of constructor that type aliases can't be used for are `tuple-structs`. tuple-enums, non-tuple-enums, and non-tuple-structs all construct just fine through type aliases.