### PR TITLE
Fix type_length_limit example.

### DIFF
--- a/src/attributes/limits.md
+++ b/src/attributes/limits.md
@@ -42,19 +42,14 @@ to set the limit based on the number of type substitutions.
 
 > Note: The default in `rustc` is 1048576.
 
-<!-- This code should fail to compile. Unfortunately rustdoc's `compile_fail`
-     stops after analysis phase, and this error is generated after that. So
-     this needs to be `ignore` for now. -->
-
-```rust,compile_fail,ignore
-#![type_length_limit = "8"]
+```rust,compile_fail
+#![type_length_limit = "4"]
 
 fn f<T>(x: T) {}
 
 // This fails to compile because monomorphizing to
-// `f::<(i32, i32, i32, i32, i32, i32, i32, i32, i32)>>` requires more
-// than 8 type elements.
-f((1, 2, 3, 4, 5, 6, 7, 8, 9));
+// `f::<((((i32,), i32), i32), i32)>` requires more than 4 type elements.
+f(((((1,), 2), 3), 4));
 ```
 
 [_MetaNameValueStr_]: ../attributes.md#meta-item-attribute-syntax


### PR DESCRIPTION
The existing example for the `type_length_limit` attribute wasn't failing as expected.  Somewhere between 2020-09-18 and 2020-09-19 the old example stopped failing (maybe https://github.com/rust-lang/rust/pull/72412 or https://github.com/rust-lang/rust/pull/76575, I can't tell).

I adjusted the example to require some recursion which now triggers the error. This is more similar to the [existing test](https://github.com/rust-lang/rust/blob/fe72845f7bb6a77b9e671e6a4f32fe714962cec4/src/test/ui/type_length_limit.rs).

Additionally, since https://github.com/rust-lang/rust/pull/68664, `ignore` can be removed and it should check the example now.
