### PR TITLE
Adjust the definition of `target_family`

### DIFF
--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -132,12 +132,15 @@ Example values:
 
 ### `target_family`
 
-Key-value option set at most once with the target's operating system value.
+Key-value option providing a more generic description of a target, such as the family of the
+operating systems or architectures that the target generally falls into. Any number of
+`target_family` key-value pairs can be set.
 
 Example values:
 
 * `"unix"`
 * `"windows"`
+* `"wasm"`
 
 ### `unix` and `windows`
 


### PR DESCRIPTION
This generalizes the `target_family` to allow it being specified more
than once and apply to other properties than just the operating system
family.

Of particular interest is an ability to match architectures that are a
part of a family of architecutes (e.g. various versions of ARM, WASM or
other targets)