### PR TITLE
Some constant/static updates.

### DIFF
--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -20,8 +20,9 @@ also constant expressions and do not cause any [`Drop::drop`][destructors] calls
 to be run.
 
 * [Literals].
-* [Paths] to [functions] and constants.
+* [Paths] to [functions] and [constants].
   Recursively defining constants is not allowed.
+* Paths to [statics]. These are only allowed within the initializer of a static.
 * [Tuple expressions].
 * [Array expressions].
 * [Struct] expressions.
@@ -53,7 +54,7 @@ to be run.
 A _const context_ is one of the following:
 
 * [Array type length expressions]
-* Repeat expression length expressions
+* [Array repeat expressions][array expressions]
 * The initializer of
   * [constants]
   * [statics]
@@ -75,6 +76,10 @@ Notable features that const contexts have, but const fn haven't are:
 * comparing raw pointers
 * union field access
 * [`transmute`] invocations.
+
+Conversely, the following are possible in a const function, but not in a const context:
+
+* Use of generic parameters.
 
 [arithmetic]:           expressions/operator-expr.md#arithmetic-and-logical-binary-operators
 [array expressions]:    expressions/array-expr.md

--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -54,7 +54,7 @@ to be run.
 A _const context_ is one of the following:
 
 * [Array type length expressions]
-* [Array repeat expressions][array expressions]
+* [Array repeat length expressions][array expressions]
 * The initializer of
   * [constants]
   * [statics]

--- a/src/items/constant-items.md
+++ b/src/items/constant-items.md
@@ -7,11 +7,12 @@
 A *constant item* is an optionally named _[constant value]_ which is not associated
 with a specific memory location in the program. Constants are essentially inlined
 wherever they are used, meaning that they are copied directly into the relevant
-context when used. References to the same constant are not necessarily
-guaranteed to refer to the same memory address.
+context when used. This includes usage of constants from external crates.
+References to the same constant are not necessarily guaranteed to refer to the
+same memory address.
 
 Constants must be explicitly typed. The type must have a `'static` lifetime: any
-references it contains must have `'static` lifetimes.
+references in the initializer must have `'static` lifetimes.
 
 Constants may refer to the address of other constants, in which case the
 address will have elided lifetimes where applicable, otherwise – in most cases

--- a/src/items/constant-items.md
+++ b/src/items/constant-items.md
@@ -7,9 +7,9 @@
 A *constant item* is an optionally named _[constant value]_ which is not associated
 with a specific memory location in the program. Constants are essentially inlined
 wherever they are used, meaning that they are copied directly into the relevant
-context when used. This includes usage of constants from external crates.
-References to the same constant are not necessarily guaranteed to refer to the
-same memory address.
+context when used. This includes usage of constants from external crates, and
+non-[`Copy`] types. References to the same constant are not necessarily
+guaranteed to refer to the same memory address.
 
 Constants must be explicitly typed. The type must have a `'static` lifetime: any
 references in the initializer must have `'static` lifetimes.
@@ -95,3 +95,4 @@ m!(const _: () = (););
 [underscore imports]: use-declarations.md#underscore-imports
 [_Type_]: ../types.md#type-expressions
 [_Expression_]: ../expressions.md
+[`Copy`]: ../special-types-and-traits.md#copy

--- a/src/items/static-items.md
+++ b/src/items/static-items.md
@@ -8,17 +8,19 @@
 A *static item* is similar to a [constant], except that it represents a precise
 memory location in the program. All references to the static refer to the same
 memory location. Static items have the `static` lifetime, which outlives all
-other lifetimes in a Rust program. Non-`mut` static items that contain a type
-that is not [interior mutable] may be placed in read-only memory. Static items
-do not call [`drop`] at the end of the program.
+other lifetimes in a Rust program. Static items do not call [`drop`] at the
+end of the program.
+
+The static initializer is a [constant expression] evaluated at compile time.
+Static initializers may refer to other statics.
+
+Non-`mut` static items that contain a type that is not [interior mutable] may
+be placed in read-only memory.
 
 All access to a static is safe, but there are a number of restrictions on
 statics:
 
 * The type must have the `Sync` trait bound to allow thread-safe access.
-* Statics allow using paths to statics in the [constant expression] used to
-  initialize them, but statics may not refer to other statics by value, only
-  through a reference.
 * Constants cannot refer to statics.
 
 ## Mutable statics

--- a/src/types/array.md
+++ b/src/types/array.md
@@ -5,7 +5,7 @@
 > &nbsp;&nbsp; `[` [_Type_] `;` [_Expression_] `]`
 
 An array is a fixed-size sequence of `N` elements of type `T`. The array type
-is written as `[T; N]`. The size is an expression that evaluates to a
+is written as `[T; N]`. The size is a [constant expression] that evaluates to a
 [`usize`].
 
 Examples:
@@ -28,3 +28,4 @@ always bounds-checked in safe methods and operators.
 [_Type_]: ../types.md#type-expressions
 [`Vec<T>`]: ../../std/vec/struct.Vec.html
 [`usize`]: numeric.md#machine-dependent-integer-types
+[constant expression]: ../const_eval.md#constant-expressions


### PR DESCRIPTION
- Clarify that array length is a "constant expression". Closes #582.
- Remove restriction that statics must use other statics by reference. This was removed in https://github.com/rust-lang/rust/pull/51110 (1.29 I believe).
- Clarify that paths to statics are allowed only within static initializers.
- Add a clarification of usage of constants from external crates (closes #22 I believe).
- Mention that generic parameters cannot be used in a const context (https://github.com/rust-lang/rust/issues/43408)
- Some other minor tweaks.
