### PR TITLE
fix comment in function parameter drop scope example

### DIFF
--- a/src/destructors.md
+++ b/src/destructors.md
@@ -110,7 +110,7 @@ dropped after any bindings introduced in that parameter's pattern.
 #         println!("drop({})", self.0);
 #     }
 # }
-// Drops the second parameter, then `y`, then the first parameter, then `x`
+// Drops `y`, then the second parameter, then `x`, then the first parameter
 fn patterns_in_parameters(
     (x, _): (PrintOnDrop, PrintOnDrop),
     (_, y): (PrintOnDrop, PrintOnDrop),


### PR DESCRIPTION
In "Scopes of function parameters" under "Destructors", the first
comment in the example that demonstrates function parameter
drop order contradicted both the text and the program behavior.