### PR TITLE
Switch style-check to Rust 2021

### DIFF
--- a/style-check/Cargo.toml
+++ b/style-check/Cargo.toml
@@ -2,7 +2,7 @@
 name = "style-check"
 version = "0.1.0"
 authors = ["steveklabnik <steve@steveklabnik.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 pulldown-cmark = "0.8"


### PR DESCRIPTION
According to `cargo fix --edition`, no migrations were necessary.

r? @ehuss
