### PR TITLE
Update auto-deref recursion_limit example

### DIFF
--- a/src/attributes/limits.md
+++ b/src/attributes/limits.md
@@ -30,7 +30,7 @@ a!{}
 #![recursion_limit = "1"]
 
 // This fails because it requires two recursive steps to auto-derefence.
-(|_: &u8| {})(&&1);
+(|_: &u8| {})(&&&1);
 ```
 
 ## The `type_length_limit` attribute


### PR DESCRIPTION
This updates the auto-deref recursion_limit example for https://github.com/rust-lang/rust/pull/82834. Previously this actually hit the recursion limit while evaluating the Freeze bound, not during auto-deref. The current example only needs one level of deref to reach the argument type. This adds one more level of nesting, so that two derefs are actually needed, and recursion_limit is hit during auto-deref and not sometime later:

```
error[E0055]: reached the recursion limit while auto-dereferencing `&{integer}`
 --> test14.rs:5:19
  |
5 |     (|_: &u8| {})(&&&1);
  |                   ^^^^ deref recursion limit reached
  |
  = help: consider adding a `#![recursion_limit="2"]` attribute to your crate (`test14`)
```

Previously:
```
error[E0275]: overflow evaluating the requirement `(): marker::Freeze`
  |
  = help: consider adding a `#![recursion_limit="2"]` attribute to your crate (`test14`)
  = note: required because it appears within the type `[closure@test14.rs:5:5: 5:18]`
```