### PR TITLE
Improve documentation of `repr(transparent)`

### DIFF
--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -556,10 +556,12 @@ the return type of a FFI function tat actually returns the bare `f64`,
 the calls to this function will be compiled incorrectly by Rust and the
 execution of the program will segfault.
 
-```rust
+```C
 // The value is returned directly in a floating-point register on ARM64.
 double do_something_and_return_a_double(void);
+```
 
+```rust
 mod bogus {
     #[repr(C)]
     struct FancyWrapper(f64);
@@ -581,6 +583,7 @@ mod correct {
         fn do_something_and_return_a_double() -> FancyWrapper;
     }
 }
+```
 
 
 
@@ -589,11 +592,10 @@ no other `repr` attribute should be present on the type. This means that
 the following definitions are illegal:
 
 ```rust
-#[repr(transparent, align = "128")]
-struct BogusAlign(f64);
-
-#[repr(transparent, packed)]
-struct BogusPacked(f64);
+// The following examples contain incompatible attributes
+// #[repr(transparent, align(128))]
+// #[repr(transparent, packed)]
+struct BogusWrapper(f64);
 ```
 
 [`align_of_val`]: ../std/mem/fn.align_of_val.html


### PR DESCRIPTION
The documentation was a bit unclear, and after reading it, it was unclear to me what a concrete example of the behaviour described by the following sentence was:

> This is different than the C representation because a struct with the C representation will always have the ABI of a C struct while, for example, a struct with the transparent representation with a primitive field will have the ABI of the primitive field.

Agreed that it was mostly due to my lack of knowledge when it comes to ABIs, but I found my answers reading the [corresponding RFC](https://rust-lang.github.io/rfcs/1758-repr-transparent.html) and thought it would be appropriate to partly import the description of the motivation from it. I found it clear enough so I kept the wording as is and merely copy pasted selected parts, I believe it doesn't raise license issues.