### PR TITLE
Explicitly state result of compound assignment

### DIFF
--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -470,6 +470,8 @@ fn example() {
 }
 ```
 
+Like assignment expressions, compound assignment expressions always produce [the unit value][unit].
+
 <div class="warning">
 
 Warning: The evaluation order of operands swaps depending on the types of the operands:


### PR DESCRIPTION
The existing text implies but doesn't explicitly say that
compound assignment produces the unit value. A reader could also
infer it from the signatures of the compound assignment trait
functions, but it seems better to be explicit.