### PR TITLE
Remove inner attributes from non-block expressions.

### DIFF
--- a/src/expressions/array-expr.md
+++ b/src/expressions/array-expr.md
@@ -4,7 +4,7 @@
 
 > **<sup>Syntax</sup>**\
 > _ArrayExpression_ :\
-> &nbsp;&nbsp; `[` [_InnerAttribute_]<sup>\*</sup> _ArrayElements_<sup>?</sup> `]`
+> &nbsp;&nbsp; `[` _ArrayElements_<sup>?</sup> `]`
 >
 > _ArrayElements_ :\
 > &nbsp;&nbsp; &nbsp;&nbsp; [_Expression_] ( `,` [_Expression_] )<sup>\*</sup> `,`<sup>?</sup>\
@@ -46,10 +46,6 @@ const EMPTY: Vec<i32> = Vec::new();
 [EMPTY; 2];
 ```
 
-### Array expression attributes
-
-[Inner attributes] are allowed directly after the opening bracket of an array expression in the same expression contexts as [attributes on block expressions].
-
 ## Array and slice indexing expressions
 
 > **<sup>Syntax</sup>**\
@@ -89,11 +85,8 @@ The array index expression can be implemented for types other than arrays and sl
 [`Copy`]: ../special-types-and-traits.md#copy
 [IndexMut]: ../../std/ops/trait.IndexMut.html
 [Index]: ../../std/ops/trait.Index.html
-[Inner attributes]: ../attributes.md
 [_Expression_]: ../expressions.md
-[_InnerAttribute_]: ../attributes.md
 [array]: ../types/array.md
-[attributes on block expressions]: block-expr.md#attributes-on-block-expressions
 [constant expression]: ../const_eval.md#constant-expressions
 [constant item]: ../items/constant-items.md
 [literal]: ../tokens.md#literals

--- a/src/expressions/grouped-expr.md
+++ b/src/expressions/grouped-expr.md
@@ -2,7 +2,7 @@
 
 > **<sup>Syntax</sup>**\
 > _GroupedExpression_ :\
-> &nbsp;&nbsp; `(` [_InnerAttribute_]<sup>\*</sup> [_Expression_] `)`
+> &nbsp;&nbsp; `(` [_Expression_] `)`
 
 A *parenthesized expression* wraps a single expression, evaluating to that expression.
 The syntax for a parenthesized expression is a `(`, then an expression, called the *enclosed operand*, and then a `)`.
@@ -39,12 +39,5 @@ assert_eq!( a.f (), "The method f");
 assert_eq!((a.f)(), "The field f");
 ```
 
-## Group expression attributes
-
-[Inner attributes] are allowed directly after the opening parenthesis of a group expression in the same expression contexts as [attributes on block expressions].
-
-[Inner attributes]: ../attributes.md
 [_Expression_]: ../expressions.md
-[_InnerAttribute_]: ../attributes.md
-[attributes on block expressions]: block-expr.md#attributes-on-block-expressions
 [place]: ../expressions.md#place-expressions-and-value-expressions

--- a/src/expressions/struct-expr.md
+++ b/src/expressions/struct-expr.md
@@ -7,7 +7,7 @@
 > &nbsp;&nbsp; | _StructExprUnit_
 >
 > _StructExprStruct_ :\
-> &nbsp;&nbsp; [_PathInExpression_] `{` [_InnerAttribute_]<sup>\*</sup> (_StructExprFields_ | _StructBase_)<sup>?</sup> `}`
+> &nbsp;&nbsp; [_PathInExpression_] `{` (_StructExprFields_ | _StructBase_)<sup>?</sup> `}`
 >
 > _StructExprFields_ :\
 > &nbsp;&nbsp; _StructExprField_ (`,` _StructExprField_)<sup>\*</sup> (`,` _StructBase_ | `,`<sup>?</sup>)
@@ -21,7 +21,6 @@
 >
 > _StructExprTuple_ :\
 > &nbsp;&nbsp; [_PathInExpression_] `(`\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>\
 > &nbsp;&nbsp; &nbsp;&nbsp; ( [_Expression_] (`,` [_Expression_])<sup>\*</sup> `,`<sup>?</sup> )<sup>?</sup>\
 > &nbsp;&nbsp; `)`
 >
@@ -122,17 +121,10 @@ let a = Gamma;  // Gamma unit value.
 let b = Gamma{};  // Exact same value as `a`.
 ```
 
-## Struct expression attributes
-
-[Inner attributes] are allowed directly after the opening brace or parenthesis of a struct expression in the same expression contexts as [attributes on block expressions].
-
 [IDENTIFIER]: ../identifiers.md
-[Inner attributes]: ../attributes.md
 [TUPLE_INDEX]: ../tokens.md#tuple-index
 [_Expression_]: ../expressions.md
-[_InnerAttribute_]: ../attributes.md
 [_PathInExpression_]: ../paths.md#paths-in-expressions
-[attributes on block expressions]: block-expr.md#attributes-on-block-expressions
 [call expression]: call-expr.md
 [enum variant]: ../items/enumerations.md
 [if let]: if-expr.md#if-let-expressions

--- a/src/expressions/tuple-expr.md
+++ b/src/expressions/tuple-expr.md
@@ -4,7 +4,7 @@
 
 > **<sup>Syntax</sup>**\
 > _TupleExpression_ :\
-> &nbsp;&nbsp; `(` [_InnerAttribute_]<sup>\*</sup> _TupleElements_<sup>?</sup> `)`
+> &nbsp;&nbsp; `(` _TupleElements_<sup>?</sup> `)`
 >
 > _TupleElements_ :\
 > &nbsp;&nbsp; ( [_Expression_] `,` )<sup>+</sup> [_Expression_]<sup>?</sup>
@@ -28,10 +28,6 @@ Examples of tuple expressions and their types:
 | `(0.0, 4.5)`         | `(f64, f64)` |
 | `("x".to_string(), )` | `(String, )`  |
 | `("a", 4usize, true)`| `(&'static str, usize, bool)` |
-
-### Tuple expression attributes
-
-[Inner attributes] are allowed directly after the opening parenthesis of a tuple expression in the same expression contexts as [attributes on block expressions].
 
 ## Tuple indexing expressions
 
@@ -70,13 +66,10 @@ assert_eq!(point.1, 0.0);
 > **Note**: Although arrays and slices also have elements, you must use an [array or slice indexing expression] or a [slice pattern] to access their elements.
 
 [_Expression_]: ../expressions.md
-[_InnerAttribute_]: ../attributes.md
 [array or slice indexing expression]: array-expr.md#array-and-slice-indexing-expressions
-[attributes on block expressions]: block-expr.md#attributes-on-block-expressions
 [call expression]: ./call-expr.md
 [decimal literal]: ../tokens.md#integer-literals
 [field access expressions]: ./field-expr.html#field-access-expressions
-[inner attributes]: ../attributes.md
 [operands]: ../expressions.md
 [parenthetical expression]: grouped-expr.md
 [place expression]: ../expressions.md#place-expressions-and-value-expressions


### PR DESCRIPTION
Inner attributes were removed in https://github.com/rust-lang/rust/pull/83312, with https://github.com/rust-lang/rust/pull/85193 re-adding support in match expressions.

Closes #1021
