### PR TITLE
linkage.md: update link to FFI section of the Book.

### DIFF
--- a/src/linkage.md
+++ b/src/linkage.md
@@ -8,7 +8,7 @@ statically and dynamically. This section will explore the various methods to
 link crates together, and more information about native libraries can be
 found in the [FFI section of the book][ffi].
 
-[ffi]: ../book/ffi.html
+[ffi]: ../book/ch19-01-unsafe-rust.html#using-extern-functions-to-call-external-code
 
 In one session of compilation, the compiler can generate multiple artifacts
 through the usage of either command line flags or the `crate_type` attribute.


### PR DESCRIPTION
Hi! I've tried to verify that this works but using `mdbook build` creates a broken link locally (in the output, `book` is the directory containing the reference, not the Book). This format, however, matches the link to the book from [`runtime.md`](https://doc.rust-lang.org/stable/reference/runtime.html#standard-behavior), which does work.