### PR TITLE
Fix link to the Bastion of the Turbofish

### DIFF
--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -591,7 +591,7 @@ See [this test] for an example of using this dependency.
 [unit]: ../types/tuple.md
 [value expression]: ../expressions.md#place-expressions-and-value-expressions
 [temporary value]: ../expressions.md#temporaries
-[this test]: https://github.com/rust-lang/rust/blob/master/src/test/ui/expr/compound-assignment/eval-order.rs
+[this test]: https://github.com/rust-lang/rust/blob/1.58.0/src/test/ui/expr/compound-assignment/eval-order.rs
 [float-float]: https://github.com/rust-lang/rust/issues/15536
 [Function pointer]: ../types/function-pointer.md
 [Function item]: ../types/function-item.md

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -322,7 +322,7 @@ example of an uninhabited type is the [never type] `!`, or an enum with no varia
 [structs]: items/structs.md
 [trait objects]: types/trait-object.md
 [traits]: items/traits.md
-[turbofish test]: https://github.com/rust-lang/rust/blob/master/src/test/ui/bastion-of-the-turbofish.rs
+[turbofish test]: https://github.com/rust-lang/rust/blob/master/src/test/ui/parser/bastion-of-the-turbofish.rs
 [types of crates]: linkage.md
 [types]: types.md
 [undefined-behavior]: behavior-considered-undefined.md

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -322,7 +322,7 @@ example of an uninhabited type is the [never type] `!`, or an enum with no varia
 [structs]: items/structs.md
 [trait objects]: types/trait-object.md
 [traits]: items/traits.md
-[turbofish test]: https://github.com/rust-lang/rust/blob/master/src/test/ui/parser/bastion-of-the-turbofish.rs
+[turbofish test]: https://github.com/rust-lang/rust/blob/1.58.0/src/test/ui/parser/bastion-of-the-turbofish.rs
 [types of crates]: linkage.md
 [types]: types.md
 [undefined-behavior]: behavior-considered-undefined.md


### PR DESCRIPTION
Since <https://github.com/rust-lang/rust/pull/89488> it was moved to a different directory.