### PR TITLE
Make statement about variable visibility more precise

### DIFF
--- a/src/statements.md
+++ b/src/statements.md
@@ -62,7 +62,8 @@ annotation and then optionally by an initializer expression. When no
 type annotation is given, the compiler will infer the type, or signal
 an error if insufficient type information is available for definite
 inference. Any variables introduced by a variable declaration are visible
-from the point of declaration until the end of the enclosing block scope.
+from the point of declaration until the end of the enclosing block scope,
+except when they are shadowed by another variable declaration.
 
 ## Expression statements
 


### PR DESCRIPTION
A variable is not visible in its entire scope; only where it is not shadowed by a different variable declaration with the same name.