### PR TITLE
Fix recursion_limit example.

### DIFF
--- a/src/attributes/limits.md
+++ b/src/attributes/limits.md
@@ -15,10 +15,10 @@ syntax to specify the recursion depth.
 #![recursion_limit = "4"]
 
 macro_rules! a {
-    () => { a!(1) };
-    (1) => { a!(2) };
-    (2) => { a!(3) };
-    (3) => { a!(4) };
+    () => { a!(1); };
+    (1) => { a!(2); };
+    (2) => { a!(3); };
+    (3) => { a!(4); };
     (4) => { };
 }
 


### PR DESCRIPTION
The macro syntax without the semicolon is not valid.  This updates it so that it is valid syntax.