### PR TITLE
Document syntax reserved in Rust 2021

### DIFF
--- a/src/tokens.md
+++ b/src/tokens.md
@@ -661,7 +661,7 @@ them are referred to as "token trees" in [macros].  The three types of brackets 
 
 ## Reserved prefixes
 
-> **<sup>Lexer 2018+</sup>**\
+> **<sup>Lexer 2021+</sup>**\
 > RESERVED_TOKEN_DOUBLE_QUOTE : ( IDENTIFIER_OR_KEYWORD <sub>_Except `b` or `r` or `br`_</sub> | `_` ) `"`\
 > RESERVED_TOKEN_SINGLE_QUOTE : ( IDENTIFIER_OR_KEYWORD <sub>_Except `b`_</sub> | `_` ) `'`\
 > RESERVED_TOKEN_POUND : ( IDENTIFIER_OR_KEYWORD <sub>_Except `r` or `br`_</sub> | `_` ) `#`

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -88,8 +88,7 @@ evaluated (primarily) at compile time.
 
 #### Suffixes
 
-A suffix is a non-raw identifier immediately (without whitespace)
-following the primary part of a literal.
+A suffix is a sequence of characters following the primary part of a literal (without intervening whitespace), of the same form as a non-raw identifier or keyword.
 
 Any kind of literal (string, integer, etc) with any suffix is valid as a token,
 and can be passed to a macro without producing an error.

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -663,7 +663,7 @@ them are referred to as "token trees" in [macros].  The three types of brackets 
 
 Some lexical forms known as _reserved prefixes_ are reserved for future use.
 
-Source input which would otherwise be lexically interpreted as a non-raw identifier (or a keyword) which is immediately followed by a `#`, `'`, or `"` character (without intervening whitespace) is identified as a reserved prefix.
+Source input which would otherwise be lexically interpreted as a non-raw identifier (or a keyword or `_`) which is immediately followed by a `#`, `'`, or `"` character (without intervening whitespace) is identified as a reserved prefix.
 
 Note that raw identifiers, raw string literals, and raw byte string literals may contain a `#` character but are not interpreted as containing a reserved prefix.
 

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -661,6 +661,11 @@ them are referred to as "token trees" in [macros].  The three types of brackets 
 
 ## Reserved prefixes
 
+> **<sup>Lexer 2018+</sup>**\
+> RESERVED_TOKEN_DOUBLE_QUOTE : ( IDENTIFIER_OR_KEYWORD <sub>_Except `b` or `r` or `br`_</sub> | `_` ) `"`\
+> RESERVED_TOKEN_SINGLE_QUOTE : ( IDENTIFIER_OR_KEYWORD <sub>_Except `b`_</sub> | `_` ) `'`\
+> RESERVED_TOKEN_POUND : ( IDENTIFIER_OR_KEYWORD <sub>_Except `r` or `br`_</sub> | `_` ) `#`
+
 Some lexical forms known as _reserved prefixes_ are reserved for future use.
 
 Source input which would otherwise be lexically interpreted as a non-raw identifier (or a keyword or `_`) which is immediately followed by a `#`, `'`, or `"` character (without intervening whitespace) is identified as a reserved prefix.

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -659,3 +659,34 @@ them are referred to as "token trees" in [macros].  The three types of brackets 
 [use declarations]: items/use-declarations.md
 [use wildcards]: items/use-declarations.md
 [while let]: expressions/loop-expr.md#predicate-pattern-loops
+
+## Reserved prefixes
+
+Some lexical forms known as _reserved prefixes_ are reserved for future use.
+
+Source input which would otherwise be lexically interpreted as a non-raw identifier (or a keyword) which is immediately followed by a `#`, `'`, or `"` character (without intervening whitespace) is identified as a reserved prefix.
+
+Note that raw identifiers, raw string literals, and raw byte string literals may contain a `#` character but are not interpreted as containing a reserved prefix.
+
+Similarly the `r`, `b`, and `br` prefixes used in raw string literals, byte literals, byte string literals, and raw byte string literals are not interpreted as reserved prefixes.
+
+> **Edition Differences**: Starting with the 2021 edition, reserved prefixes are reported as an error by the lexer (in particular, they cannot be passed to macros).
+>
+> Before the 2021 edition, a reserved prefixes are accepted by the lexer and interpreted as multiple tokens (for example, one token for the identifier or keyword, followed by a `#` token).
+>
+> Examples accepted in all editions:
+> ```rust
+> macro_rules! lexes {($($_:tt)*) => {}}
+> lexes!{a #foo}
+> lexes!{continue 'foo}
+> lexes!{match "..." {}}
+> lexes!{r#let#foo}         // three tokens: r#let # foo
+> ```
+>
+> Examples accepted before the 2021 edition but rejected later:
+> ```rust,edition2018
+> macro_rules! lexes {($($_:tt)*) => {}}
+> lexes!{a#foo}
+> lexes!{continue'foo}
+> lexes!{match"..." {}}
+> ```


### PR DESCRIPTION
Closes #1069.

I believe this is a correct description of what was implemented in rust-lang/rust#84599 .

I haven't tried to make use of the Reference-level explanation section from RFC3101, which I think doesn't capture what was implemented (for example, it doesn't indicate that `continue'label` is now rejected).

This PR leaves reserved prefixes undocumented in the Lexer rules blocks, but I hope that's acceptable for now (suffixes for string literals are already missing there).
