### PR TITLE
Mention "function item type to `fn pointer`" coercion

### DIFF
--- a/src/type-coercions.md
+++ b/src/type-coercions.md
@@ -150,6 +150,8 @@ Coercion is allowed between the following types:
     structs. In addition, coercions from sub-traits to super-traits will be
     added. See [RFC 401] for more details.-->
 
+* Function item types to `fn` pointers
+
 * Non capturing closures to `fn` pointers
 
 * `!` to any `T`


### PR DESCRIPTION
Fixes https://github.com/rust-lang/nomicon/issues/237
This is mentioned in [RFC 401](https://github.com/rust-lang/rfcs/blob/master/text/0401-coercions.md#function-type-polymorphism) but it seems the reference doesn't mention it currently.