### PR TITLE
Clarify object safety rules for methods striked from the vtable

### DIFF
--- a/src/items/traits.md
+++ b/src/items/traits.md
@@ -67,23 +67,23 @@ trait Seq<T> {
 Object safe traits can be the base trait of a [trait object]. A trait is
 *object safe* if it has the following qualities (defined in [RFC 255]):
 
-* It must not require `Self: Sized`
-* All associated functions must either have a `where Self: Sized` bound, or
-    * Not have any type parameters (although lifetime parameters are allowed),
-      and
-    * Be a [method] that does not use `Self` except in the type of the receiver.
+* All [supertraits] must also be object safe.
+* It must not require `Self: Sized` (i.e. `Sized` must not be a [supertrait][supertraits])
 * It must not have any associated constants.
-* All supertraits must also be object safe.
-
-When there isn't a `Self: Sized` bound on a method, the type of a method
-receiver must be one of the following types:
-
-* `&Self`
-* `&mut Self`
-* [`Box<Self>`]
-* [`Rc<Self>`]
-* [`Arc<Self>`]
-* [`Pin<P>`] where `P` is one of the types above
+* All associated functions must "dispatchable from a trait object" or "explicitly non-dispatchable from a trait object":
+    * Dispatchable functions require:
+        * Not have any type parameters (although lifetime parameters are allowed),
+        * Be a [method] that does not use `Self` except in the type of the receiver.
+        * Have a receiver with one of the following types:
+            * `&Self` (i.e. `&self`)
+            * `&mut Self` (i.e `&mut self`)
+            * [`Box<Self>`]
+            * [`Rc<Self>`]
+            * [`Arc<Self>`]
+            * [`Pin<P>`] where `P` is one of the types above
+        * Does not have a `where Self: Sized` bound (reciever type of `Self` (i.e. `self`) implies this).
+    * Explicitly non-dispatchable functions require:
+        * Have a `where Self: Sized` bound (reciever type of `Self` (i.e. `self`) implies this).
 
 ```rust
 # use std::rc::Rc;
@@ -325,6 +325,7 @@ fn main() {
 [RFC 255]: https://github.com/rust-lang/rfcs/blob/master/text/0255-object-safety.md
 [associated items]: associated-items.md
 [method]: associated-items.md#methods
+[supertraits]: #supertraits
 [implementations]: implementations.md
 [generics]: generics.md
 [where clauses]: generics.md#where-clauses

--- a/src/items/traits.md
+++ b/src/items/traits.md
@@ -68,9 +68,9 @@ Object safe traits can be the base trait of a [trait object]. A trait is
 *object safe* if it has the following qualities (defined in [RFC 255]):
 
 * All [supertraits] must also be object safe.
-* It must not require `Self: Sized` (i.e. `Sized` must not be a [supertrait][supertraits])
+* `Sized` must not be a [supertrait][supertraits]. In other words, it must not require `Self: Sized`.
 * It must not have any associated constants.
-* All associated functions must "dispatchable from a trait object" or "explicitly non-dispatchable from a trait object":
+* All associated functions must either be dispatchable from a trait object or be explicitly non-dispatchable:
     * Dispatchable functions require:
         * Not have any type parameters (although lifetime parameters are allowed),
         * Be a [method] that does not use `Self` except in the type of the receiver.


### PR DESCRIPTION
When trying to figure out how `async_trait` object safety worked and thinking about `Stream::next`'s object safety, I found it very hard to understand 

This clarifies that object-safety can still be possible even if a method is striked from the vtable, and that `self` and `where `Self: Sized` are the ONLY ways to do that.
This was only really explained clearly in the examples below, so this includes this clarification in the object safety rules in the beginning of the section


---
Separately, NonDispatchable seems like you are out of luck, but this pattern: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=5529e6424895cccda19d4dd81f389b69, where we impl the trait for &T where T: Trait + ?Sized is actually quite common in the std (albeit with `self` parameter's so you don't need the `(&obj_ref)` dance to get method resolution to be happy, see https://rust-lang.zulipchat.com/#narrow/stream/249502-wg-async-foundations.2Fstream-trait-rfc/topic/Object.20safety/near/226749056 for more info). 

This seems like a pattern we should explain somewhere, but is the reference the right place for it? I have not mentioned it in this PR, but would be curious what people think