### PR TITLE
Fix ambiguous phrasing in 8.2.13 in paragraph on closure traits

### DIFF
--- a/src/expressions/closure-expr.md
+++ b/src/expressions/closure-expr.md
@@ -31,8 +31,8 @@ A closure can be forced to capture its environment by copying or moving values b
 This is often used to ensure that the closure's type is `'static`.
 
 The compiler will determine which of the [closure traits](../types/closure.md#call-traits-and-coercions) the closure's type will implement by how it acts on its captured variables.
-The closure will also implement [`Send`](../special-types-and-traits.md#send) and/or [`Sync`](../special-types-and-traits.md#sync) if all of its captured types do.
-These traits allow functions to accept closures using generics, even though the exact types can't be named.
+The closure will also implement the closure traits [`Send`](../special-types-and-traits.md#send) and/or [`Sync`](../special-types-and-traits.md#sync) if all of its captured types do.
+Closure traits allow functions to accept closures using generics, even though the exact types can't be named.
 
 In this example, we define a function `ten_times` that takes a higher-order function argument, and we then call it with a closure expression as an argument, followed by a closure expression that moves values from its environment.
 


### PR DESCRIPTION
Addresses #983.

8.2.13 contains a paragraph of three sentences, in which the first sentence talks about the set of all closure traits, the second sentence talks about the specific closure traits `send` and `sync`, and the third sentence uses the phrase "these traits". In the third sentence it is unclear if the referent of "these traits" is closure traits (first sentence), the specific closure traits described in the second sentence, or nothing at all (IE it could mean "these characteristics" in the informal English sense).

This patch clarifies the text so that it is totally clear the two traits in sentence two are a subset of closure traits and totally clear that "these traits" in sentence three refers to "closure traits". I didn't get any answers in #983 but that is my best reasonable guess what the text means. Obviously only merge this if this is actually the text's intent…!