### PR TITLE
Fix formatting in the tuple section

### DIFF
--- a/src/types/tuple.md
+++ b/src/types/tuple.md
@@ -36,6 +36,7 @@ index expression] or [pattern matching].
 
 [^1]: Structural types are always equivalent if their internal types are
     equivalent. For a nominal version of tuples, see [tuple structs].
+
 [^2]: Element is equivalent to field, except numerical indexes instead of
     identifiers
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/23638587/104041127-91f36300-51a6-11eb-898e-1301b96faa4e.png)

After:

![image](https://user-images.githubusercontent.com/23638587/104041112-8c961880-51a6-11eb-8e96-0e366d5ada29.png)

Caught by cargo-deadlinks in https://github.com/deadlinks/cargo-deadlinks/issues/133#issuecomment-748399781.