### PR TITLE
Switch the default edition for examples to 2021

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install mdbook
       run: |
         mkdir bin
-        curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.5/mdbook-v0.4.5-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
+        curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.14/mdbook-v0.4.14-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
         echo "$(pwd)/bin" >> $GITHUB_PATH
     - name: Report versions
       run: |

--- a/STYLE.md
+++ b/STYLE.md
@@ -41,7 +41,7 @@ See https://highlightjs.org/ for a list of supported languages.
 
 Rust examples are tested via rustdoc, and should include the appropriate annotations when tests are expected to fail:
 
-* `edition2018` — If it is edition-specific.
+* `edition2015` or `edition2018` — If it is edition-specific (see `book.toml` for the default).
 * `no_run` — The example should compile successfully, but should not be executed.
 * `should_panic` — The example should compile and run, but produce a panic.
 * `compile_fail` — The example is expected to fail to compile.

--- a/book.toml
+++ b/book.toml
@@ -11,4 +11,4 @@ git-repository-url = "https://github.com/rust-lang/reference/"
 "/expressions/enum-variant-expr.html" = "struct-expr.html"
 
 [rust]
-edition = "2018"
+edition = "2021"


### PR DESCRIPTION
This changes book.toml as requested in #1065, and updates the Github Actions to use a new enough version of mdBook.

I've also suggested an update to the part of the style guide that talks about edition annotations on examples.

Closes #1065
