### PR TITLE
Update grammar for parser unification.

### DIFF
--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -1,5 +1,12 @@
 # Associated Items
 
+> **<sup>Syntax</sup>**\
+> _AssociatedItem_ :\
+> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> (\
+> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; [_MacroInvocationSemi_]\
+> &nbsp;&nbsp; &nbsp;&nbsp; | ( [_Visibility_]<sup>?</sup> ( [_TypeAlias_] | [_ConstantItem_] | [_Function_] ) )\
+> &nbsp;&nbsp; )
+
 *Associated Items* are the items declared in [traits] or defined in
 [implementations]. They are called this because they are defined on an associate
 type &mdash; the type in the implementation. They are a subset of the kinds of
@@ -78,21 +85,6 @@ let _: f64 = f64::from_i32(42);
 ```
 
 ### Methods
-
-> _Method_ :\
-> &nbsp;&nbsp; [_FunctionQualifiers_] `fn` [IDENTIFIER]&nbsp;[_GenericParams_]<sup>?</sup>\
-> &nbsp;&nbsp; &nbsp;&nbsp; `(` _SelfParam_ (`,` [_FunctionParam_])<sup>\*</sup> `,`<sup>?</sup> `)`\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_FunctionReturnType_]<sup>?</sup> [_WhereClause_]<sup>?</sup>\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_BlockExpression_]
->
-> _SelfParam_ :\
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> ( _ShorthandSelf_ | _TypedSelf_ )
->
-> _ShorthandSelf_ :\
-> &nbsp;&nbsp;  (`&` | `&` [_Lifetime_])<sup>?</sup> `mut`<sup>?</sup> `self`
->
-> _TypedSelf_ :\
-> &nbsp;&nbsp; `mut`<sup>?</sup> `self` `:` [_Type_]
 
 Associated functions whose first parameter is named `self` are called *methods*
 and may be invoked using the [method call operator], for example, `x.foo()`, as
@@ -227,6 +219,8 @@ If a type `Item` has an associated type `Assoc` from a trait `Trait`, then
 associated type definition. Furthermore, if `Item` is a type parameter, then
 `Item::Assoc` can be used in type parameters.
 
+Associated types must not include [generic parameters] or [where clauses].
+
 ```rust
 trait AssociatedType {
     // Associated type declaration
@@ -340,19 +334,16 @@ fn main() {
 }
 ```
 
-[_BlockExpression_]: ../expressions/block-expr.md
-[_FunctionParam_]: functions.md
-[_FunctionQualifiers_]: functions.md
-[_FunctionReturnType_]: functions.md
-[_GenericParams_]: generics.md
-[_Lifetime_]: ../trait-bounds.md
-[_Type_]: ../types.md#type-expressions
-[_WhereClause_]: generics.md#where-clauses
+[_ConstantItem_]: constant-items.md
+[_Function_]: functions.md
+[_MacroInvocationSemi_]: ../macros.md#macro-invocation
+[_OuterAttribute_]: ../attributes.md
+[_TypeAlias_]: type-aliases.md
+[_Visibility_]: ../visibility-and-privacy.md
 [`Arc<Self>`]: ../special-types-and-traits.md#arct
 [`Box<Self>`]: ../special-types-and-traits.md#boxt
 [`Pin<P>`]: ../special-types-and-traits.md#pinp
 [`Rc<Self>`]: ../special-types-and-traits.md#rct
-[_OuterAttribute_]: ../attributes.md
 [traits]: traits.md
 [type aliases]: type-aliases.md
 [inherent implementations]: implementations.md#inherent-implementations
@@ -367,3 +358,5 @@ fn main() {
 [method call operator]: ../expressions/method-call-expr.md
 [path]: ../paths.md
 [regular function parameters]: functions.md#attributes-on-function-parameters
+[generic parameters]: generics.md
+[where clauses]: generics.md#where-clauses

--- a/src/items/constant-items.md
+++ b/src/items/constant-items.md
@@ -2,7 +2,7 @@
 
 > **<sup>Syntax</sup>**\
 > _ConstantItem_ :\
-> &nbsp;&nbsp; `const` ( [IDENTIFIER] | `_` ) `:` [_Type_] `=` [_Expression_] `;`
+> &nbsp;&nbsp; `const` ( [IDENTIFIER] | `_` ) `:` [_Type_] ( `=` [_Expression_] )<sup>?</sup> `;`
 
 A *constant item* is an optionally named _[constant value]_ which is not associated
 with a specific memory location in the program. Constants are essentially inlined
@@ -37,6 +37,8 @@ const BITS_N_STRINGS: BitsNStrings<'static> = BitsNStrings {
     mystring: STRING,
 };
 ```
+
+The constant expression may only be omitted in a [trait definition].
 
 ## Constants with Destructors
 
@@ -91,6 +93,7 @@ m!(const _: () = (););
 [constant value]: ../const_eval.md#constant-expressions
 [free]: ../glossary.md#free-item
 [static lifetime elision]: ../lifetime-elision.md#static-lifetime-elision
+[trait definition]: traits.md
 [IDENTIFIER]: ../identifiers.md
 [underscore imports]: use-declarations.md#underscore-imports
 [_Type_]: ../types.md#type-expressions

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -10,25 +10,8 @@
 > _ExternalItem_ :\
 > &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> (\
 > &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; [_MacroInvocationSemi_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | ( [_Visibility_]<sup>?</sup> ( _ExternalStaticItem_ | _ExternalFunctionItem_ ) )\
+> &nbsp;&nbsp; &nbsp;&nbsp; | ( [_Visibility_]<sup>?</sup> ( [_StaticItem_] | [_Function_] ) )\
 > &nbsp;&nbsp; )
->
-> _ExternalStaticItem_ :\
-> &nbsp;&nbsp; `static` `mut`<sup>?</sup> [IDENTIFIER] `:` [_Type_] `;`
->
-> _ExternalFunctionItem_ :\
-> &nbsp;&nbsp; `fn` [IDENTIFIER]&nbsp;[_GenericParams_]<sup>?</sup>\
-> &nbsp;&nbsp; `(` ( _NamedFunctionParameters_ | _NamedFunctionParametersWithVariadics_ )<sup>?</sup> `)`\
-> &nbsp;&nbsp; [_FunctionReturnType_]<sup>?</sup> [_WhereClause_]<sup>?</sup> `;`
->
-> _NamedFunctionParameters_ :\
-> &nbsp;&nbsp; _NamedFunctionParam_ ( `,` _NamedFunctionParam_ )<sup>\*</sup> `,`<sup>?</sup>
->
-> _NamedFunctionParam_ :\
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> ( [IDENTIFIER] | `_` ) `:` [_Type_]
->
-> _NamedFunctionParametersWithVariadics_ :\
-> &nbsp;&nbsp; ( _NamedFunctionParam_ `,` )<sup>\*</sup> _NamedFunctionParam_ `,` [_OuterAttribute_]<sup>\*</sup> `...`
 
 External blocks provide _declarations_ of items that are not _defined_ in the
 current crate and are the basis of Rust's foreign function interface. These are
@@ -46,9 +29,10 @@ token stream.
 ## Functions
 
 Functions within external blocks are declared in the same way as other Rust
-functions, with the exception that they may not have a body and are instead
+functions, with the exception that they must not have a body and are instead
 terminated by a semicolon. Patterns are not allowed in parameters, only
-[IDENTIFIER] or `_` may be used.
+[IDENTIFIER] or `_` may be used. Function qualifiers (`const`, `async`,
+`unsafe`, and `extern`) are not allowed.
 
 Functions within external blocks may be called by Rust code, just like
 functions defined in Rust. The Rust compiler automatically translates between
@@ -109,12 +93,15 @@ There are also some platform-specific ABI strings:
 
 ## Variadic functions
 
-Functions within external blocks may be variadic by specifying `...` after one
-or more named arguments in the argument list:
+Functions within external blocks may be variadic by specifying `...` as the
+last argument. There must be at least one parameter before the variadic
+parameter. The variadic parameter may optionally be specified with an
+identifier.
 
 ```rust
-extern {
+extern "C" {
     fn foo(x: i32, ...);
+    fn with_name(format: *const u8, args: ...);
 }
 ```
 
@@ -189,15 +176,13 @@ restrictions as [regular function parameters].
 [functions]: functions.md
 [statics]: static-items.md
 [_Abi_]: functions.md
-[_FunctionReturnType_]: functions.md
-[_GenericParams_]: generics.md
+[_Function_]: functions.md
 [_InnerAttribute_]: ../attributes.md
 [_MacroInvocationSemi_]: ../macros.md#macro-invocation
 [_MetaListNameValueStr_]: ../attributes.md#meta-item-attribute-syntax
 [_MetaNameValueStr_]: ../attributes.md#meta-item-attribute-syntax
 [_OuterAttribute_]: ../attributes.md
-[_Type_]: ../types.md#type-expressions
+[_StaticItem_]: static-items.md
 [_Visibility_]: ../visibility-and-privacy.md
-[_WhereClause_]: generics.md#where-clauses
 [attributes]: ../attributes.md
 [regular function parameters]: functions.md#attributes-on-function-parameters

--- a/src/items/implementations.md
+++ b/src/items/implementations.md
@@ -7,14 +7,8 @@
 > _InherentImpl_ :\
 > &nbsp;&nbsp; `impl` [_GenericParams_]<sup>?</sup>&nbsp;[_Type_]&nbsp;[_WhereClause_]<sup>?</sup> `{`\
 > &nbsp;&nbsp; &nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>\
-> &nbsp;&nbsp; &nbsp;&nbsp; _InherentImplItem_<sup>\*</sup>\
+> &nbsp;&nbsp; &nbsp;&nbsp; [_AssociatedItem_]<sup>\*</sup>\
 > &nbsp;&nbsp; `}`
->
-> _InherentImplItem_ :\
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> (\
-> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; [_MacroInvocationSemi_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | ( [_Visibility_]<sup>?</sup> ( [_ConstantItem_] | [_Function_] | [_Method_] ) )\
-> &nbsp;&nbsp; )
 >
 > _TraitImpl_ :\
 > &nbsp;&nbsp; `unsafe`<sup>?</sup> `impl` [_GenericParams_]<sup>?</sup> `!`<sup>?</sup>
@@ -22,14 +16,8 @@
 > &nbsp;&nbsp; [_WhereClause_]<sup>?</sup>\
 > &nbsp;&nbsp; `{`\
 > &nbsp;&nbsp; &nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>\
-> &nbsp;&nbsp; &nbsp;&nbsp; _TraitImplItem_<sup>\*</sup>\
+> &nbsp;&nbsp; &nbsp;&nbsp; [_AssociatedItem_]<sup>\*</sup>\
 > &nbsp;&nbsp; `}`
->
-> _TraitImplItem_ :\
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> (\
-> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; [_MacroInvocationSemi_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | ( [_Visibility_]<sup>?</sup> ( [_TypeAlias_] | [_ConstantItem_] | [_Function_] | [_Method_] ) )\
-> &nbsp;&nbsp; )
 
 An _implementation_ is an item that associates items with an _implementing type_.
 Implementations are defined with the keyword `impl` and contain functions
@@ -52,7 +40,7 @@ the _associated items_ to the implementing type.
 
 Inherent implementations associate the contained items to the
 implementing type.  Inherent implementations can contain [associated
-functions] (including methods) and [associated constants]. They cannot
+functions] (including [methods]) and [associated constants]. They cannot
 contain associated type aliases.
 
 The [path] to an associated item is any path to the implementing type,
@@ -281,17 +269,11 @@ attributes must come before any associated items. That attributes that have
 meaning here are [`cfg`], [`deprecated`], [`doc`], and [the lint check
 attributes].
 
-[_ConstantItem_]: constant-items.md
-[_Function_]: functions.md
+[_AssociatedItem_]: associated-items.md
 [_GenericParams_]: generics.md
 [_InnerAttribute_]: ../attributes.md
-[_MacroInvocationSemi_]: ../macros.md#macro-invocation
-[_Method_]: associated-items.md#methods
-[_OuterAttribute_]: ../attributes.md
-[_TypeAlias_]: type-aliases.md
 [_TypePath_]: ../paths.md#paths-in-types
 [_Type_]: ../types.md#type-expressions
-[_Visibility_]: ../visibility-and-privacy.md
 [_WhereClause_]: generics.md#where-clauses
 [trait]: traits.md
 [associated constants]: associated-items.md#associated-constants
@@ -303,6 +285,7 @@ attributes].
 [`deprecated`]: ../attributes/diagnostics.md#the-deprecated-attribute
 [`doc`]: ../../rustdoc/the-doc-attribute.html
 [generic parameters]: generics.md
+[methods]: associated-items.md#methods
 [path]: ../paths.md
 [the lint check attributes]: ../attributes/diagnostics.md#lint-check-attributes
 [Unsafe traits]: traits.md#unsafe-traits

--- a/src/items/static-items.md
+++ b/src/items/static-items.md
@@ -3,7 +3,7 @@
 > **<sup>Syntax</sup>**\
 > _StaticItem_ :\
 > &nbsp;&nbsp; `static` `mut`<sup>?</sup> [IDENTIFIER] `:` [_Type_]
->              `=` [_Expression_] `;`
+>              ( `=` [_Expression_] )<sup>?</sup> `;`
 
 A *static item* is similar to a [constant], except that it represents a precise
 memory location in the program. All references to the static refer to the same
@@ -22,6 +22,9 @@ statics:
 
 * The type must have the `Sync` trait bound to allow thread-safe access.
 * Constants cannot refer to statics.
+
+The initializer expression must be omitted in an [external block], and must be
+provided for free static items.
 
 ## Mutable statics
 
@@ -73,6 +76,7 @@ following are true:
 [constant]: constant-items.md
 [`drop`]: ../destructors.md
 [constant expression]: ../const_eval.md#constant-expressions
+[external block]: external-blocks.md
 [interior mutable]: ../interior-mutability.md
 [IDENTIFIER]: ../identifiers.md
 [_Type_]: ../types.md#type-expressions

--- a/src/items/traits.md
+++ b/src/items/traits.md
@@ -7,45 +7,8 @@
 >              ( `:` [_TypeParamBounds_]<sup>?</sup> )<sup>?</sup>
 >              [_WhereClause_]<sup>?</sup> `{`\
 > &nbsp;&nbsp;&nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>\
-> &nbsp;&nbsp;&nbsp;&nbsp; _TraitItem_<sup>\*</sup>\
+> &nbsp;&nbsp;&nbsp;&nbsp; [_AssociatedItem_]<sup>\*</sup>\
 > &nbsp;&nbsp; `}`
->
-> _TraitItem_ :\
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> [_Visibility_]<sup>?</sup> (\
-> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; _TraitFunc_\
-> &nbsp;&nbsp; &nbsp;&nbsp; | _TraitMethod_\
-> &nbsp;&nbsp; &nbsp;&nbsp; | _TraitConst_\
-> &nbsp;&nbsp; &nbsp;&nbsp; | _TraitType_\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_MacroInvocationSemi_]\
-> &nbsp;&nbsp; )
->
-> _TraitFunc_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; _TraitFunctionDecl_ ( `;` | [_BlockExpression_] )
->
-> _TraitMethod_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; _TraitMethodDecl_ ( `;` | [_BlockExpression_] )
->
-> _TraitFunctionDecl_ :\
-> &nbsp;&nbsp; [_FunctionQualifiers_] `fn` [IDENTIFIER]&nbsp;[_GenericParams_]<sup>?</sup>\
-> &nbsp;&nbsp; &nbsp;&nbsp; `(` _TraitFunctionParameters_<sup>?</sup> `)`\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_FunctionReturnType_]<sup>?</sup> [_WhereClause_]<sup>?</sup>
->
-> _TraitMethodDecl_ :\
-> &nbsp;&nbsp; [_FunctionQualifiers_] `fn` [IDENTIFIER]&nbsp;[_GenericParams_]<sup>?</sup>\
-> &nbsp;&nbsp; &nbsp;&nbsp; `(` [_SelfParam_] (`,` _TraitFunctionParam_)<sup>\*</sup> `,`<sup>?</sup> `)`\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_FunctionReturnType_]<sup>?</sup> [_WhereClause_]<sup>?</sup>
->
-> _TraitFunctionParameters_ :\
-> &nbsp;&nbsp; _TraitFunctionParam_ (`,` _TraitFunctionParam_)<sup>\*</sup> `,`<sup>?</sup>
->
-> _TraitFunctionParam_<sup>[†](#parameter-patterns)</sup> :\
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> ( [_Pattern_] `:` )<sup>?</sup> [_Type_]
->
-> _TraitConst_ :\
-> &nbsp;&nbsp; `const` [IDENTIFIER] `:` [_Type_]&nbsp;( `=` [_Expression_] )<sup>?</sup> `;`
->
-> _TraitType_ :\
-> &nbsp;&nbsp; `type` [IDENTIFIER] ( `:` [_TypeParamBounds_]<sup>?</sup> )<sup>?</sup> `;`
 
 A _trait_ describes an abstract interface that types can implement. This
 interface consists of [associated items], which come in three varieties:
@@ -61,10 +24,26 @@ other traits and so forth [as usual][generics].
 
 Traits are implemented for specific types through separate [implementations].
 
-Items associated with a trait do not need to be defined in the trait, but they
-may be. If the trait provides a definition, then this definition acts as a
-default for any implementation which does not override it. If it does not, then
-any implementation must provide a definition.
+Trait functions may omit the function body by replacing it with a semicolon.
+This indicates that the implementation must define the function. If the trait
+function defines a body, this definition acts as a default for any
+implementation which does not override it. Similarly, associated constants may
+omit the equals sign and expression to indicate implementations must define
+the constant value. Associated types must never define the type, the type may
+only be specified in an implementation.
+
+```rust
+// Examples of associated trait items with and without definitions.
+trait Example {
+    const CONST_NO_DEFAULT: i32;
+    const CONST_WITH_DEFAULT: i32 = 99;
+    type TypeNoDefault;
+    fn method_without_default(&self);
+    fn method_with_default(&self) {}
+}
+```
+
+Trait functions are are not allowed to be [`async`] or [`const`].
 
 ## Trait bounds
 
@@ -335,18 +314,10 @@ fn main() {
 
 [IDENTIFIER]: ../identifiers.md
 [WildcardPattern]: ../patterns.md#wildcard-pattern
-[_BlockExpression_]: ../expressions/block-expr.md
-[_Expression_]: ../expressions.md
-[_FunctionQualifiers_]: functions.md
-[_FunctionReturnType_]: functions.md
+[_AssociatedItem_]: associated-items.md
 [_GenericParams_]: generics.md
-[_MacroInvocationSemi_]: ../macros.md#macro-invocation
-[_OuterAttribute_]: ../attributes.md
 [_InnerAttribute_]: ../attributes.md
-[_Pattern_]: ../patterns.md
-[_SelfParam_]: associated-items.md#methods
 [_TypeParamBounds_]: ../trait-bounds.md
-[_Type_]: ../types.md#type-expressions
 [_Visibility_]: ../visibility-and-privacy.md
 [_WhereClause_]: generics.md#where-clauses
 [bounds]: ../trait-bounds.md
@@ -366,3 +337,5 @@ fn main() {
 [`Box<Self>`]: ../special-types-and-traits.md#boxt
 [`Pin<P>`]: ../special-types-and-traits.md#pinp
 [`Rc<Self>`]: ../special-types-and-traits.md#rct
+[`async`]: functions.md#async-functions
+[`const`]: functions.md#const-functions

--- a/src/items/type-aliases.md
+++ b/src/items/type-aliases.md
@@ -3,14 +3,12 @@
 > **<sup>Syntax</sup>**\
 > _TypeAlias_ :\
 > &nbsp;&nbsp; `type` [IDENTIFIER]&nbsp;[_GenericParams_]<sup>?</sup>
->              [_WhereClause_]<sup>?</sup> `=` [_Type_] `;`
+>              [_WhereClause_]<sup>?</sup> ( `=` [_Type_] ) `;`
 
 A _type alias_ defines a new name for an existing [type]. Type aliases are
 declared with the keyword `type`. Every value has a single, specific type, but
 may implement several different traits, or be compatible with several different
 type constraints.
-
-[type]: ../types.md
 
 For example, the following defines the type `Point` as a synonym for the type
 `(u8, u8)`, the type of pairs of unsigned 8 bit integers:
@@ -32,7 +30,13 @@ let _ = UseAlias(5); // OK
 let _ = TypeAlias(5); // Doesn't work
 ```
 
+A type alias without the [_Type_] specification may only appear as an
+[associated type] in a [trait].
+
 [IDENTIFIER]: ../identifiers.md
 [_GenericParams_]: generics.md
 [_WhereClause_]: generics.md#where-clauses
 [_Type_]: ../types.md#type-expressions
+[associated type]: associated-items.md#associated-types
+[trait]: traits.md
+[type]: ../types.md

--- a/src/types/function-pointer.md
+++ b/src/types/function-pointer.md
@@ -2,8 +2,11 @@
 
 > **<sup>Syntax</sup>**\
 > _BareFunctionType_ :\
-> &nbsp;&nbsp; [_ForLifetimes_]<sup>?</sup> [_FunctionQualifiers_] `fn`\
+> &nbsp;&nbsp; [_ForLifetimes_]<sup>?</sup> _FunctionTypeQualifiers_ `fn`\
 > &nbsp;&nbsp; &nbsp;&nbsp;  `(` _FunctionParametersMaybeNamedVariadic_<sup>?</sup> `)` _BareFunctionReturnType_<sup>?</sup>
+>
+> _FunctionTypeQualifiers_:\
+> &nbsp;&nbsp; `unsafe`<sup>?</sup> (`extern` [_Abi_]<sup>?</sup>)<sup>?</sup>
 >
 > _BareFunctionReturnType_:\
 > &nbsp;&nbsp; `->` [_TypeNoBounds_]
@@ -50,8 +53,8 @@ Attributes on function pointer parameters follow the same rules and
 restrictions as [regular function parameters].
 
 [IDENTIFIER]: ../identifiers.md
+[_Abi_]: ../items/functions.md
 [_ForLifetimes_]: ../items/generics.md#where-clauses
-[_FunctionQualifiers_]: ../items/functions.md
 [_TypeNoBounds_]: ../types.md#type-expressions
 [_Type_]: ../types.md#type-expressions
 [_OuterAttribute_]: ../attributes.md


### PR DESCRIPTION
Updates the grammar for function and associated item unification/simplification. Over a series of PRs, various parts of the grammar were unified so that some the same grammar is reused in various places, with restrictions and validation applied after parsing.

Some of the PRs:
* https://github.com/rust-lang/rust/pull/67131: Merge `TraitItem` & `ImplItem` into `AssocItem`
* https://github.com/rust-lang/rust/pull/68728: merge `fn` syntax + cleanup item parsing
* https://github.com/rust-lang/rust/pull/68764: syntactically allow `self` in all `fn` contexts
* https://github.com/rust-lang/rust/pull/68788: towards unified `fn` grammar
* https://github.com/rust-lang/rust/pull/69023: unify function front matter parsing
* https://github.com/rust-lang/rust/pull/69194: fuse associated and extern items up to defaultness

This also includes a few other fixes:
* Function front matter fixes (like `async const`).
* Fix function pointer front matter (which does not syntactically allow `async` or `const`).
* Add some notes about various restrictions.

I can provide links to rustc parser functions if you want, but I think they are pretty easy to find.

Closes #750
Closes #751
