### PR TITLE
move text about checking of bounds on generics

### DIFF
--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -230,23 +230,13 @@ parameters.
 The `for` keyword can be used to introduce [higher-ranked lifetimes]. It only
 allows [_LifetimeParam_] parameters.
 
-Bounds that don't use the item's parameters or [higher-ranked lifetimes] are
-checked when the item is defined. It is an error for such a bound to be false.
-
-[`Copy`], [`Clone`], and [`Sized`] bounds are also checked for certain generic
-types when defining the item. It is an error to have `Copy` or `Clone` as a
-bound on a mutable reference, [trait object] or [slice][arrays] or `Sized` as a
-bound on a trait object or slice.
-
-```rust,compile_fail
+```rust
 struct A<T>
 where
     T: Iterator,            // Could use A<T: Iterator> instead
-    T::Item: Copy,
-    String: PartialEq<T>,
+    T::Item: Copy,          // Bound on an associated type
+    String: PartialEq<T>,   // Bound on `String`, using the type parameter
     i32: Default,           // Allowed, but not useful
-    i32: Iterator,          // Error: the trait bound is not satisfied
-    [T]: Copy,              // Error: the trait bound is not satisfied
 {
     f: T,
 }
@@ -303,9 +293,6 @@ struct Foo<#[my_flexible_clone(unbounded)] H> {
 [path expression]: ../expressions/path-expr.md
 [raw pointers]: ../types/pointer.md#raw-pointers-const-and-mut
 [references]: ../types/pointer.md#shared-references-
-[`Clone`]: ../special-types-and-traits.md#clone
-[`Copy`]: ../special-types-and-traits.md#copy
-[`Sized`]: ../special-types-and-traits.md#sized
 [structs]: structs.md
 [tuples]: ../types/tuple.md
 [trait object]: ../types/trait-object.md

--- a/src/trait-bounds.md
+++ b/src/trait-bounds.md
@@ -77,7 +77,7 @@ Bounds that don't use the item's parameters or [higher-ranked lifetimes] are che
 It is an error for such a bound to be false.
 
 [`Copy`], [`Clone`], and [`Sized`] bounds are also checked for certain generic types when using the item, even if the use does not provide a concrete type.
-It is an error to have `Copy` or `Clone` as a bound on a mutable reference, [trait object], or [slice][arrays].
+It is an error to have `Copy` or `Clone` as a bound on a mutable reference, [trait object], or [slice].
 It is an error to have `Sized` as a bound on a trait object or slice.
 
 ```rust,compile_fail
@@ -171,6 +171,7 @@ fn call_on_ref_zero<F>(f: F) where F: for<'a> Fn(&'a i32) {
 [supertraits]: items/traits.md#supertraits
 [generic]: items/generics.md
 [higher-ranked lifetimes]: #higher-ranked-trait-bounds
+[slice]: types/slice.md
 [Trait]: items/traits.md#trait-bounds
 [trait object]: types/trait-object.md
 [trait objects]: types/trait-object.md

--- a/src/trait-bounds.md
+++ b/src/trait-bounds.md
@@ -73,6 +73,26 @@ fn name_figure<U: Shape>(
 }
 ```
 
+Bounds that don't use the item's parameters or [higher-ranked lifetimes] are
+checked when the item is defined. It is an error for such a bound to be false.
+
+[`Copy`], [`Clone`], and [`Sized`] bounds are also checked for certain generic types when using the item, even if the use does not provide a concrete type.
+It is an error to have `Copy` or `Clone` as a bound on a mutable reference, [trait object], or [slice][arrays].
+It is an error to have `Sized` as a bound on a trait object or slice.
+
+```rust,compile_fail
+struct A<'a, T>
+where
+    i32: Default,           // Allowed, but not useful
+    i32: Iterator,          // Error: `i32` is not an iterator
+    &'a mut T: Copy,        // (at use) Error: the trait bound is not satisfied
+    [T]: Sized,             // (at use) Error: size cannot be known at compilation
+{
+    f: &'a T,
+}
+struct UsesA<'a, T>(A<'a, T>);
+```
+
 Trait and lifetime bounds are also used to name [trait objects].
 
 ## `?Sized`
@@ -142,11 +162,16 @@ fn call_on_ref_zero<F>(f: F) where F: for<'a> Fn(&'a i32) {
 [LIFETIME_OR_LABEL]: tokens.md#lifetimes-and-loop-labels
 [_GenericParams_]: items/generics.md
 [_TypePath_]: paths.md#paths-in-types
+[`Clone`]: special-types-and-traits.md#clone
+[`Copy`]: special-types-and-traits.md#copy
 [`Sized`]: special-types-and-traits.md#sized
 
+[arrays]: types/array.md
 [associated types]: items/associated-items.md#associated-types
 [supertraits]: items/traits.md#supertraits
 [generic]: items/generics.md
+[higher-ranked lifetimes]: #higher-ranked-trait-bounds
 [Trait]: items/traits.md#trait-bounds
+[trait object]: types/trait-object.md
 [trait objects]: types/trait-object.md
 [where clause]: items/generics.md#where-clauses

--- a/src/trait-bounds.md
+++ b/src/trait-bounds.md
@@ -73,8 +73,8 @@ fn name_figure<U: Shape>(
 }
 ```
 
-Bounds that don't use the item's parameters or [higher-ranked lifetimes] are
-checked when the item is defined. It is an error for such a bound to be false.
+Bounds that don't use the item's parameters or [higher-ranked lifetimes] are checked when the item is defined.
+It is an error for such a bound to be false.
 
 [`Copy`], [`Clone`], and [`Sized`] bounds are also checked for certain generic types when using the item, even if the use does not provide a concrete type.
 It is an error to have `Copy` or `Clone` as a bound on a mutable reference, [trait object], or [slice][arrays].


### PR DESCRIPTION
Move text about the timing of checking of bounds on generics
from the "Where clauses" subsection to "Trait and lifetime
bounds", where it makes more sense. Split parts of the example
accordingly. Correct an error about when `Clone`, `Copy`, and
`Sized` trait bounds are checked.

Fixes #1024.

I'm not sure if the previous text about checking trait bounds on generics at the definition instead of at the use site was ever correct, but it doesn't seem correct now on stable.