### PR TITLE
Document current limitation of type aliases on enums

### DIFF
--- a/src/items/type-aliases.md
+++ b/src/items/type-aliases.md
@@ -36,7 +36,7 @@ A type alias without the [_Type_] specification may only appear as an
 
 A type alias to an enum cannot refer to the enum's variants within a [use declaration]:
 
-```rust,edition2018,compile_fail
+```rust,edition2018,compile_fail,E0432
 mod my_mod {
     pub enum MyEnum {
         MyVariant

--- a/src/items/type-aliases.md
+++ b/src/items/type-aliases.md
@@ -1,3 +1,4 @@
+
 # Type aliases
 
 > **<sup>Syntax</sup>**\
@@ -33,6 +34,25 @@ let _ = TypeAlias(5); // Doesn't work
 A type alias without the [_Type_] specification may only appear as an
 [associated type] in a [trait].
 
+A type alias to an enum cannot refer to the enum's variants within a [use declaration]:
+
+```rust,edition2018,compile_fail
+mod my_mod {
+    pub enum MyEnum {
+        MyVariant
+    }
+
+    pub type TypeAlias = MyEnum;
+}
+
+use my_mod::MyEnum; // OK
+use my_mod::MyEnum::MyVariant; // OK
+use my_mod::TypeAlias; // OK
+use my_mod::TypeAlias::MyVariant; // Doesn't work
+
+let _ = my_mod::TypeAlias::MyVariant; // OK
+```
+
 [IDENTIFIER]: ../identifiers.md
 [_GenericParams_]: generics.md
 [_WhereClause_]: generics.md#where-clauses
@@ -40,3 +60,4 @@ A type alias without the [_Type_] specification may only appear as an
 [associated type]: associated-items.md#associated-types
 [trait]: traits.md
 [type]: ../types.md
+[use declaration]: use-declarations.md


### PR DESCRIPTION
Question: is the intent of the reference to document how the language *currently* is, or how it *should* be? Because the behavior documented in this PR is something that I would like to be changed in the future (https://github.com/rust-lang/rust/issues/83248), but in the meantime it might be useful to readers to better understand the limitations of type aliases as they are currently implemented.