### PR TITLE
`LifetimeWhereClauseItem` can have missing `LifetimeBounds`

### DIFF
--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -219,7 +219,7 @@ fn generic<const B: bool>() {
 > &nbsp;&nbsp; | _TypeBoundWhereClauseItem_
 >
 > _LifetimeWhereClauseItem_ :\
-> &nbsp;&nbsp; [_Lifetime_] `:` [_LifetimeBounds_]
+> &nbsp;&nbsp; [_Lifetime_] `:` [_LifetimeBounds_]<sup>?</sup>
 >
 > _TypeBoundWhereClauseItem_ :\
 > &nbsp;&nbsp; [_ForLifetimes_]<sup>?</sup> [_Type_] `:` [_TypeParamBounds_]<sup>?</sup>


### PR DESCRIPTION
https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=7509c10ee125dbeec7f77ce5bb1d9295:
```rs
fn __<'a>() where 'a: {}
```
is valid rust