### PR TITLE
mention implicit `Sized` bound in more places

### DIFF
--- a/src/dynamically-sized-types.md
+++ b/src/dynamically-sized-types.md
@@ -11,11 +11,12 @@ types">DSTs</abbr>. Such types can only be used in certain cases:
     * Pointers to slices also store the number of elements of the slice.
     * Pointers to trait objects also store a pointer to a vtable.
 * <abbr title="dynamically sized types">DSTs</abbr> can be provided as
-  type arguments when a bound of `?Sized`. By default any type parameter
-  has a `Sized` bound.
+  type arguments to generic type parameters having the special `?Sized` bound.
+  They can also be used for associated type definitions when the corresponding associated type declaration has a `?Sized` bound.
+  By default, any type parameter or associated type has a `Sized` bound, unless it is relaxed using `?Sized`.
 * Traits may be implemented for <abbr title="dynamically sized
-  types">DSTs</abbr>. Unlike type parameters `Self: ?Sized` by default in trait
-  definitions.
+  types">DSTs</abbr>.
+  Unlike with generic type parameters, `Self: ?Sized` is the default in trait definitions.
 * Structs may contain a <abbr title="dynamically sized type">DST</abbr> as the
   last field, this makes the struct itself a
   <abbr title="dynamically sized type">DST</abbr>.

--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -210,6 +210,7 @@ finally an optional list of trait bounds.
 
 The identifier is the name of the declared type alias. The optional trait bounds
 must be fulfilled by the implementations of the type alias.
+There is an implicit [`Sized`] bound on associated types that can be relaxed using the special `?Sized` bound.
 
 An *associated type definition* defines a type alias on another type. It is
 written as `type`, then an [identifier], then an `=`, and finally a [type].
@@ -344,6 +345,7 @@ fn main() {
 [`Box<Self>`]: ../special-types-and-traits.md#boxt
 [`Pin<P>`]: ../special-types-and-traits.md#pinp
 [`Rc<Self>`]: ../special-types-and-traits.md#rct
+[`Sized`]: ../special-types-and-traits.md#sized
 [traits]: traits.md
 [type aliases]: type-aliases.md
 [inherent implementations]: implementations.md#inherent-implementations

--- a/src/special-types-and-traits.md
+++ b/src/special-types-and-traits.md
@@ -134,10 +134,10 @@ UnwindSafe>` is a valid type.
 
 ## `Sized`
 
-The [`Sized`] trait indicates that the size of this type is known at
-compile-time; that is, it's not a [dynamically sized type]. [Type parameters]
-are `Sized` by default. `Sized` is always implemented automatically by the
-compiler, not by [implementation items].
+The [`Sized`] trait indicates that the size of this type is known at compile-time; that is, it's not a [dynamically sized type].
+[Type parameters] are `Sized` by default, as are [associated types].
+`Sized` is always implemented automatically by the compiler, not by [implementation items].
+These implicit `Sized` bounds may be relaxed by using the special `?Sized` bound.
 
 [`Arc<Self>`]: ../std/sync/struct.Arc.html
 [`Box<T>`]: ../std/boxed/struct.Box.html
@@ -160,6 +160,7 @@ compiler, not by [implementation items].
 [`Unpin`]: ../std/marker/trait.Unpin.html
 
 [Arrays]: types/array.md
+[associated types]: items/associated-items.md#associated-types
 [call expressions]: expressions/call-expr.md
 [deref coercions]: type-coercions.md#coercion-types
 [dereference operator]: expressions/operator-expr.md#the-dereference-operator

--- a/src/trait-bounds.md
+++ b/src/trait-bounds.md
@@ -77,9 +77,8 @@ Trait and lifetime bounds are also used to name [trait objects].
 
 ## `?Sized`
 
-`?` is only used to declare that the [`Sized`] trait may not be
-implemented for a type parameter or associated type. `?Sized` may
-not be used as a bound for other types.
+`?` is only used to relax the implicit [`Sized`] trait bound for [type parameters] or [associated types].
+`?Sized` may not be used as a bound for other types.
 
 ## Lifetime bounds
 
@@ -149,4 +148,5 @@ fn call_on_ref_zero<F>(f: F) where F: for<'a> Fn(&'a i32) {
 [generic]: items/generics.md
 [Trait]: items/traits.md#trait-bounds
 [trait objects]: types/trait-object.md
+[type parameters]: types/parameters.md
 [where clause]: items/generics.md#where-clauses


### PR DESCRIPTION
Mention that there is an implicit `Sized` bound on associated types
as well as on type parameters. Make it more clear that `?Sized`
relaxes the implicit `Sized` bound. Also fix some grammar issues
where omitted words caused confusion.

Fixes #1023. Credit to @mcclure for working on this earlier in #992.

Closes #987, closes #992