### PR TITLE
Use `doc`, not `test` for fn item inner attr example

### DIFF
--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -290,12 +290,12 @@ responsibility to ensure that.
 [Outer attributes][attributes] are allowed on functions. [Inner
 attributes][attributes] are allowed directly after the `{` inside its [block].
 
-This example shows an inner attribute on a function. The function will only be
-available while running tests.
+This example shows an inner attribute on a function. The function is documented
+with just the word "Example".
 
 ```rust
-fn test_only() {
-    #![doc("Example")]
+fn documented() {
+    #![doc = "Example"]
 }
 ```
 

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -295,7 +295,7 @@ available while running tests.
 
 ```rust
 fn test_only() {
-    #![test]
+    #![doc("Example")]
 }
 ```
 


### PR DESCRIPTION
Using `test` causes a deny-by-default lint to trigger. See
https://github.com/rust-lang/rust/pull/79003 for more information.