### PR TITLE
minor typo-fix

### DIFF
--- a/src/trait-bounds.md
+++ b/src/trait-bounds.md
@@ -76,7 +76,7 @@ fn name_figure<U: Shape>(
 Bounds that don't use the item's parameters or [higher-ranked lifetimes] are checked when the item is defined.
 It is an error for such a bound to be false.
 
-[`Copy`], [`Clone`], and [`Sized`] bounds are also checked for certain generic types when using the item, even if the use does not provide a concrete type.
+[`Copy`], [`Clone`], and [`Sized`] bounds are also checked for certain generic types when using the item, even if the user does not provide a concrete type.
 It is an error to have `Copy` or `Clone` as a bound on a mutable reference, [trait object], or [slice].
 It is an error to have `Sized` as a bound on a trait object or slice.
 


### PR DESCRIPTION
Changed the term `use` to `user` , as it makes sense in this context.