### PR TITLE
Fix documented build output path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ And then generate the book:
 mdbook build
 ```
 
-The generated HTML will be in the `docs` folder.
+The generated HTML will be in the `book` folder.


### PR DESCRIPTION
The `mdbook build` default output directory is `book`, not `docs`.