### PR TITLE
Add `unsafe` for `mod` and `extern`.

### DIFF
--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -2,7 +2,7 @@
 
 > **<sup>Syntax</sup>**\
 > _ExternBlock_ :\
-> &nbsp;&nbsp; `extern` [_Abi_]<sup>?</sup> `{`\
+> &nbsp;&nbsp; `unsafe`<sup>?</sup> `extern` [_Abi_]<sup>?</sup> `{`\
 > &nbsp;&nbsp; &nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>\
 > &nbsp;&nbsp; &nbsp;&nbsp; _ExternalItem_<sup>\*</sup>\
 > &nbsp;&nbsp; `}`
@@ -37,6 +37,11 @@ akin to unchecked imports.
 Two kind of item _declarations_ are allowed in external blocks: [functions] and
 [statics]. Calling functions or accessing statics that are declared in external
 blocks is only allowed in an `unsafe` context.
+
+The `unsafe` keyword is syntactically allowed to appear before the `extern`
+keyword, but it is rejected at a semantic level. This allows macros to consume
+the syntax and make use of the `unsafe` keyword, before removing it from the
+token stream.
 
 ## Functions
 

--- a/src/items/modules.md
+++ b/src/items/modules.md
@@ -2,8 +2,8 @@
 
 > **<sup>Syntax:</sup>**\
 > _Module_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `mod` [IDENTIFIER] `;`\
-> &nbsp;&nbsp; | `mod` [IDENTIFIER] `{`\
+> &nbsp;&nbsp; &nbsp;&nbsp; `unsafe`<sup>?</sup> `mod` [IDENTIFIER] `;`\
+> &nbsp;&nbsp; | `unsafe`<sup>?</sup> `mod` [IDENTIFIER] `{`\
 > &nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>\
 > &nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp; [_Item_]<sup>\*</sup>\
 > &nbsp;&nbsp; &nbsp;&nbsp; `}`
@@ -39,6 +39,11 @@ same name as a module in scope is forbidden: that is, a type definition, trait,
 struct, enumeration, union, type parameter or crate can't shadow the name of a
 module in scope, or vice versa. Items brought into scope with `use` also have
 this restriction.
+
+The `unsafe` keyword is syntactically allowed to appear before the `mod`
+keyword, but it is rejected at a semantic level. This allows macros to consume
+the syntax and make use of the `unsafe` keyword, before removing it from the
+token stream.
 
 ## Module Source Filenames
 


### PR DESCRIPTION
New syntax added in https://github.com/rust-lang/rust/pull/75857/.
