### PR TITLE
Fix an invalid variable name in the loop example

### DIFF
--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -179,7 +179,7 @@ is equivalent to
                 Option::Some(val) => next = val,
                 Option::None => break,
             };
-            let PAT = next;
+            let PATTERN = next;
             let () = { /* loop body */ };
         },
     };


### PR DESCRIPTION
Since the original code is `'label: for PATTERN in iter_expr {`, the variable name should be `PATTERN` too.