### PR TITLE
Update 'Subtyping and Variance' example to use `dyn Trait` syntax

### DIFF
--- a/src/subtyping.md
+++ b/src/subtyping.md
@@ -29,8 +29,8 @@ let subtype: &(for<'a> fn(&'a i32) -> &'a i32) = &((|x| x) as fn(&_) -> &_);
 let supertype: &(fn(&'static i32) -> &'static i32) = subtype;
 
 // This works similarly for trait objects
-let subtype: &(for<'a> Fn(&'a i32) -> &'a i32) = &|x| x;
-let supertype: &(Fn(&'static i32) -> &'static i32) = subtype;
+let subtype: &(dyn for<'a> Fn(&'a i32) -> &'a i32) = &|x| x;
+let supertype: &(dyn Fn(&'static i32) -> &'static i32) = subtype;
 
 // We can also substitute one higher-ranked lifetime for another
 let subtype: &(for<'a, 'b> fn(&'a i32, &'b i32))= &((|x, y| {}) as fn(&_, &_));


### PR DESCRIPTION
This will allow the example to be built under edition 2021.