### PR TITLE
State in the UAX31 profile description that a lone `_` is not an identifier

### DIFF
--- a/src/identifiers.md
+++ b/src/identifiers.md
@@ -27,6 +27,8 @@ The profile used from UAX #31 is:
 * Continue := [`XID_Continue`]
 * Medial := empty
 
+with the additional constraint that a single underscore character is not an identifier.
+
 > **Note**: Identifiers starting with an underscore are typically used to indicate an identifier that is intentionally unused, and will silence the unused warning in `rustc`.
 
 Identifiers may not be a [strict] or [reserved] keyword without the `r#` prefix described below in [raw identifiers](#raw-identifiers).


### PR DESCRIPTION
This is following on from discussion in PR #1128.

UAX31 says an implementation that uses a variant of the default rules should

>  declare that it uses a **profile** and define that profile with a precise specification of the characters that are added to or removed from Start, Continue, and Medial and/or provide a list of additional constraints on identifiers. 

so I suppose this counts as such an additional constraint.
