### PR TITLE
Be more precise about array offset in type layouts

### DIFF
--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -70,9 +70,9 @@ at least equal to the size and alignment of a pointer.
 
 ## Array Layout
 
-Arrays are laid out so that the `nth` element of the array is offset from the
-start of the array by `n * the size of the type` bytes. An array of `[T; n]`
-has a size of `size_of::<T>() * n` and the same alignment of `T`.
+An array of `[T; N]` has a size of `size_of::<T>() * N` and the same alignment
+of `T`. Arrays are laid out so that the zero-based `nth` element of the array
+is offset from the start of the array by `n * size_of::<T>()` bytes.
 
 ## Slice Layout
 


### PR DESCRIPTION
Currently it states that the nth element has an offset of n*(size of type). I think this is assuming that people are starting at 0, but that's not really what `nth` implies. The first element has an offset of 0, but currently it implies that `n=1`, giving it a non-zero offset.

This might want a larger rewording, but I added the zero-case explicitly to try and be clearer.