### PR TITLE
Make explicit reference to scrutinee expression in grammar snippet

### DIFF
--- a/src/expressions/if-expr.md
+++ b/src/expressions/if-expr.md
@@ -41,12 +41,15 @@ assert_eq!(y, "Bigger");
 
 > **<sup>Syntax</sup>**\
 > _IfLetExpression_ :\
-> &nbsp;&nbsp; `if` `let` [_Pattern_] `=` [_Expression_]<sub>_except struct or lazy boolean operator expression_</sub>
+> &nbsp;&nbsp; `if` `let` [_Pattern_] `=` Scrutinee
 >              [_BlockExpression_]\
 > &nbsp;&nbsp; (`else` (
 >   [_BlockExpression_]
 > | _IfExpression_
 > | _IfLetExpression_ ) )<sup>\?</sup>
+>
+> _Scrutinee_:
+> &nbsp;&nbsp; [_Expression_]<sub>_except struct or lazy boolean operator expression_</sub>
 
 An `if let` expression is semantically similar to an `if` expression but in place of a condition operand it expects the keyword `let` followed by a pattern, an `=` and a [scrutinee] operand.
 If the value of the scrutinee matches the pattern, the corresponding block will execute.

--- a/src/expressions/if-expr.md
+++ b/src/expressions/if-expr.md
@@ -41,15 +41,12 @@ assert_eq!(y, "Bigger");
 
 > **<sup>Syntax</sup>**\
 > _IfLetExpression_ :\
-> &nbsp;&nbsp; `if` `let` [_Pattern_] `=` _Scrutinee_
+> &nbsp;&nbsp; `if` `let` [_Pattern_] `=` [_Scrutinee_]<sub>_except lazy boolean operator expression_</sub>
 >              [_BlockExpression_]\
 > &nbsp;&nbsp; (`else` (
 >   [_BlockExpression_]
 > | _IfExpression_
 > | _IfLetExpression_ ) )<sup>\?</sup>
->
-> _Scrutinee_:\
-> &nbsp;&nbsp; [_Expression_]<sub>_except struct or lazy boolean operator expression_</sub>
 
 An `if let` expression is semantically similar to an `if` expression but in place of a condition operand it expects the keyword `let` followed by a pattern, an `=` and a [scrutinee] operand.
 If the value of the scrutinee matches the pattern, the corresponding block will execute.
@@ -151,6 +148,7 @@ if let PAT = ( EXPR || EXPR ) { .. }
 [_Expression_]: ../expressions.md
 [_LazyBooleanOperatorExpression_]: operator-expr.md#lazy-boolean-operators
 [_Pattern_]: ../patterns.md
+[_Scrutinee_]: match-expr.md
 [_eRFCIfLetChain_]: https://github.com/rust-lang/rfcs/blob/master/text/2497-if-let-chains.md#rollout-plan-and-transitioning-to-rust-2018
 [`match` expression]: match-expr.md
 [boolean type]: ../types/boolean.md

--- a/src/expressions/if-expr.md
+++ b/src/expressions/if-expr.md
@@ -41,14 +41,14 @@ assert_eq!(y, "Bigger");
 
 > **<sup>Syntax</sup>**\
 > _IfLetExpression_ :\
-> &nbsp;&nbsp; `if` `let` [_Pattern_] `=` Scrutinee
+> &nbsp;&nbsp; `if` `let` [_Pattern_] `=` _Scrutinee_
 >              [_BlockExpression_]\
 > &nbsp;&nbsp; (`else` (
 >   [_BlockExpression_]
 > | _IfExpression_
 > | _IfLetExpression_ ) )<sup>\?</sup>
 >
-> _Scrutinee_:
+> _Scrutinee_:\
 > &nbsp;&nbsp; [_Expression_]<sub>_except struct or lazy boolean operator expression_</sub>
 
 An `if let` expression is semantically similar to an `if` expression but in place of a condition operand it expects the keyword `let` followed by a pattern, an `=` and a [scrutinee] operand.

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -62,11 +62,8 @@ while i < 10 {
 
 > **<sup>Syntax</sup>**\
 > [_PredicatePatternLoopExpression_] :\
-> &nbsp;&nbsp; `while` `let` [_Pattern_] `=` _Scrutinee_
+> &nbsp;&nbsp; `while` `let` [_Pattern_] `=` [_Scrutinee_]<sub>_except lazy boolean operator expression_</sub>
 >              [_BlockExpression_]
->
-> _Scrutinee_:\
-> &nbsp;&nbsp; [_Expression_]<sub>_except struct or lazy boolean operator expression_</sub>
 
 
 A `while let` loop is semantically similar to a `while` loop but in place of a condition expression it expects the keyword `let` followed by a pattern, an `=`, a [scrutinee] expression and a block expression.
@@ -268,6 +265,7 @@ In the case a `loop` has an associated `break`, it is not considered diverging, 
 [_BlockExpression_]: block-expr.md
 [_Expression_]: ../expressions.md
 [_Pattern_]: ../patterns.md
+[_Scrutinee_]: match-expr.md
 [`match` expression]: match-expr.md
 [boolean]: ../types/boolean.md
 [scrutinee]: ../glossary.md#scrutinee

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -62,8 +62,12 @@ while i < 10 {
 
 > **<sup>Syntax</sup>**\
 > [_PredicatePatternLoopExpression_] :\
-> &nbsp;&nbsp; `while` `let` [_Pattern_] `=` [_Expression_]<sub>_except struct or lazy boolean operator expression_</sub>
+> &nbsp;&nbsp; `while` `let` [_Pattern_] `=` Scrutinee
 >              [_BlockExpression_]
+>
+> _Scrutinee_:
+> &nbsp;&nbsp; [_Expression_]<sub>_except struct or lazy boolean operator expression_</sub>
+
 
 A `while let` loop is semantically similar to a `while` loop but in place of a condition expression it expects the keyword `let` followed by a pattern, an `=`, a [scrutinee] expression and a block expression.
 If the value of the scrutinee matches the pattern, the loop body block executes then control returns to the pattern matching statement.

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -62,10 +62,10 @@ while i < 10 {
 
 > **<sup>Syntax</sup>**\
 > [_PredicatePatternLoopExpression_] :\
-> &nbsp;&nbsp; `while` `let` [_Pattern_] `=` Scrutinee
+> &nbsp;&nbsp; `while` `let` [_Pattern_] `=` _Scrutinee_
 >              [_BlockExpression_]
 >
-> _Scrutinee_:
+> _Scrutinee_:\
 > &nbsp;&nbsp; [_Expression_]<sub>_except struct or lazy boolean operator expression_</sub>
 
 

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -2,7 +2,7 @@
 
 > **<sup>Syntax</sup>**\
 > _MatchExpression_ :\
-> &nbsp;&nbsp; `match` Scrutinee `{`\
+> &nbsp;&nbsp; `match` _Scrutinee_ `{`\
 > &nbsp;&nbsp; &nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>\
 > &nbsp;&nbsp; &nbsp;&nbsp; _MatchArms_<sup>?</sup>\
 > &nbsp;&nbsp; `}`

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -2,10 +2,13 @@
 
 > **<sup>Syntax</sup>**\
 > _MatchExpression_ :\
-> &nbsp;&nbsp; `match` [_Expression_]<sub>_except struct expression_</sub> `{`\
+> &nbsp;&nbsp; `match` Scrutinee `{`\
 > &nbsp;&nbsp; &nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>\
 > &nbsp;&nbsp; &nbsp;&nbsp; _MatchArms_<sup>?</sup>\
 > &nbsp;&nbsp; `}`
+>
+>_Scrutinee_ :\
+> &nbsp;&nbsp; [_Expression_]<sub>_except struct expression_</sub>
 >
 > _MatchArms_ :\
 > &nbsp;&nbsp; ( _MatchArm_ `=>`


### PR DESCRIPTION
Adding an explicit mention of the scrutinee in the grammar snippet makes the usage of the term in the description clearer, at @zancas's suggestion. 