### PR TITLE
Improve associated constant item CTFE timing section

### DIFF
--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -293,8 +293,8 @@ type that the definition has to implement.
 An *associated constant definition* defines a constant associated with a
 type. It is written the same as a [constant item].
 
-Unlike [free] constants, associated constant definitions undergo
-[constant evaluation] only when referenced.
+Associated constant definitions undergo [constant evaluation] only when
+referenced.
 
 ```rust
 struct Struct;
@@ -381,5 +381,4 @@ fn main() {
 [regular function parameters]: functions.md#attributes-on-function-parameters
 [generic parameters]: generics.md
 [where clauses]: generics.md#where-clauses
-[free]: ../glossary.md#free-item
 [constant evaluation]: ../const_eval.md

--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -294,7 +294,8 @@ An *associated constant definition* defines a constant associated with a
 type. It is written the same as a [constant item].
 
 Associated constant definitions undergo [constant evaluation] only when
-referenced.
+referenced. Further, definitions that include [generic parameters] are
+evaluated after monomorphization.
 
 ```rust
 struct Struct;

--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -297,19 +297,31 @@ Associated constant definitions undergo [constant evaluation] only when
 referenced. Further, definitions that include [generic parameters] are
 evaluated after monomorphization.
 
-```rust
+```rust,compile_fail
 struct Struct;
+struct GenericStruct<const ID: i32>;
 
 impl Struct {
-    const ID: i32 = 1;
     // Definition not immediately evaluated
     const PANIC: () = panic!("compile-time panic");
 }
 
+impl<const ID: i32> GenericStruct<ID> {
+    // Definition not immediately evaluated
+    const NON_ZERO: () = if ID == 0 {
+        panic!("contradiction")
+    };
+}
+
 fn main() {
-    assert_eq!(1, Struct::ID);
     // Referencing Struct::PANIC causes compilation error
-    // let _ = Struct::PANIC;
+    let _ = Struct::PANIC;
+
+    // Fine, ID is not 0
+    let _ = GenericStruct::<1>::NON_ZERO;
+
+    // Compilation error from evaluating NON_ZERO with ID=0
+    let _ = GenericStruct::<0>::NON_ZERO;
 }
 ```
 


### PR DESCRIPTION
@RalfJung pointed out in a [comment] that the previous phrasing of the
sentence can read like it is giving guarantees about free constant
definitions always undergoing CTFE, even when unused. That seems to be
how the compiler behaves right now, but it's unclear whether it's
intentional.

Be more precise and don't talk about free constants at all.

---

Related to this, I'm not sure if https://github.com/rust-lang/rust/issues/89006
stabilized the fact that *unamed constants* (in contrast to named but unused free constants) always undergo CTFE. It's part
of the issue, and it's used in the release notes to demo the feature, so I had assumed that it does. Going through the RFC and the issue though, it does not state it explicitly, so it's possible that nothing with regards to when CTFE is guaranteed to happen was actually stabilized.

I'm fairly new to the language overall, but maybe it's time that I try to write an RFC about the _whens_ of CTFE? 

[comment]: https://github.com/rust-lang/reference/pull/1120#discussion_r791928575