### PR TITLE
Document auto trait inference for async blocks

### DIFF
--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -117,6 +117,24 @@ loop {
 }
 ```
 
+### Auto traits and `async` blocks
+
+Auto trait inference for `async` blocks follow the same [rules as closures] except that [temporary values that are in scope][temporary-scopes] at an `await` expression are also considered. For example, consider the following block:
+
+```rust
+#fn bar() -> i32 { 42 }
+#async fn foo() {}
+async {
+    match bar() {
+        _ => foo().await,
+    }
+}
+#;
+```
+
+Here the result of `bar()` is in scope during the await of `foo()`, so the result of `bar()` will impact the inferred auto traits.
+If `bar()` is not `Send`, then the future for the whole match block will also not be `Send`.
+
 ## `unsafe` blocks
 
 > **<sup>Syntax</sup>**\
@@ -189,3 +207,5 @@ fn is_unix_platform() -> bool {
 [tuple expressions]: tuple-expr.md
 [unsafe operations]: ../unsafety.md
 [value expressions]: ../expressions.md#place-expressions-and-value-expressions
+[rules as closures]: ../special-types-and-traits.md#auto-traits
+[temporary-scopes]: ../destructors.md#temporary-scopes


### PR DESCRIPTION
We are in the process of changing this (rust-lang/rust#69663), but it would be good to document the existing rules before changing them. This should also help explain the compilation errors people are getting in the meantime.