### PR TITLE
Mention that MAX / -1 and MAX % -1 always panic

### DIFF
--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -24,7 +24,7 @@ The following things are considered to be overflow:
 
 * When `+`, `*` or `-` create a value greater than the maximum value, or less than the minimum value that can be stored.
   This includes unary `-` on the smallest value of any signed integer type.
-* Using `/` or `%`, where the left-hand argument is the smallest integer of a signed integer type and the right-hand argument is `-1`.
+* Using `/` or `%`, where the left-hand argument is the smallest integer of a signed integer type and the right-hand argument is `-1`. These checks occur even when `-C overflow-checks` is disabled, for legacy reasons.
 * Using `<<` or `>>` where the right-hand argument is greater than or equal to the number of bits in the type of the left-hand argument, or is negative.
 
 ## Borrow operators

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -24,7 +24,8 @@ The following things are considered to be overflow:
 
 * When `+`, `*` or `-` create a value greater than the maximum value, or less than the minimum value that can be stored.
   This includes unary `-` on the smallest value of any signed integer type.
-* Using `/` or `%`, where the left-hand argument is the smallest integer of a signed integer type and the right-hand argument is `-1`. These checks occur even when `-C overflow-checks` is disabled, for legacy reasons.
+* Using `/` or `%`, where the left-hand argument is the smallest integer of a signed integer type and the right-hand argument is `-1`.
+  These checks occur even when `-C overflow-checks` is disabled, for legacy reasons.
 * Using `<<` or `>>` where the right-hand argument is greater than or equal to the number of bits in the type of the left-hand argument, or is negative.
 
 ## Borrow operators


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/86099#issuecomment-862857244 for some more context. These operations always panic, even when overflow checks are disabled.