### PR TITLE
Add more content to impl-trait.md

### DIFF
--- a/src/types/impl-trait.md
+++ b/src/types/impl-trait.md
@@ -24,8 +24,9 @@ fn bar() -> impl Trait {
 ## Anonymous type parameters
 
 > Note: This is often called "impl Trait in argument position".
+(The term "parameter" is more correct here, but "impl Trait in argument position" is the phrasing used during the development of this feature, and it remains in parts of the implementation.)
 
-Functions can use `impl` followed by a set of trait bounds to declare an argument as having an anonymous type.
+Functions can use `impl` followed by a set of trait bounds to declare a parameter as having an anonymous type.
 The caller must provide a type that satisfies the bounds declared by the anonymous type parameter, and the function can only use the methods available through the trait bounds of the anonymous type parameter.
 
 For example, these two forms are almost equivalent:
@@ -45,9 +46,9 @@ fn foo(arg: impl Trait) {
 That is, `impl Trait` in argument position is syntactic sugar for a generic type parameter like `<T: Trait>`, except that the type is anonymous and doesn't appear in the [_GenericParams_] list.
 
 > **Note:**
-> For function arguments, generic type parameters and `impl Trait` are not exactly equivalent.
+> For function parameters, generic type parameters and `impl Trait` are not exactly equivalent.
 > With a generic parameter such as `<T: Trait>`, the caller has the option to explicitly specify the generic argument for `T` at the call site using [_GenericArgs_], for example, `foo::<usize>(1)`.
-> If `impl Trait` is the type of *any* function argument, then the caller can't ever provide any generic arguments when calling that function.
+> If `impl Trait` is the type of *any* function parameter, then the caller can't ever provide any generic arguments when calling that function.
 This includes generic arguments for the return type or any const generics.
 >
 > Therefore, changing the function signature from either one to the other can constitute a breaking change for the callers of a function.
@@ -112,7 +113,7 @@ Instead, the function chooses the return type, but only promises that it will im
 
 ## Limitations
 
-`impl Trait` can only appear as the argument or return type of a free or inherent function.
+`impl Trait` can only appear as a parameter or return type of a free or inherent function.
 It cannot appear inside implementations of traits, nor can it be the type of a let binding or appear inside a type alias.
 
 [closures]: closure.md

--- a/src/types/impl-trait.md
+++ b/src/types/impl-trait.md
@@ -160,12 +160,10 @@ With `impl Trait`, the function asserts that the return type will implement this
 So with `impl Trait`, unlike with a generic type parameter for the return type, the caller can't choose the return type, and the function itself gets to choose.
 If we tried to define parse with `Result<impl F,...` as the return type, it wouldn't work.
 
-### Using `impl Trait` in more places
+## Limitations
 
-As previously mentioned, as a start, you will only be able to use `impl Trait` as the argument or return type of a free or inherent function.
-However, `impl Trait` can't be used inside implementations of traits, nor can it be used as the type of a let binding or inside a type alias.
-Some of these restrictions will eventually be lifted.
-For more information, see the [tracking issue on `impl Trait`](https://github.com/rust-lang/rust/issues/34511).
+`impl Trait` can only appear as the argument or return type of a free or inherent function.
+It cannot appear inside implementations of traits, nor can it be the type of a let binding or appear inside a type alias.
 
 [closures]: closure.md
 [_GenericArgs_]: ../paths.md#paths-in-expressions

--- a/src/types/impl-trait.md
+++ b/src/types/impl-trait.md
@@ -25,7 +25,7 @@ fn foo() -> impl Trait {
 > Note: This is often called "impl Trait in argument position".
 
 Functions can declare an argument to be an anonymous type parameter where the
-callee must provide a type that has the bounds declared by the anonymous type
+caller must provide a type that has the bounds declared by the anonymous type
 parameter and the function can only use the methods available by the trait
 bounds of the anonymous type parameter.
 

--- a/src/types/impl-trait.md
+++ b/src/types/impl-trait.md
@@ -5,8 +5,6 @@
 >
 > _ImplTraitTypeOneBound_ : `impl` [_TraitBound_]
 
-> **Edition differences**: `impl Trait` is new in the 2018 edition.
-
 `impl Trait` provides ways to specify unnamed but concrete types that
 implement a specific trait.
 It can appear in two sorts of places: argument position (where it can act as an anonymous type parameter to functions), and return position (where it can act as an abstract return type).
@@ -49,7 +47,8 @@ That is, `impl Trait` in argument position is syntactic sugar for a generic type
 > **Note:**
 > For function arguments, generic type parameters and `impl Trait` are not exactly equivalent.
 > With a generic parameter such as `<T: Trait>`, the caller has the option to explicitly specify the generic argument for `T` at the call site using [_GenericArgs_], for example, `foo::<usize>(1)`.
-> If `impl Trait` is the type of a function argument, then the caller can't ever specify the type of that argument by using a generic argument.
+> If `impl Trait` is the type of *any* function argument, then the caller can't ever provide any generic arguments when calling that function.
+This includes generic arguments for the return type or any const generics.
 >
 > Therefore, changing the function signature from either one to the other can constitute a breaking change for the callers of a function.
 

--- a/src/types/impl-trait.md
+++ b/src/types/impl-trait.md
@@ -5,10 +5,22 @@
 >
 > _ImplTraitTypeOneBound_ : `impl` [_TraitBound_]
 
-## Anonymous type parameters
+`impl Trait` is the new way to specify unnamed but concrete types that
+implement a specific trait.
+There are two places you can put it: argument position, and return position.
 
-> Note: This section is a placeholder for more comprehensive reference
-> material.
+```rust,ignore
+trait Trait {}
+
+// argument position
+fn foo(arg: impl Trait) {
+}
+
+// return position
+fn foo() -> impl Trait {
+}
+```
+## Anonymous type parameters
 
 > Note: This is often called "impl Trait in argument position".
 
@@ -18,11 +30,28 @@ parameter and the function can only use the methods available by the trait
 bounds of the anonymous type parameter.
 
 They are written as `impl` followed by a set of trait bounds.
+In argument position, this feature is quite simple.
+These two forms are almost the same:
+
+```rust,ignore
+trait Trait {}
+
+fn foo<T: Trait>(arg: T) {
+}
+
+fn foo(arg: impl Trait) {
+}
+```
+
+That is, it's a slightly shorter syntax for a generic type parameter.
+It means, "`arg` is an argument that takes any type that implements the `Trait` trait."
+
+However, there's also an important technical difference between `T: Trait` and `impl Trait` here.
+When you write the former, you can specify the type of `T` at the call site with turbo-fish syntax as with `foo::<usize>(1)`.
+In the case of `impl Trait`, if it is used anywhere in the function definition, then you can't use turbo-fish at all.
+Therefore, you should be mindful that changing both from and to `impl Trait` can constitute a breaking change for the users of your code.
 
 ## Abstract return types
-
-> Note: This section is a placeholder for more comprehensive reference
-> material.
 
 > Note: This is often called "impl Trait in return position".
 
@@ -32,6 +61,117 @@ use-site may only use the trait methods declared by the trait bounds of the
 type.
 
 They are written as `impl` followed by a set of trait bounds.
+
+Before `impl Trait`, you could do this with trait objects:
+
+```rust
+trait Trait {}
+
+impl Trait for i32 {}
+
+fn returns_a_trait_object() -> Box<dyn Trait> {
+    Box::new(5)
+}
+```
+
+However, this has some overhead: the `Box<T>` means that there's a heap allocation here, and this will use dynamic dispatch.
+See the `dyn Trait` section for an explanation of this syntax.
+But we only ever return one possible thing here, the `Box<i32>`.
+This means that we're paying for dynamic dispatch, even though we don't use it!
+
+With `impl Trait`, the code above could be written like this:
+
+```rust
+trait Trait {}
+
+impl Trait for i32 {}
+
+fn returns_a_trait_object() -> impl Trait {
+    5
+}
+```
+
+Here, we have no `Box<T>`, no trait object, and no dynamic dispatch.
+But we still can obscure the `i32` return type.
+
+With `i32`, this isn't super useful.
+But there's one major place in Rust where this is much more useful: closures.
+
+### `impl Trait` and closures
+
+> If you need to catch up on closures, check out [their chapter in the
+> book](https://doc.rust-lang.org/book/second-edition/ch13-01-closures.html).
+
+In Rust, closures have a unique, un-writable type.
+They do implement the `Fn` family of traits, however.
+This means that previously, the only way to return a closure from a function was to use a trait object:
+
+```rust
+fn returns_closure() -> Box<dyn Fn(i32) -> i32> {
+    Box::new(|x| x + 1)
+}
+```
+
+You couldn't write the type of the closure, only use the `Fn` trait.
+That means that the trait object is necessary. However, with `impl Trait`:
+
+```rust
+fn returns_closure() -> impl Fn(i32) -> i32 {
+    |x| x + 1
+}
+```
+
+We can now return closures by value, just like any other type!
+
+## More details
+
+The above is all you need to know to get going with `impl Trait`, but for some more nitty-gritty details: type parameters and `impl Trait` work slightly differently when they're in argument position versus return position.
+Consider this function:
+
+```rust,ignore
+fn foo<T: Trait>(x: T) {
+```
+
+When you call it, you set the type, `T`.
+"you" being the caller here.
+This signature says "I accept any type that implements `Trait`."
+("any type" == universal in the jargon)
+
+This version:
+
+```rust,ignore
+fn foo<T: Trait>() -> T {
+```
+
+is similar, but also different.
+You, the caller, provide the type you want, `T`, and then the function returns it.
+You can see this in Rust today with things like parse or collect:
+
+```rust,ignore
+let x: i32 = "5".parse()?;
+let x: u64 = "5".parse()?;
+```
+
+Here, `.parse` has this signature:
+
+```rust,ignore
+pub fn parse<F>(&self) -> Result<F, <F as FromStr>::Err> where
+    F: FromStr,
+```
+
+Same general idea, though with a result type and `FromStr` has an associated type... anyway, you can see how `F` is in the return position here.
+So you have the ability to choose.
+
+With `impl Trait`, you're saying "hey, some type exists that implements this trait, but I'm not gonna tell you what it is."
+So now, the caller can't choose, and the function itself gets to choose.
+If we tried to define parse with `Result<impl F,...` as the return type, it wouldn't work.
+
+### Using `impl Trait` in more places
+
+As previously mentioned, as a start, you will only be able to use `impl Trait` as the argument or return type of a free or inherent function.
+However, `impl Trait` can't be used inside implementations of traits, nor can it be used as the type of a let binding or inside a type alias.
+Some of these restrictions will eventually be lifted.
+For more information, see the [tracking issue on `impl Trait`](https://github.com/rust-lang/rust/issues/34511).
 
 [_TraitBound_]: ../trait-bounds.md
 [_TypeParamBounds_]: ../trait-bounds.md

--- a/src/types/impl-trait.md
+++ b/src/types/impl-trait.md
@@ -119,46 +119,28 @@ fn returns_closure() -> impl Fn(i32) -> i32 {
 
 It is now possible to return closures by value, just like any other type.
 
-## More details
+### Differences between generics and `impl Trait` in return position
 
-The above is all you need to know to get going with `impl Trait`, but for some more nitty-gritty details: type parameters and `impl Trait` work slightly differently when they're in argument position versus return position.
-Consider this function:
+In argument position, `impl Trait` is very similar in semantics to a generic type parameter.
+However, there are significant differences between the two in return position.
+With `impl Trait`, unlike with a generic type parameter, the function chooses the return type, and the caller cannot choose the return type.
 
-```rust,ignore
-fn foo<T: Trait>(x: T) {
-```
-
-The caller of this function determines the type, `T`.
-This function signature means that the function accepts any type that implements `Trait`."
-
-This version:
+The function:
 
 ```rust,ignore
 fn foo<T: Trait>() -> T {
 ```
 
-is similar, but also different.
-The caller determines the return type, `T`, and the function returns it.
-Examples of this include the `.parse()` or `.collect()` methods:
+allows the caller to determine the return type, `T`, and the function returns that type.
+
+The function:
 
 ```rust,ignore
-let x: i32 = "5".parse()?;
-let x: u64 = "5".parse()?;
+fn foo() -> impl Trait {
 ```
 
-Here, `.parse()` has this signature:
-
-```rust,ignore
-pub fn parse<F>(&self) -> Result<F, <F as FromStr>::Err> where
-    F: FromStr,
-```
-
-Same general idea, though with a result type and `FromStr` has an associated type... anyway, you can see how `F` is in the return position here.
-So you have the ability to choose.
-
-With `impl Trait`, the function asserts that the return type will implement this trait, but the caller can't know exactly which type.
-So with `impl Trait`, unlike with a generic type parameter for the return type, the caller can't choose the return type, and the function itself gets to choose.
-If we tried to define parse with `Result<impl F,...` as the return type, it wouldn't work.
+doesn't allow the caller to determine the return type.
+Instead, the function chooses the return type, but only promises that it will implement `Trait`.
 
 ## Limitations
 


### PR DESCRIPTION
Much of this comes from the edition-guide. Some information comes from the RFCs about the `impl Trait` feature. (rust-lang/rfcs#1522, rust-lang/rfcs#1951, and rust-lang/rfcs#2250)

Some finer points from the RFCs might need to be added, but maybe a new issue should be opened to enumerate and track those? I guess the biggest one would be checking that the syntax changes of rust-lang/rfcs#2250 are adequately documented in the reference. Lifetime defaults, especially for `impl Trait` in return position, should probably also be checked.

CC #276.