### PR TITLE
Update const_eval.md for feature stabilization

### DIFF
--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -90,7 +90,6 @@ Notable features that are allowed in const contexts but not in const functions i
   * floating point values are treated just like generic parameters without trait bounds beyond
   `Copy`. So you cannot do anything with them but copy/move them around.
 * comparing raw pointers
-* union field access
 
 Conversely, the following are possible in a const function, but not in a const context:
 

--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -89,7 +89,6 @@ Notable features that are allowed in const contexts but not in const functions i
 * floating point operations
   * floating point values are treated just like generic parameters without trait bounds beyond
   `Copy`. So you cannot do anything with them but copy/move them around.
-* comparing raw pointers
 
 Conversely, the following are possible in a const function, but not in a const context:
 

--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -65,8 +65,8 @@ A _const context_ is one of the following:
 
 A _const fn_ is a function that one is permitted to call from a const context. Declaring a function
 `const` has no effect on any existing uses, it only restricts the types that arguments and the
-return type may use, as well as prevent various expressions from being used within it. You can freely do anything with a const function that
-you can do with a regular function.
+return type may use, as well as prevent various expressions from being used within it. You can freely
+do anything with a const function that you can do with a regular function.
 
 When called from a const context, the function is interpreted by the
 compiler at compile time. The interpretation happens in the
@@ -84,13 +84,12 @@ slightly) different results. It is advisable to not make array lengths and enum
 discriminants depend on floating point computations.
 
 
-Notable features that const contexts have, but const fn haven't are:
+Notable features that are allowed in const contexts but not in const functions include:
 
 * floating point operations
   * floating point values are treated just like generic parameters without trait bounds beyond
   `Copy`. So you cannot do anything with them but copy/move them around.
 * `dyn Trait` types
-* generic bounds on generic parameters beyond `Sized`
 * comparing raw pointers
 * union field access
 

--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -89,7 +89,6 @@ Notable features that are allowed in const contexts but not in const functions i
 * floating point operations
   * floating point values are treated just like generic parameters without trait bounds beyond
   `Copy`. So you cannot do anything with them but copy/move them around.
-* `dyn Trait` types
 * comparing raw pointers
 * union field access
 


### PR DESCRIPTION
We are in the process of stabilizing `const_fn_fn_ptr_basics` and `const_fn_trait_bound` (see https://github.com/rust-lang/rust/pull/93827). This edit updates const_eval.md to reflect the new capabilities after stabilizing these features.