### PR TITLE
fix crate_name attribute description

### DIFF
--- a/src/crates-and-source-files.md
+++ b/src/crates-and-source-files.md
@@ -132,7 +132,7 @@ name of the crate with the [_MetaNameValueStr_] syntax.
 ```
 
 The crate name must not be empty, and must only contain [Unicode alphanumeric]
-or `-` (U+002D) characters.
+or `_` (U+005F) characters.
 
 [^phase-distinction]: This distinction would also exist in an interpreter.
     Static checks like syntactic analysis, type checking, and lints should


### PR DESCRIPTION
I think the underscore is correct, not the hyphen

![image](https://user-images.githubusercontent.com/5462263/142891091-f32676b4-3840-455b-9047-da0b639c5d40.png)


```rust
#![crate_name = "foo-bar"]

fn main() {
    println!("Hello, world!");
}
```
```bash
$ rustc src\main.rs
error: invalid character `-` in crate name: `foo-bar`
 --> src\main.rs:1:1
  |
1 | #![crate_name = "foo-bar"]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to previous error
```

```rust
#![crate_name = "foo\u{002D}bar"]

fn main() {
    println!("Hello, world!");
}
```
```bash
$ rustc src\main.rs
error: invalid character `-` in crate name: `foo-bar`
 --> src\main.rs:1:1
  |
1 | #![crate_name = "foo\u{002D}bar"]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to previous error
```


`#![crate_name = "foo_bar"]` is no error
`#![crate_name = "foo\u{005F}bar"]` is no error
