### PR TITLE
Fix various grammatical errors around ?Sized

### DIFF
--- a/src/dynamically-sized-types.md
+++ b/src/dynamically-sized-types.md
@@ -11,7 +11,7 @@ types">DSTs</abbr>. Such types can only be used in certain cases:
     * Pointers to slices also store the number of elements of the slice.
     * Pointers to trait objects also store a pointer to a vtable.
 * <abbr title="dynamically sized types">DSTs</abbr> can be provided as
-  type arguments when the type parameter has the special lifetime bound [`?Sized`][sized] specified. (In other words by default any type parameter on a non-trait item
+  type arguments when the type parameter has the special lifetime bound [`?Sized`](trait-bounds.html#sized) specified. (In other words by default any type parameter on a non-trait item
   has a `Sized` bound, and specifying the `?Sized` bound removes it.)
 * Traits may be implemented for <abbr title="dynamically sized
   types">DSTs</abbr>. Unlike type parameters on other kinds of items, `Self: ?Sized` is the default in trait

--- a/src/dynamically-sized-types.md
+++ b/src/dynamically-sized-types.md
@@ -11,10 +11,10 @@ types">DSTs</abbr>. Such types can only be used in certain cases:
     * Pointers to slices also store the number of elements of the slice.
     * Pointers to trait objects also store a pointer to a vtable.
 * <abbr title="dynamically sized types">DSTs</abbr> can be provided as
-  type arguments when a bound of `?Sized`. By default any type parameter
-  has a `Sized` bound.
+  type arguments when the type parameter has the special lifetime bound [`?Sized`][sized] specified. (In other words by default any type parameter on a non-trait item
+  has a `Sized` bound, and specifying the `?Sized` bound removes it.)
 * Traits may be implemented for <abbr title="dynamically sized
-  types">DSTs</abbr>. Unlike type parameters `Self: ?Sized` by default in trait
+  types">DSTs</abbr>. Unlike type parameters on other kinds of items, `Self: ?Sized` is the default in trait
   definitions.
 * Structs may contain a <abbr title="dynamically sized type">DST</abbr> as the
   last field, this makes the struct itself a

--- a/src/trait-bounds.md
+++ b/src/trait-bounds.md
@@ -77,8 +77,8 @@ Trait and lifetime bounds are also used to name [trait objects].
 
 ## `?Sized`
 
-`?` is only used to declare that the [`Sized`] trait may not be
-implemented for a type parameter or associated type. `?Sized` may
+`?` is only used to declare that the [`Sized`] trait may be
+unimplemented for a type parameter or associated type. `?Sized` may
 not be used as a bound for other types.
 
 ## Lifetime bounds


### PR DESCRIPTION
* Section 10.2 contains two sentences which are not sentences (I.E., they do not contain verbs). Patch makes the sentences grammatical and less ambugious, also links on the phrase ?Sized to the doc for ?Sized.
* Section 10.6 contains the text '? is only used to declare that the Sized trait may not be implemented for a type parameter or associated type'. 'May not' makes it sound as if it is prohibited to implement the Sized trait, whereas in fact the text means that the type may at its option fail to implement the sized trait. Patch clarifies.

I am not completely certain about this text. I think my text is *better* (because the existing text is not valid English) but my text is definitely more ungainly. (I would love to find an excuse to remove the words "a non-trait item" in the first bullet point.) I also do not know for a fact that my replacement text is *correct*— it is my best guess from looking at the other documentation (in particular [Sized](https://doc.rust-lang.org/std/marker/trait.Sized.html) in the stdlib). I am new at Rust and have yet to learn traits.

[EDIT: Removed note about ?sized link]