### PR TITLE
Update the description of staticlib

### DIFF
--- a/src/linkage.md
+++ b/src/linkage.md
@@ -41,10 +41,10 @@ be ignored in favor of only building the artifacts specified by command line.
   the compiler will never attempt to link to `staticlib` outputs. The
   purpose of this output type is to create a static library containing all of
   the local crate's code along with all upstream dependencies. The static
-  library is actually a `*.a` archive on linux and osx and a `*.lib` file on
-  windows. This format is recommended for use in situations such as linking
-  Rust code into an existing non-Rust application because it will not have
-  dynamic dependencies on other Rust code.
+  library is actually a `*.a` archive on linux and osx and windows(MinGW), and
+  a `*.lib` file on windows(MSVC). This format is recommended for use in
+  situations such as linking Rust code into an existing non-Rust application
+  because it will not have dynamic dependencies on other Rust code.
 
 * `--crate-type=cdylib`, `#[crate_type = "cdylib"]` - A dynamic system
   library will be produced.  This is used when compiling


### PR DESCRIPTION
Now Windows MinGW uses `.a` extension for staticlib.

c.f. https://github.com/rust-lang/rust/pull/70937