### PR TITLE
Rearrange HRTB grammar.

### DIFF
--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -221,10 +221,7 @@ fn generic<const B: bool>() {
 > &nbsp;&nbsp; [_Lifetime_] `:` [_LifetimeBounds_]
 >
 > _TypeBoundWhereClauseItem_ :\
-> &nbsp;&nbsp; _ForLifetimes_<sup>?</sup> [_Type_] `:` [_TypeParamBounds_]<sup>?</sup>
->
-> _ForLifetimes_ :\
-> &nbsp;&nbsp; `for` [_GenericParams_](#generic-parameters)
+> &nbsp;&nbsp; [_ForLifetimes_]<sup>?</sup> [_Type_] `:` [_TypeParamBounds_]<sup>?</sup>
 
 *Where clauses* provide another way to specify bounds on type and lifetime
 parameters as well as a way to specify bounds on types that aren't type
@@ -277,6 +274,7 @@ struct Foo<#[my_flexible_clone(unbounded)] H> {
 [IDENTIFIER]: ../identifiers.md
 [LIFETIME_OR_LABEL]: ../tokens.md#lifetimes-and-loop-labels
 
+[_ForLifetimes_]: ../trait-bounds.md#higher-ranked-trait-bounds
 [_LifetimeParam_]: #generic-parameters
 [_LifetimeBounds_]: ../trait-bounds.md
 [_Lifetime_]: ../trait-bounds.md

--- a/src/trait-bounds.md
+++ b/src/trait-bounds.md
@@ -100,6 +100,9 @@ fn f<'a, 'b>(x: &'a i32, mut y: &'b i32) where 'a: 'b {
 
 ## Higher-ranked trait bounds
 
+> _ForLifetimes_ :\
+> &nbsp;&nbsp; `for` [_GenericParams_]
+
 Type bounds may be *higher ranked* over lifetimes. These bounds specify a bound
 is true *for all* lifetimes. For example, a bound such as `for<'a> &'a T:
 PartialEq<i32>` would require an implementation like
@@ -137,6 +140,7 @@ fn call_on_ref_zero<F>(f: F) where F: for<'a> Fn(&'a i32) {
 ```
 
 [LIFETIME_OR_LABEL]: tokens.md#lifetimes-and-loop-labels
+[_GenericParams_]: items/generics.md
 [_TypePath_]: paths.md#paths-in-types
 [`Sized`]: special-types-and-traits.md#sized
 

--- a/src/types/function-pointer.md
+++ b/src/types/function-pointer.md
@@ -54,7 +54,7 @@ restrictions as [regular function parameters].
 
 [IDENTIFIER]: ../identifiers.md
 [_Abi_]: ../items/functions.md
-[_ForLifetimes_]: ../items/generics.md#where-clauses
+[_ForLifetimes_]: ../trait-bounds.md#higher-ranked-trait-bounds
 [_TypeNoBounds_]: ../types.md#type-expressions
 [_Type_]: ../types.md#type-expressions
 [_OuterAttribute_]: ../attributes.md


### PR DESCRIPTION
_ForLifetimes_ are used in multiple places, so I don't think it makes sense to define them as part of _WhereClause_. Also, I often got confused hitting the "Higher-ranked trait bounds" section and not seeing the grammar there.