### PR TITLE
Byte literal and string syntax: add missing quote escapes

### DIFF
--- a/src/tokens.md
+++ b/src/tokens.md
@@ -235,7 +235,7 @@ r##"foo #"# bar"##;                // foo #"# bar
 >
 > BYTE_ESCAPE :\
 > &nbsp;&nbsp; &nbsp;&nbsp; `\x` HEX_DIGIT HEX_DIGIT\
-> &nbsp;&nbsp; | `\n` | `\r` | `\t` | `\\` | `\0`
+> &nbsp;&nbsp; | `\n` | `\r` | `\t` | `\\` | `\0` | `\'` | `\"`
 
 A _byte literal_ is a single ASCII character (in the `U+0000` to `U+007F`
 range) or a single _escape_ preceded by the characters `U+0062` (`b`) and


### PR DESCRIPTION
Current definitions of byte characters and byte literals do not allow escaped
single and double quotes. Updated lexical syntax for byte characters and
strings to allow these characters. This is in sync with the implementation.