### PR TITLE
example for bindings after at

### DIFF
--- a/src/patterns.md
+++ b/src/patterns.md
@@ -384,7 +384,7 @@ match slice {
     // `end` is a slice of everything but the first element, which must be "a".
     ["a", end @ ..] => println!("ends with: {:?}", end),
 
-    // 'whole' is the entire slice and `last` the the final element
+    // 'whole' is the entire slice and `last` is the final element
     whole @ [.., last] => println!("the last element of {:?} is {}", whole, last)
 
     rest => println!("{:?}", rest),

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -384,6 +384,9 @@ match slice {
     // `end` is a slice of everything but the first element, which must be "a".
     ["a", end @ ..] => println!("ends with: {:?}", end),
 
+    // 'whole' is the entire slice and `last` the the final element
+    whole @ [.., last] => println!("the last element of {:?} is {}", whole, last)
+
     rest => println!("{:?}", rest),
 }
 

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -385,7 +385,7 @@ match slice {
     ["a", end @ ..] => println!("ends with: {:?}", end),
 
     // 'whole' is the entire slice and `last` is the final element
-    whole @ [.., last] => println!("the last element of {:?} is {}", whole, last)
+    whole @ [.., last] => println!("the last element of {:?} is {}", whole, last),
 
     rest => println!("{:?}", rest),
 }


### PR DESCRIPTION
This adds a example of binding a varible after an `@`. `bindings_after_at` is currently unstable, but if [85305](https://github.com/rust-lang/rust/pull/85305) is merged, it may merit an example (so dont merge this untill then :sweat_smile:). I think one could argue the feature is obscure enough that the example may be more noise than useful. I'll leave that call up to those with more expirence than myself. 