### PR TITLE
Fix typo in type cast expression table

### DIFF
--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -343,7 +343,7 @@ well as the following additional casts. Here `*T` means either `*const T` or
 | `bool` or `char`      | Integer type          | Primitive to integer cast        |
 | `u8`                  | `char`                | `u8` to `char` cast              |
 | `*T`                  | `*V` where `V: Sized` \* | Pointer to pointer cast       |
-| `*T` where `T: Sized` | Numeric type          | Pointer to address cast          |
+| `*T` where `T: Sized` | Integer type          | Pointer to address cast          |
 | Integer type          | `*V` where `V: Sized` | Address to pointer cast          |
 | `&[T; n]`             | `*const T`            | Array to pointer cast            |
 | [Function item]       | [Function pointer]    | Function item to function pointer cast |


### PR DESCRIPTION
Typo originally reported in the compiler issue tracker:

https://github.com/rust-lang/rust/issues/81686#issuecomment-772820785

It doesn't make sense to cast a pointer to a float, and it's currently
rejected by the compiler:

    error[E0606]: casting `*const T` as `f32` is invalid
     --> test.rs:2:5
      |
    2 |     a as f32
      |     ^^^^^^^^

    error: aborting due to previous error

I think what's meant here is "integer type" rather than "numeric type".