### PR TITLE
Document pre-Rust-2021 special case for IntoIterator method lookup

### DIFF
--- a/src/expressions/method-call-expr.md
+++ b/src/expressions/method-call-expr.md
@@ -66,6 +66,11 @@ Once a method is looked up, if it can't be called for one (or more) of those rea
 If a step is reached where there is more than one possible method, such as where generic methods or traits are considered the same, then it is a compiler error.
 These cases require a [disambiguating function call syntax] for method and function invocation.
 
+> **Edition Differences**: Before the 2021 edition, during the search for visible methods, if the candidate receiver type is an [array type], methods provided by the standard library [`IntoIterator`] trait are ignored.
+>
+> The edition used for this purpose is determined by the token representing the method name.
+
+
 <div class="warning">
 
 ***Warning:*** For [trait objects], if there is an inherent method of the same name as a trait method, it will give a compiler error when trying to call the method in a method call expression.
@@ -79,9 +84,11 @@ Just don't define inherent methods on trait objects with the same name as a trai
 [_Expression_]: ../expressions.md
 [_PathExprSegment_]: ../paths.md#paths-in-expressions
 [visible]: ../visibility-and-privacy.md
+[array type]: ../types/array.md
 [trait objects]: ../types/trait-object.md
 [disambiguate call]: call-expr.md#disambiguating-function-calls
 [disambiguating function call syntax]: call-expr.md#disambiguating-function-calls
 [dereference]: operator-expr.md#the-dereference-operator
 [methods]: ../items/associated-items.md#methods
 [unsized coercion]: ../type-coercions.md#unsized-coercions
+[`IntoIterator`]: ../../std/iter/trait.IntoIterator.html

--- a/src/expressions/method-call-expr.md
+++ b/src/expressions/method-call-expr.md
@@ -69,6 +69,8 @@ These cases require a [disambiguating function call syntax] for method and funct
 > **Edition Differences**: Before the 2021 edition, during the search for visible methods, if the candidate receiver type is an [array type], methods provided by the standard library [`IntoIterator`] trait are ignored.
 >
 > The edition used for this purpose is determined by the token representing the method name.
+>
+> This special case may be removed in the future.
 
 
 <div class="warning">


### PR DESCRIPTION
Closes #1068

This behaviour is also documented in the standard library docs for the [array type][1].

[1]: https://github.com/rust-lang/rust/blob/ad88831cd50ffe9cb9006bbdcb7fc9d97142e410/library/std/src/primitive_docs.rs#L585

The edition guide doesn't say that the special-case behaviour applies when the array type is reached via deref coercions, but this is clear from the implementation. It's also mentioned in https://github.com/rust-lang/rust/pull/84147#issuecomment-819000436.

