### PR TITLE
Add "Logic errors" as behavior not considered unsafe

### DIFF
--- a/src/behavior-not-considered-unsafe.md
+++ b/src/behavior-not-considered-unsafe.md
@@ -36,4 +36,21 @@ semantics.
 See [RFC 560] for error conditions, rationale, and more details about
 integer overflow.
 
+##### Logic errors
+
+Safe code may impose extra logical constraints that can be checked
+at neither compile-time nor runtime. If a program breaks such
+a constraint, the behavior may be unspecified but will not result in
+undefined behavior. This could include panics, incorrect results,
+aborts, and non-termination. The behavior may also differ between
+runs, builds, or kinds of build.
+
+For example, implementing both `Hash` and `Eq` requires that values
+considered equal have equal hashes. Another example are data structures
+like `BinaryHeap`, `BTreeMap`, `BTreeSet`, `HashMap` and `HashSet`
+which describe constraints on the modification of their keys while
+they are in the data structure. Violating such constraints is not
+considered unsafe, yet the program is considered erroneous and
+its behavior unpredictable.
+
 [RFC 560]: https://github.com/rust-lang/rfcs/blob/master/text/0560-integer-overflow.md


### PR DESCRIPTION
In https://github.com/rust-lang/rust/issues/80657 and https://github.com/rust-lang/rust/pull/80681 it is discussed how to clarify/define what a "logic error" is and what are their consequences. The reference should mention them as well.

We could use other term instead of "unspecified", e.g. "unpredictable"; in case we want to emphasize that the results may not the same between runs, builds, kinds of build, etc. For instance, from the description of integer overflow, it looks like the implementation needs to choose some reasonable behavior (e.g. a panic or wrap around), even if not documented (therefore, "unspecified", in terms of the C and C++ standards). However, logic errors seem to require more freedom: the implementation may not even be able (or want) to predict what may happen, so it cannot "reasonably choose" a particular behavior, even if such behavior is guaranteed to be safe (similar to deadlocks, although in that case the set of possible behavior is known, even if nondeterministic between runs).

As I mentioned in one of the linked discussions, it might be a good idea to define a separate, clear term for this kind of behavior that is considered erroneous and unpredictable, yet safe. So not exactly "unspecified", at least as used in the C and C++ standards -- it is closer to "safe UB" than "unspecified". In other words, in the same spirit as C's "bounded UB" or Ada's "bounded error". Ideally, the term would not overload another common term in other language specs (like UB).