### PR TITLE
Added variable back into example.

### DIFF
--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -66,7 +66,7 @@ Multiple match patterns may be joined with the `|` operator. Each pattern will b
 tested in left-to-right sequence until a successful match is found.
 
 ```rust
-# let x = 9;
+let x = 9;
 let message = match x {
     0 | 1  => "not many",
     2 ..= 9 => "a few",


### PR DESCRIPTION
This PR adds the assignment of x back into the match example. Without it, the example doesn't seem to make sense.