### PR TITLE
Added a compiler warning and explanations for irrefutable patterns.

### DIFF
--- a/src/patterns.md
+++ b/src/patterns.md
@@ -111,17 +111,7 @@ if let (a, 3) = (1, 2) {           // "(a, 3)" is refutable, and will not match
 }
 ```
 
-Using an irrefutable pattern in `match`, `if let` or `while let` expressions produces a compiler warning.
-
-Example:
-```rust
-| /     if let (x, y) = (1, 2) {
-| |         print!("an irrefutable pattern, x={}, y={}", x, y)
-| |     }
-| |_____^
-|
-= note: `#[warn(irrefutable_let_patterns)]` on by default
-```
+Using an irrefutable pattern in `match`, `if let` or `while let` expressions produces a compiler warning. E.g. `if let (x, y) = (1, 2) { ... }` results in this compiler message `#[warn(irrefutable_let_patterns)]`.
 
 Patterns used in `let` statements, `for` expressions, *Function* and *closure* parameters are always irrefutable.
 

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -111,6 +111,20 @@ if let (a, 3) = (1, 2) {           // "(a, 3)" is refutable, and will not match
 }
 ```
 
+Using an irrefutable pattern in `match`, `if let` or `while let` expressions produces a compiler warning.
+
+Example:
+```rust
+| /     if let (x, y) = (1, 2) {
+| |         print!("an irrefutable pattern, x={}, y={}", x, y)
+| |     }
+| |_____^
+|
+= note: `#[warn(irrefutable_let_patterns)]` on by default
+```
+
+Patterns used in `let` statements, `for` expressions, *Function* and *closure* parameters are always irrefutable.
+
 ## Literal patterns
 
 > **<sup>Syntax</sup>**\


### PR DESCRIPTION
In response to issue https://github.com/rust-lang/reference/issues/799

I am very new to Rust (10 days), so it needs to be reviewed for correctness.
I got the compiler warning from running the code and the irrefutability requirements from reading:

* https://doc.rust-lang.org/reference/expressions/closure-expr.html
* https://doc.rust-lang.org/reference/items/functions.html
* https://doc.rust-lang.org/reference/expressions/loop-expr.html#iterator-loops
* https://doc.rust-lang.org/reference/statements.html#let-statements