### PR TITLE
Default all examples to 2018 edition.

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -9,3 +9,6 @@ git-repository-url = "https://github.com/rust-lang/reference/"
 
 [output.html.redirect]
 "/expressions/enum-variant-expr.html" = "struct-expr.html"
+
+[rust]
+edition = "2018"

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -109,7 +109,7 @@ Similarly, if `<expr>?` propagates an error, that error is propagated as the res
 Finally, the `break` and `continue` keywords cannot be used to branch out from an async block.
 Therefore the following is illegal:
 
-```rust,edition2018,compile_fail
+```rust,compile_fail
 loop {
     async move {
         break; // This would break out of the loop.

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -109,6 +109,8 @@ These conventions are documented here.
   }
   ```
 
+  All examples are written for the latest edition unless otherwise stated.
+
 * The grammar and lexical structure is in blockquotes with either "Lexer" or "Syntax" in <sup>**bold superscript**</sup> as the first line.
 
   > **<sup>Syntax</sup>**\

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -227,7 +227,7 @@ use the [`extern` function qualifier](#extern-function-qualifier).
 Functions may be qualified as async, and this can also be combined with the
 `unsafe` qualifier:
 
-```rust,edition2018
+```rust
 async fn regular_example() { }
 async unsafe fn unsafe_example() { }
 ```
@@ -240,7 +240,7 @@ An async function is roughly equivalent to a function
 that returns [`impl Future`] and with an [`async move` block][async-blocks] as
 its body:
 
-```rust,edition2018
+```rust
 // Source
 async fn example(x: &str) -> usize {
     x.len()
@@ -249,7 +249,7 @@ async fn example(x: &str) -> usize {
 
 is roughly equivalent to:
 
-```rust,edition2018
+```rust
 # use std::future::Future;
 // Desugared
 fn example<'a>(x: &'a str) -> impl Future<Output = usize> + 'a {
@@ -285,7 +285,7 @@ resulting function is unsafe to call and (like any async function)
 returns a future. This future is just an ordinary future and thus an
 `unsafe` context is not required to "await" it:
 
-```rust,edition2018
+```rust
 // Returns a future that, when awaited, dereferences `x`.
 //
 // Soundness condition: `x` must be safe to dereference until

--- a/src/items/traits.md
+++ b/src/items/traits.md
@@ -251,7 +251,8 @@ allowed, but it is deprecated and will become a hard error in the future.
 In the 2015 edition, the pattern for a trait function or method parameter is
 optional:
 
-```rust
+```rust,edition2015
+// 2015 Edition
 trait T {
     fn f(i32);  // Parameter identifiers are not required.
 }
@@ -269,7 +270,7 @@ Beginning in the 2018 edition, function or method parameter patterns are no
 longer optional. Also, all irrefutable patterns are allowed as long as there
 is a body. Without a body, the limitations listed above are still in effect.
 
-```rust,edition2018
+```rust
 trait T {
     fn f1((a, b): (i32, i32)) {}
     fn f2(_: (i32, i32));  // Cannot use tuple pattern without a body.

--- a/src/items/type-aliases.md
+++ b/src/items/type-aliases.md
@@ -20,7 +20,7 @@ let p: Point = (41, 68);
 
 A type alias to a tuple-struct or unit-struct cannot be used to qualify that type's constructor:
 
-```rust,edition2018,compile_fail
+```rust,compile_fail
 struct MyStruct(u32);
 
 use MyStruct as UseAlias;

--- a/src/items/use-declarations.md
+++ b/src/items/use-declarations.md
@@ -144,7 +144,7 @@ fn main() {}
 > unambiguously select the crate name. This is to retain compatibility with
 > potential future changes. <!-- uniform_paths future-proofing -->
 >
-> ```rust,edition2018
+> ```rust
 > // use std::fs; // Error, this is ambiguous.
 > use ::std::fs;  // Imports from the `std` crate, not the module below.
 > use self::std::fs as self_fs;  // Imports the module below.

--- a/src/paths.md
+++ b/src/paths.md
@@ -172,6 +172,16 @@ the path must resolve to an item.
 > crates in the [extern prelude]. That is, they must be followed by the name of a crate.
 
 ```rust
+pub fn foo() {
+    // In the 2018 edition, this accesses `std` via the extern prelude.
+    // In the 2015 edition, this accesses `std` via the crate root.
+    let now = ::std::time::Instant::now();
+    println!("{:?}", now);
+}
+```
+
+```rust,edition2015
+// 2015 Edition
 mod a {
     pub fn foo() {}
 }
@@ -353,11 +363,11 @@ mod without { // ::without
             fn g(&self) {} // None
         }
 
-        impl OtherTrait for ::a::Struct {
+        impl OtherTrait for crate::a::Struct {
             fn g(&self) {} // None
         }
 
-        impl ::a::Trait for OtherStruct {
+        impl crate::a::Trait for OtherStruct {
             fn f(&self) {} // None
         }
     }

--- a/src/trait-bounds.md
+++ b/src/trait-bounds.md
@@ -47,7 +47,7 @@ trait is implemented for a type. For example, given `Ty: Trait`
 ```rust
 # type Surface = i32;
 trait Shape {
-    fn draw(&self, Surface);
+    fn draw(&self, surface: Surface);
     fn name() -> &'static str;
 }
 

--- a/src/visibility-and-privacy.md
+++ b/src/visibility-and-privacy.md
@@ -110,7 +110,7 @@ pub fn public_api() {}
 // Similarly to 'public_api', this module is public so external crates may look
 // inside of it.
 pub mod submodule {
-    use crate_helper_module;
+    use crate::crate_helper_module;
 
     pub fn my_method() {
         // Any item in the local crate may invoke the helper module's public
@@ -161,7 +161,7 @@ to `pub(in self)` or not using `pub` at all.
 
 Here's an example:
 
-```rust
+```rust,edition2015
 pub mod outer_mod {
     pub mod inner_mod {
         // This function is visible within `outer_mod`


### PR DESCRIPTION
I would like to move the reference towards describing the latest edition first and foremost.  This is a small step to switch all the examples to default 2018 unless otherwise noted.

Closes #1039
cc #281
