### PR TITLE
Specify that SSE4.1 includes SSSE3 instead of SSE3

### DIFF
--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -93,7 +93,7 @@ Feature     | Implicitly Enables | Description
 `sse`       |          | [SSE] — Streaming <abbr title="Single Instruction Multiple Data">SIMD</abbr> Extensions
 `sse2`      | `sse`    | [SSE2] — Streaming SIMD Extensions 2
 `sse3`      | `sse2`   | [SSE3] — Streaming SIMD Extensions 3
-`sse4.1`    | `sse3`   | [SSE4.1] — Streaming SIMD Extensions 4.1
+`sse4.1`    | `ssse3`  | [SSE4.1] — Streaming SIMD Extensions 4.1
 `sse4.2`    | `sse4.1` | [SSE4.2] — Streaming SIMD Extensions 4.2
 `ssse3`     | `sse3`   | [SSSE3] — Supplemental Streaming SIMD Extensions 3
 `xsave`     |          | [`xsave`] — Save processor extended states


### PR DESCRIPTION
According to LLVM source code: https://github.com/llvm/llvm-project/blob/544a6aa2674e3875e4014eafb101a982f9296439/llvm/lib/Target/X86/X86.td#L66-L82

Fixes https://github.com/rust-lang/reference/issues/891