### PR TITLE
Add undocumented outer attributes above StructExpr fields

### DIFF
--- a/src/expressions/struct-expr.md
+++ b/src/expressions/struct-expr.md
@@ -18,7 +18,7 @@
 > &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; [IDENTIFIER]\
 > &nbsp;&nbsp; &nbsp;&nbsp; | ([IDENTIFIER] | [TUPLE_INDEX]) `:` [_Expression_]\
 > &nbsp;&nbsp; )
-> 
+>
 > _StructBase_ :\
 > &nbsp;&nbsp; `..` [_Expression_]
 >

--- a/src/expressions/struct-expr.md
+++ b/src/expressions/struct-expr.md
@@ -124,7 +124,7 @@ let a = Gamma;  // Gamma unit value.
 let b = Gamma{};  // Exact same value as `a`.
 ```
 
-[_OuterAttribute_]: attributes.md
+[_OuterAttribute_]: ../attributes.md
 [IDENTIFIER]: ../identifiers.md
 [TUPLE_INDEX]: ../tokens.md#tuple-index
 [_Expression_]: ../expressions.md

--- a/src/expressions/struct-expr.md
+++ b/src/expressions/struct-expr.md
@@ -13,9 +13,12 @@
 > &nbsp;&nbsp; _StructExprField_ (`,` _StructExprField_)<sup>\*</sup> (`,` _StructBase_ | `,`<sup>?</sup>)
 >
 > _StructExprField_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [IDENTIFIER]\
-> &nbsp;&nbsp; | ([IDENTIFIER] | [TUPLE_INDEX]) `:` [_Expression_]
->
+> &nbsp;&nbsp; [_OuterAttribute_] <sup>\*</sup>\
+> &nbsp;&nbsp; (\
+> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; [IDENTIFIER]\
+> &nbsp;&nbsp; &nbsp;&nbsp; | ([IDENTIFIER] | [TUPLE_INDEX]) `:` [_Expression_]\
+> &nbsp;&nbsp; )
+> 
 > _StructBase_ :\
 > &nbsp;&nbsp; `..` [_Expression_]
 >
@@ -121,6 +124,7 @@ let a = Gamma;  // Gamma unit value.
 let b = Gamma{};  // Exact same value as `a`.
 ```
 
+[_OuterAttribute_]: attributes.md
 [IDENTIFIER]: ../identifiers.md
 [TUPLE_INDEX]: ../tokens.md#tuple-index
 [_Expression_]: ../expressions.md


### PR DESCRIPTION
`StructExprField` may use outer attributes: https://replit.com/@pushkine/Attributes-in-Struct-Expressions#src/main.rs

Here's an occurrence in rust's compiler:

https://github.com/rust-lang/rust/blob/a00e130dae74a213338e2b095ec855156d8f3d8a/compiler/rustc_data_structures/src/sync.rs#L571-L577