### PR TITLE
clarify when reading uninititalized memory is allowed

### DIFF
--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -57,6 +57,11 @@ code.
     > **Note**: `rustc` achieves this with the unstable
     > `rustc_layout_scalar_valid_range_*` attributes.
 
+Note that uninitialized memory is also implicitly invalid for any type that has
+a restricted set of valid values.  In other words, the only cases in which
+reading uninitialized memory is permitted is inside `union`s, and between the
+fields of a compound type (in the "padding").
+
 A reference/pointer is "dangling" if it is null or not all of the bytes it
 points to are part of the same allocation (so in particular they all have to be
 part of *some* allocation). The span of bytes it points to is determined by the

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -59,7 +59,7 @@ code.
 
 **Note:** Uninitialized memory is also implicitly invalid for any type that has
 a restricted set of valid values. In other words, the only cases in which
-reading uninitialized memory is permitted is inside `union`s and in "padding"
+reading uninitialized memory is permitted are inside `union`s and in "padding"
 (the gaps between the fields/elements of a type).
 
 A reference/pointer is "dangling" if it is null or not all of the bytes it

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -59,8 +59,8 @@ code.
 
 **Note:** Uninitialized memory is also implicitly invalid for any type that has
 a restricted set of valid values. In other words, the only cases in which
-reading uninitialized memory is permitted is inside `union`s and between the
-fields of a compound type (in the "padding").
+reading uninitialized memory is permitted is inside `union`s and in "padding"
+(the gaps between the fields/elements of a type).
 
 A reference/pointer is "dangling" if it is null or not all of the bytes it
 points to are part of the same allocation (so in particular they all have to be

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -57,9 +57,9 @@ code.
     > **Note**: `rustc` achieves this with the unstable
     > `rustc_layout_scalar_valid_range_*` attributes.
 
-Note that uninitialized memory is also implicitly invalid for any type that has
-a restricted set of valid values.  In other words, the only cases in which
-reading uninitialized memory is permitted is inside `union`s, and between the
+**Note:** Uninitialized memory is also implicitly invalid for any type that has
+a restricted set of valid values. In other words, the only cases in which
+reading uninitialized memory is permitted is inside `union`s and between the
 fields of a compound type (in the "padding").
 
 A reference/pointer is "dangling" if it is null or not all of the bytes it


### PR DESCRIPTION
This should hopefully help avoid confusion like [this one](https://internals.rust-lang.org/t/why-even-unused-data-needs-to-be-valid/12734/23?u=ralfjung).