### PR TITLE
Remove "Memory Ownership" chapter

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -111,7 +111,6 @@
 
 - [Memory model](memory-model.md)
     - [Memory allocation and lifetime](memory-allocation-and-lifetime.md)
-    - [Memory ownership](memory-ownership.md)
     - [Variables](variables.md)
 
 - [Linkage](linkage.md)

--- a/src/memory-ownership.md
+++ b/src/memory-ownership.md
@@ -1,4 +1,0 @@
-## Memory ownership
-
-When a stack frame is exited, its local allocations are all released, and its
-references to boxes are dropped.


### PR DESCRIPTION
It's a holdover from pre-Rust 1.0 when the reference was the main
document to understand anything about the language. Its contents are
completely meaningless and to avoid having hopeful people step into this
useless page and have their hopes smashed, we are removing it.