### PR TITLE
Note difference in CTFE timing between associated and free constants

### DIFF
--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -296,6 +296,22 @@ type. It is written the same as a [constant item].
 Unlike [free] constants, associated constant definitions undergo
 [constant evaluation] only when referenced.
 
+```rust
+struct Struct;
+
+impl Struct {
+    const ID: i32 = 1;
+    // Definition not immediately evaluated
+    const PANIC: () = panic!("compile-time panic");
+}
+
+fn main() {
+    assert_eq!(1, Struct::ID);
+    // Referencing Struct::PANIC causes compilation error
+    // let _ = Struct::PANIC;
+}
+```
+
 ### Associated Constants Examples
 
 A basic example:
@@ -335,24 +351,6 @@ impl ConstantIdDefault for OtherStruct {
 fn main() {
     assert_eq!(1, Struct::ID);
     assert_eq!(5, OtherStruct::ID);
-}
-```
-
-[Constant evaluation] timing:
-
-```rust
-struct Struct;
-
-impl Struct {
-    const ID: i32 = 1;
-    // Definition not immediately evaluated
-    const PANIC: () = panic!("compile-time panic");
-}
-
-fn main() {
-    assert_eq!(1, Struct::ID);
-    // Referencing Struct::PANIC causes compilation error
-    // let _ = Struct::PANIC;
 }
 ```
 

--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -293,6 +293,9 @@ type that the definition has to implement.
 An *associated constant definition* defines a constant associated with a
 type. It is written the same as a [constant item].
 
+Unlike [free] constants, associated constant definitions undergo
+[constant evaluation] only when referenced.
+
 ### Associated Constants Examples
 
 A basic example:
@@ -335,6 +338,24 @@ fn main() {
 }
 ```
 
+[Constant evaluation] timing:
+
+```rust
+struct Struct;
+
+impl Struct {
+    const ID: i32 = 1;
+    // Definition not immediately evaluated
+    const PANIC: () = panic!("compile-time panic");
+}
+
+fn main() {
+    assert_eq!(1, Struct::ID);
+    // Referencing Struct::PANIC causes compilation error
+    // let _ = Struct::PANIC;
+}
+```
+
 [_ConstantItem_]: constant-items.md
 [_Function_]: functions.md
 [_MacroInvocationSemi_]: ../macros.md#macro-invocation
@@ -362,3 +383,5 @@ fn main() {
 [regular function parameters]: functions.md#attributes-on-function-parameters
 [generic parameters]: generics.md
 [where clauses]: generics.md#where-clauses
+[free]: ../glossary.md#free-item
+[constant evaluation]: ../const_eval.md


### PR DESCRIPTION
Since const panics are now [stabilized], I figure it would be good to
document some of its gotchas. I couldn't really find documents for
the specifics I ran into. I am no const eval expert, and what I
wrote is basically a paraphrase of Ralf's comments[^1][^2],
but I hope to get the ball rolling for adding some docs.

I deliberately chose to not mention the guarantee about syntactically
referenced constants in functions that require code generation as it
seems hard to explain completely without some ambiguity. It also seems
to me that the rules are not completely stable[^3][^4] yet.

[stabilized]: https://github.com/rust-lang/rust/issues/89006
[^1]: https://github.com/rust-lang/rust/issues/91877#issuecomment-995026270
[^2]: https://github.com/rust-lang/rust/issues/91877#issuecomment-995977016
[^3]: https://github.com/rust-lang/rust/issues/71800
[^4]: https://github.com/rust-lang/rust/issues/51999#issuecomment-832086617