### PR TITLE
Document destructuring assignment

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -66,7 +66,7 @@
         - [Match expressions](expressions/match-expr.md)
         - [Return expressions](expressions/return-expr.md)
         - [Await expressions](expressions/await-expr.md)
-        - [Underscore expression](expressions/underscore-expr.md)
+        - [Underscore expressions](expressions/underscore-expr.md)
 
 - [Patterns](patterns.md)
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -66,6 +66,7 @@
         - [Match expressions](expressions/match-expr.md)
         - [Return expressions](expressions/return-expr.md)
         - [Await expressions](expressions/await-expr.md)
+        - [Underscore expression](expressions/underscore-expr.md)
 
 - [Patterns](patterns.md)
 

--- a/src/expressions.md
+++ b/src/expressions.md
@@ -26,6 +26,7 @@
 > &nbsp;&nbsp; &nbsp;&nbsp; | [_BreakExpression_]\
 > &nbsp;&nbsp; &nbsp;&nbsp; | [_RangeExpression_]\
 > &nbsp;&nbsp; &nbsp;&nbsp; | [_ReturnExpression_]\
+> &nbsp;&nbsp; &nbsp;&nbsp; | [_UnderscoreExpression_]\
 > &nbsp;&nbsp; &nbsp;&nbsp; | [_MacroInvocation_]\
 > &nbsp;&nbsp; )
 >
@@ -139,10 +140,11 @@ assert_eq!(
 
 ## Place Expressions and Value Expressions
 
-Expressions are divided into two main categories: place expressions and
-value expressions. Likewise, within each expression, operands may occur
-in either place context or value context. The evaluation of an expression
-depends both on its own category and the context it occurs within.
+Expressions are divided into two main categories: place expressions and value
+expressions; there is also a third, minor category of expressions called
+assignee expressions. Within each expression, operands may likewise occur in
+either place context or value context. The evaluation of an expression depends
+both on its own category and the context it occurs within.
 
 A *place expression* is an expression that represents a memory location. These
 expressions are [paths] which refer to local variables, [static variables],
@@ -154,8 +156,7 @@ A *value expression* is an expression that represents an actual value.
 
 The following contexts are *place expression* contexts:
 
-* The left operand of an [assignment][assign] or [compound assignment]
-  expression.
+* The left operand of a [compound assignment] expression.
 * The operand of a unary [borrow] or [dereference][deref] operator.
 * The operand of a field expression.
 * The indexed operand of an array indexing expression.
@@ -167,6 +168,20 @@ The following contexts are *place expression* contexts:
 
 > Note: Historically, place expressions were called *lvalues* and value
 > expressions were called *rvalues*.
+
+An *assignee expression* is an expression that appears in the left operand of an
+[assignment][assign] expression. Explicitly, the assignee expressions are:
+
+- Place expressions.
+- [Underscores][_UnderscoreExpression_].
+- [Tuples][_TupleExpression_] of assignee expressions.
+- [Slices][_ArrayExpression_] of assingee expressions.
+- [Tuple structs][_StructExpression_] of assignee expressions.
+- [Structs][_StructExpression_] of assignee expressions (with optionally named
+  fields).
+- [Unit structs][_StructExpression_].
+
+Arbitrary parenthesisation is permitted inside assignee expressions.
 
 ### Moved and copied types
 
@@ -349,4 +364,5 @@ They are never allowed before:
 [_TupleExpression_]:              expressions/tuple-expr.md
 [_TupleIndexingExpression_]:      expressions/tuple-expr.md#tuple-indexing-expressions
 [_TypeCastExpression_]:           expressions/operator-expr.md#type-cast-expressions
+[_UnderscoreExpression_]:         expressions/underscore-expr.md
 [_UnsafeBlockExpression_]:        expressions/block-expr.md#unsafe-blocks

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -428,13 +428,20 @@ assert_eq!(values[1], 3);
 
 An *assignment expression* moves a value into a specified place.
 
-An assignment expression consists of a [mutable] [place expression], the *assigned place operand*, followed by an equals sign (`=`) and a [value expression], the *assigned value operand*.
+An assignment expression consists of a [mutable] [assignee expression], the
+*assignee operand*, followed by an equals sign (`=`) and a [value expression],
+the *assigned value operand*. In its most basic form, an assignee expression is
+a [place expression], and we discuss this case first. The more general case of
+destructuring assignment is discussed below, but this case always decomposes
+into sequential assignments to place expressions, which may be considered the
+more fundamental case.
 
-Unlike other place operands, the assigned place operand must be a place expression.
-Attempting to use a value expression is a compiler error rather than promoting it to a temporary.
+### Basic assignments
 
-Evaluating assignment expressions begins by evaluating its operands.
-The assigned value operand is evaluated first, followed by the assigned place operand.
+Evaluating assignment expressions begins by evaluating its operands. The
+assigned value operand is evaluated first, followed by the assignee expression.
+(For destructuring assignment, subexpressions of the assignee expression are
+evaluated left-to-right.)
 
 > **Note**: This is different than other expressions in that the right operand is evaluated before the left one.
 
@@ -450,6 +457,67 @@ let mut x = 0;
 let y = 0;
 x = y;
 ```
+
+### Destructuring assignments
+
+Destructuring assignment is a counterpart to destructuring pattern matches for
+variable declaration, permitting assignment to complex values, such as tuples or
+structs. For instance, we may swap two mutable variables:
+
+```rust,ignore
+let (mut a, mut b) = (0, 1);
+// Swap `a` and `b` using destructuring assignment.
+(b, a) = (a, b);
+```
+
+In contrast to destructuring declarations using `let`, patterns may not appear
+on the left-hand side of an assignment due to syntactic ambiguities. Instead, a
+group of expressions that correspond to patterns are designated to be [assignee
+expressions][assignee expression], and permitted on the left-hand side of an
+assignment. Assignee expressions are then desugared to pattern matches followed
+by sequential assignment. The desugared patterns must be irrefutable: in
+particular, this means that only slice patterns whose length is known at
+compile-time, and the trivial slice `[..]`, are permitted for destructuring
+assignment.
+
+The desugaring method is straightforward, and is illustrated best by example.
+
+```rust,ignore
+(a, b) = (3, 4);
+
+[a, b] = [3, 4];
+
+Struct { x: a, y: b } = Struct { x: 3, y: 4};
+
+// desugars to:
+
+{
+    let (_a, _b) = (3, 4);
+    a = _a;
+    b = _b;
+}
+
+{
+    let [_a, _b] = [3, 4];
+    a = _a;
+    b = _b;
+}
+
+{
+    let Struct { x: _a, y: _b } = Struct { x: 3, y: 4};
+    a = _a;
+    b = _b;
+}
+```
+
+Identifiers are not forbidden from being used multiple times in a single
+assignee expression.
+
+[Underscore expressions][_UnderscoreExpression_] and empty [range
+expressions][_RangeExpression_] may be used to ignore certain values, without
+binding them.
+
+Note that default binding modes do not apply for the desugared expression.
 
 ## Compound assignment expressions
 
@@ -530,6 +598,7 @@ See [this test] for an example of using this dependency.
 [logical xor]: ../types/boolean.md#logical-xor
 [mutable]: ../expressions.md#mutability
 [place expression]: ../expressions.md#place-expressions-and-value-expressions
+[assignee expression]: ../expressions.md#place-expressions-and-value-expressions
 [undefined behavior]: ../behavior-considered-undefined.md
 [unit]: ../types/tuple.md
 [value expression]: ../expressions.md#place-expressions-and-value-expressions
@@ -552,3 +621,5 @@ See [this test] for an example of using this dependency.
 
 [_Expression_]: ../expressions.md
 [_TypeNoBounds_]: ../types.md#type-expressions
+[_RangeExpression_]: ./range-expr.md
+[_UnderscoreExpression_]: ./underscore-expr.md

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -428,20 +428,15 @@ assert_eq!(values[1], 3);
 
 An *assignment expression* moves a value into a specified place.
 
-An assignment expression consists of a [mutable] [assignee expression], the
-*assignee operand*, followed by an equals sign (`=`) and a [value expression],
-the *assigned value operand*. In its most basic form, an assignee expression is
-a [place expression], and we discuss this case first. The more general case of
-destructuring assignment is discussed below, but this case always decomposes
-into sequential assignments to place expressions, which may be considered the
-more fundamental case.
+An assignment expression consists of a [mutable] [assignee expression], the *assignee operand*, followed by an equals sign (`=`) and a [value expression], the *assigned value operand*.
+In its most basic form, an assignee expression is a [place expression], and we discuss this case first.
+The more general case of destructuring assignment is discussed below, but this case always decomposes into sequential assignments to place expressions, which may be considered the more fundamental case.
 
 ### Basic assignments
 
-Evaluating assignment expressions begins by evaluating its operands. The
-assigned value operand is evaluated first, followed by the assignee expression.
-(For destructuring assignment, subexpressions of the assignee expression are
-evaluated left-to-right.)
+Evaluating assignment expressions begins by evaluating its operands.
+The assigned value operand is evaluated first, followed by the assignee expression.
+For destructuring assignment, subexpressions of the assignee expression are evaluated left-to-right.
 
 > **Note**: This is different than other expressions in that the right operand is evaluated before the left one.
 
@@ -460,29 +455,25 @@ x = y;
 
 ### Destructuring assignments
 
-Destructuring assignment is a counterpart to destructuring pattern matches for
-variable declaration, permitting assignment to complex values, such as tuples or
-structs. For instance, we may swap two mutable variables:
+Destructuring assignment is a counterpart to destructuring pattern matches for variable declaration, permitting assignment to complex values, such as tuples or structs.
+For instance, we may swap two mutable variables:
 
-```rust,ignore
+```rust
 let (mut a, mut b) = (0, 1);
 // Swap `a` and `b` using destructuring assignment.
 (b, a) = (a, b);
 ```
 
-In contrast to destructuring declarations using `let`, patterns may not appear
-on the left-hand side of an assignment due to syntactic ambiguities. Instead, a
-group of expressions that correspond to patterns are designated to be [assignee
-expressions][assignee expression], and permitted on the left-hand side of an
-assignment. Assignee expressions are then desugared to pattern matches followed
-by sequential assignment. The desugared patterns must be irrefutable: in
-particular, this means that only slice patterns whose length is known at
-compile-time, and the trivial slice `[..]`, are permitted for destructuring
-assignment.
+In contrast to destructuring declarations using `let`, patterns may not appear on the left-hand side of an assignment due to syntactic ambiguities.
+Instead, a group of expressions that correspond to patterns are designated to be [assignee expressions][assignee expression], and permitted on the left-hand side of an assignment.
+Assignee expressions are then desugared to pattern matches followed by sequential assignment.
+The desugared patterns must be irrefutable: in particular, this means that only slice patterns whose length is known at compile-time, and the trivial slice `[..]`, are permitted for destructuring assignment.
 
 The desugaring method is straightforward, and is illustrated best by example.
 
-```rust,ignore
+```rust
+# struct Struct { x: u32, y: u32 }
+# let (mut a, mut b) = (0, 0);
 (a, b) = (3, 4);
 
 [a, b] = [3, 4];
@@ -510,12 +501,9 @@ Struct { x: a, y: b } = Struct { x: 3, y: 4};
 }
 ```
 
-Identifiers are not forbidden from being used multiple times in a single
-assignee expression.
+Identifiers are not forbidden from being used multiple times in a single assignee expression.
 
-[Underscore expressions][_UnderscoreExpression_] and empty [range
-expressions][_RangeExpression_] may be used to ignore certain values, without
-binding them.
+[Underscore expressions][_UnderscoreExpression_] and empty [range expressions][_RangeExpression_] may be used to ignore certain values, without binding them.
 
 Note that default binding modes do not apply for the desugared expression.
 

--- a/src/expressions/underscore-expr.md
+++ b/src/expressions/underscore-expr.md
@@ -1,19 +1,17 @@
-# `_` expression
+# `_` expressions
 
 > **<sup>Syntax</sup>**\
 > _UnderscoreExpression_ :\
 > &nbsp;&nbsp; `_`
 
-The underscore expression, denoted with the symbol `_`, is used to signify a
-placeholder in a destructuring assignment. It may only appear in the left-hand
+Underscore expressions, denoted with the symbol `_`, are used to signify a
+placeholder in a destructuring assignment. They may only appear in the left-hand
 side of an assignment.
 
 An example of an `_` expression:
 
-```rust,ignore
+```rust
 let p = (1, 2);
 let mut a = 0;
 (_, a) = p;
 ```
-
-[_Expression_]: ../expressions.md

--- a/src/expressions/underscore-expr.md
+++ b/src/expressions/underscore-expr.md
@@ -1,0 +1,19 @@
+# `_` expression
+
+> **<sup>Syntax</sup>**\
+> _UnderscoreExpression_ :\
+> &nbsp;&nbsp; `_`
+
+The underscore expression, denoted with the symbol `_`, is used to signify a
+placeholder in a destructuring assignment. It may only appear in the left-hand
+side of an assignment.
+
+An example of an `_` expression:
+
+```rust,ignore
+let p = (1, 2);
+let mut a = 0;
+(_, a) = p;
+```
+
+[_Expression_]: ../expressions.md

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -140,11 +140,10 @@ the syntax element that matched them. The keyword metavariable `$crate` can be
 used to refer to the current crate; see [Hygiene] below. Metavariables can be
 transcribed more than once or not at all.
 
-For reasons of backwards compatibility, although `_` is a (keyword) identifier,
-it is not matched by the `ident` fragment specifier. Similarly, though `_` [is
-also an expression][_UnderscoreExpression_], a standalone underscore is not
-matched by the `expr` fragment specifier. However, `_` is matched by the `expr`
-fragment specifier when it appears as a subexpression.
+For reasons of backwards compatibility, though `_` [is also an
+expression][_UnderscoreExpression_], a standalone underscore is not matched by
+the `expr` fragment specifier. However, `_` is matched by the `expr` fragment
+specifier when it appears as a subexpression.
 
 > **Edition Differences**: Starting with the 2021 edition, `pat` fragment-specifiers match top-level or-patterns (that is, they accept [_Pattern_]).
 >

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -140,6 +140,12 @@ the syntax element that matched them. The keyword metavariable `$crate` can be
 used to refer to the current crate; see [Hygiene] below. Metavariables can be
 transcribed more than once or not at all.
 
+For reasons of backwards compatibility, although `_` is a (keyword) identifier,
+it is not matched by the `ident` fragment specifier. Similarly, though `_` [is
+also an expression][_UnderscoreExpression_], a standalone underscore is not
+matched by the `expr` fragment specifier. However, `_` is matched by the `expr`
+fragment specifier when it appears as a subexpression.
+
 > **Edition Differences**: Starting with the 2021 edition, `pat` fragment-specifiers match top-level or-patterns (that is, they accept [_Pattern_]).
 >
 > Before the 2021 edition, they match exactly the same fragments as `pat_param` (that is, they accept [_PatternNoTopAlt_]).
@@ -506,6 +512,7 @@ For more detail, see the [formal specification].
 [_Token_]: tokens.md
 [_TypePath_]: paths.md#paths-in-types
 [_Type_]: types.md#type-expressions
+[_UnderscoreExpression_]: expressions/underscore-expr.md
 [_Visibility_]: visibility-and-privacy.md
 [formal specification]: macro-ambiguity.md
 [token]: tokens.md

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -582,7 +582,7 @@ usages and meanings are defined in the linked pages.
 | `>=`   | Ge          | [Greater than or equal to][comparison], [Generics]
 | `<=`   | Le          | [Less than or equal to][comparison]
 | `@`    | At          | [Subpattern binding]
-| `_`    | Underscore  | [Wildcard patterns], [Inferred types], Unnamed items in [constants], [extern crates], and [use declarations]
+| `_`    | Underscore  | [Wildcard patterns], [Inferred types], Unnamed items in [constants], [extern crates], [use declarations], and [destructuring assignment]
 | `.`    | Dot         | [Field access][field], [Tuple index]
 | `..`   | DotDot      | [Range][range], [Struct expressions], [Patterns], [Range Patterns][rangepat]
 | `...`  | DotDotDot   | [Variadic functions][extern], [Range patterns]
@@ -625,6 +625,7 @@ them are referred to as "token trees" in [macros].  The three types of brackets 
 [compound]: expressions/operator-expr.md#compound-assignment-expressions
 [constants]: items/constant-items.md
 [dereference]: expressions/operator-expr.md#the-dereference-operator
+[destructuring assignment]: expressions/underscore-expr.md
 [extern crates]: items/extern-crates.md
 [extern]: items/external-blocks.md
 [field]: expressions/field-expr.md


### PR DESCRIPTION
Adds documentation for the `destructuring_assignment` feature (https://github.com/rust-lang/rust/issues/71126), which is accepted for stabilisation (https://github.com/rust-lang/rust/pull/90521). The documentation is based on the [RFC text](https://github.com/rust-lang/rfcs/blob/master/text/2909-destructuring-assignment.md#reference-level-explanation).