### PR TITLE
Standardize reference of "Attribute Macro"

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -25,14 +25,14 @@ the bang after the hash, apply to the thing that follows the attribute.
 
 The attribute consists of a path to the attribute, followed by an optional
 delimited token tree whose interpretation is defined by the attribute.
-Attributes other than macro attributes also allow the input to be an equals
+Attributes other than attribute macros also allow the input to be an equals
 sign (`=`) followed by a literal expression. See the [meta item
 syntax](#meta-item-attribute-syntax) below for more details.
 
 Attributes can be classified into the following kinds:
 
 * [Built-in attributes]
-* [Macro attributes][attribute macros]
+* [Attribute macros][attribute macros]
 * [Derive macro helper attributes]
 * [Tool attributes](#tool-attributes)
 


### PR DESCRIPTION
The Attributes section uses "macro attributes" but links to a section calling them "attribute macros"