### PR TITLE
(minor) Add backticks to token

### DIFF
--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -21,7 +21,7 @@
 > &nbsp;&nbsp; | `{` _MacroMatch_<sup>\*</sup> `}`
 >
 > _MacroMatch_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_Token_]<sub>_except $ and [delimiters]_</sub>\
+> &nbsp;&nbsp; &nbsp;&nbsp; [_Token_]<sub>_except `$` and [delimiters]_</sub>\
 > &nbsp;&nbsp; | _MacroMatcher_\
 > &nbsp;&nbsp; | `$` ( [IDENTIFIER_OR_KEYWORD] <sub>_except `crate`_</sub> | [RAW_IDENTIFIER] | `_` ) `:` _MacroFragSpec_\
 > &nbsp;&nbsp; | `$` `(` _MacroMatch_<sup>+</sup> `)` _MacroRepSep_<sup>?</sup> _MacroRepOp_


### PR DESCRIPTION
Viewing the repository locally on VSCode's markdown preview shows an error at that position

<img width="562" alt="Code_2022-01-28_11-24-11" src="https://user-images.githubusercontent.com/30108880/151530566-26795994-66e9-4f37-91eb-cc7743b0d59c.png">

Adding backticks fixes the issue
<img width="496" alt="Code_2022-01-28_11-24-19" src="https://user-images.githubusercontent.com/30108880/151530571-82c8ac7d-17e5-463e-a013-4a0e92e43924.png">

