### PR TITLE
Restrict call expression grammar

### DIFF
--- a/src/expressions/call-expr.md
+++ b/src/expressions/call-expr.md
@@ -2,7 +2,7 @@
 
 > **<sup>Syntax</sup>**\
 > _CallExpression_ :\
-> &nbsp;&nbsp; [_Expression_] `(` _CallParams_<sup>?</sup> `)`
+> &nbsp;&nbsp; [_ExpressionWithoutBlock_] `(` _CallParams_<sup>?</sup> `)`
 >
 > _CallParams_ :\
 > &nbsp;&nbsp; [_Expression_]&nbsp;( `,` [_Expression_] )<sup>\*</sup> `,`<sup>?</sup>
@@ -87,6 +87,7 @@ Refer to [RFC 132] for further details and motivations.
 
 [RFC 132]: https://github.com/rust-lang/rfcs/blob/master/text/0132-ufcs.md
 [_Expression_]: ../expressions.md
+[_ExpressionWithoutBlock_]: ../expressions.md
 [`default()`]: ../../std/default/trait.Default.html#tymethod.default
 [`size_of()`]: ../../std/mem/fn.size_of.html
 [`std::ops::FnMut`]: ../../std/ops/trait.FnMut.html


### PR DESCRIPTION
I made the minimal change to the doc for correctness but I welcome ideas for improvement if anyone feels
the below examples should be called out. I suspect that no additional descriptive text is warranted since
no one has noticed this issue before and commented on it.

This change restricts the CallExpression grammar to match rustc and to resolve a grammatical ambiguity.

CallExpression was described as accepting expressions (including ExpressionWithBlock) as a function operand.
However, rustc parses a block followed by a parenthetical expression as a sequence of Statements, not as a function call.

Furthermore, the `Expression ( CallParams? )` grammar leads to an ambiguity as shown:

`{expression}(param)`

This can be parsed as two statements in sequence or as a function call according to the documented grammar.

Or in this example using `if`:

`if true {String::new} else {String::new}(some_str)`

This can be rewritten as an unambiguous CallExpression by wrapping the if block in parenthesis:

`(if true {String::new} else {String::new})(some_str)`
