### PR TITLE
Update to `dyn Trait` syntax in a couple places

### DIFF
--- a/src/subtyping.md
+++ b/src/subtyping.md
@@ -63,7 +63,7 @@ Variance of types is automatically determined as follows
 | `fn(T) -> ()`                 |                   | contravariant     |
 | `std::cell::UnsafeCell<T>`    |                   | invariant         |
 | `std::marker::PhantomData<T>` |                   | covariant         |
-| `Trait<T> + 'a`               | covariant         | invariant         |
+| `dyn Trait<T> + 'a`           | covariant         | invariant         |
 
 The variance of other `struct`, `enum`, `union`, and tuple types is decided by
 looking at the variance of the types of their fields. If the parameter is used

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -95,8 +95,8 @@ zero-sized type to have a size of 0 and an alignment of 1.
 
 Trait objects have the same layout as the value the trait object is of.
 
-> Note: This is about the raw trait object types, not pointers (`&Trait`,
-> `Box<Trait>`, etc.) to trait objects.
+> Note: This is about the raw trait object types, not pointers (`&dyn Trait`,
+> `Box<dyn Trait>`, etc.) to trait objects.
 
 ## Closure Layout
 


### PR DESCRIPTION
Bare `Trait` is deprecated, so these examples should use `dyn Trait`.