### PR TITLE
Add an extra fn() entry to the variance table in the subtyping chapter

### DIFF
--- a/src/subtyping.md
+++ b/src/subtyping.md
@@ -61,6 +61,7 @@ Variance of types is automatically determined as follows
 | `[T]` and `[T; n]`            |                   | covariant         |
 | `fn() -> T`                   |                   | covariant         |
 | `fn(T) -> ()`                 |                   | contravariant     |
+| `fn(T) -> T`                  |                   | invariant         |
 | `std::cell::UnsafeCell<T>`    |                   | invariant         |
 | `std::marker::PhantomData<T>` |                   | covariant         |
 | `Trait<T> + 'a`               | covariant         | invariant         |


### PR DESCRIPTION
While discussing variance on a Rust help channel, I noticed that the subtyping chapter does not specifically mention the special case where a type parameter is used both in the input and output of a function, which, as far as I know, would make it be treated as invariant because its the intersection of both contravariance and covariance.

In case I'm not totally wrong with this, I propose adding that case to the table to make it a bit more clear.

<!-- https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=0f8e809bb71c498e03ce2fd054c757b0 -->