### PR TITLE
patterns.md - add word "underscore" to _ paragraph

### DIFF
--- a/src/patterns.md
+++ b/src/patterns.md
@@ -282,7 +282,7 @@ it is dereferenced and this process repeats.
 > _WildcardPattern_ :\
 > &nbsp;&nbsp; `_`
 
-The _wildcard pattern_ matches any value. It is used to ignore values when they don't
+The _wildcard pattern_ (an underscore symbol) matches any value. It is used to ignore values when they don't
 matter. Inside other patterns it matches a single data field (as opposed to the `..`
 which matches the remaining fields). Unlike identifier patterns, it does not copy, move
 or borrow the value it matches.


### PR DESCRIPTION
Add word "underscore" for better search accessibility.
`_` is a short, widely-used symbol and I didn't even try to search for it.
I think this simple change can prevent someone (would have prevented me) from being confused & asking on Reddit :)