### PR TITLE
Add supported Directives list

### DIFF
--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -491,6 +491,7 @@ The following directives are guaranteed to be supported by the assembler:
 .4byte
 .8byte
 .byte
+.short
 .word
 .long
 .quad
@@ -523,6 +524,9 @@ The following directives are guaranteed to be supported by the assembler:
 .comm
 .lcomm
 .option
+.equ
+.set
+.align
 ```
 
 The following directives are guaranteed to be supported for `global_asm` only:

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -527,6 +527,7 @@ The following directives are guaranteed to be supported by the assembler:
 .equ
 .set
 .align
+.inst
 ```
 
 The following directives are guaranteed to be supported for `global_asm` only:

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -593,7 +593,7 @@ On x86 targets, both 32-bit and 64-bit, the following additional directives are 
 - `.intel_syntax`
 - `.nops`
 
-Use of the `.att_syntax` and `.intel_syntax` with no parameters is supported, but the syntax must be restored to the option at entry (`.intel_syntax` without the `att_syntax` asm option, or `.att_syntax` with that option) or the behaviour is undefined (the output of the compiler may be corrupted as a result). Use of `.att_syntax` and `.intel_syntax` with an option (such as `.intel_syntax prefix` or `.att_syntax noprefix`) is unsupported and results in assembler-dependant behaviour. If operand interpolations are used between setting the syntax mode with one of these directives, and restoring it to the block's default, the behaviour is undefined.
+Use of the `.att_syntax` and `.intel_syntax` directives with no parameters (or with parameters equivalent to the defaults) is supported, but the syntax must be restored to the option at entry (`.intel_syntax` without the `att_syntax` asm option, or `.att_syntax` with that option) or the behavior is undefined (the compiled output may be corrupted as a result). Use of `.att_syntax` and `.intel_syntax` with a non-default option (such as `.intel_syntax prefix` or `.att_syntax noprefix`) is unsupported. If operand interpolations are used between setting the syntax mode with one of these directives, and restoring it to the block's default, the behaviour is undefined.
 
 On x86 for `global_asm!` only, the following additional directives are guaranteed to be supported (it is unspecified whether `.code16` or `.code32` are supported for `asm!()`):
 

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -486,57 +486,57 @@ The result of using other directives is assembler-specific (and may cause an err
 
 The following directives are guaranteed to be supported by the assembler:
 
-```as
-.2byte
-.4byte
-.8byte
-.byte
-.short
-.word
-.long
-.quad
-.float
-.double
-.octa
-.sleb128
-.uleb128
-.ascii
-.asciz
-.string
-.skip
-.space
-.balign
-.balignl
-.balignw
-.balign
-.balignl
-.balignw
-.fill
-.section
-.pushsection
-.popsection
-.text
-.bss
-.data
-.def
-.endef
-.scl
-.comm
-.lcomm
-.option
-.equ
-.set
-.align
-.inst
-```
+
+- `.2byte`
+- `.4byte`
+- `.8byte`
+- `.byte`
+- `.short`
+- `.word`
+- `.long`
+- `.quad`
+- `.float`
+- `.double`
+- `.octa`
+- `.sleb128`
+- `.uleb128`
+- `.ascii`
+- `.asciz`
+- `.string`
+- `.skip`
+- `.space`
+- `.balign`
+- `.balignl`
+- `.balignw`
+- `.balign`
+- `.balignl`
+- `.balignw`
+- `.fill`
+- `.section`
+- `.pushsection`
+- `.popsection`
+- `.text`
+- `.bss`
+- `.data`
+- `.def`
+- `.endef`
+- `.scl`
+- `.comm`
+- `.lcomm`
+- `.option`
+- `.equ`
+- `.set`
+- `.align`
+- `.inst`
+
 
 The following directives are guaranteed to be supported for `global_asm` only:
-```as
-.alt_entry
-.private_extern
-.globl
-.global
-```
+
+- `.alt_entry`
+- `.private_extern`
+- `.globl`
+- `.global`
+
 
 #### Target Specific Directive Support
 
@@ -544,69 +544,66 @@ The following directives are guaranteed to be supported for `global_asm` only:
 
 The following directives are supported on ELF targets that support DWARF unwind info:
 
-```as
-.cfi_adjust_cfa_offset
-.cfi_def_cfa
-.cfi_def_cfa_offset
-.cfi_def_cfa_register
-.cfi_endproc
-.cfi_escape
-.cfi_lsda
-.cfi_offset
-.cfi_personality
-.cfi_register
-.cfi_rel_offset
-.cfi_remember_state
-.cfi_restore
-.cfi_restore_state
-.cfi_return_column
-.cfi_same_value
-.cfi_sections
-.cfi_signal_frame
-.cfi_startproc
-.cfi_undefined
-.cfi_window_save
-```
+
+- `.cfi_adjust_cfa_offset`
+- `.cfi_def_cfa`
+- `.cfi_def_cfa_offset`
+- `.cfi_def_cfa_register`
+- `.cfi_endproc`
+- `.cfi_escape`
+- `.cfi_lsda`
+- `.cfi_offset`
+- `.cfi_personality`
+- `.cfi_register`
+- `.cfi_rel_offset`
+- `.cfi_remember_state`
+- `.cfi_restore`
+- `.cfi_restore_state`
+- `.cfi_return_column`
+- `.cfi_same_value`
+- `.cfi_sections`
+- `.cfi_signal_frame`
+- `.cfi_startproc`
+- `.cfi_undefined`
+- `.cfi_window_save`
+
 
 ##### Structured Exception Handling
 
 On targets with structured exception Handling, the following additional directives are guaranteed to be supported:
-```as
-.seh_endproc
-.seh_endprologue
-.seh_proc
-.seh_pushreg
-.seh_savereg
-.seh_setframe
-.seh_stackalloc
-```
+
+- `.seh_endproc`
+- `.seh_endprologue`
+- `.seh_proc`
+- `.seh_pushreg`
+- `.seh_savereg`
+- `.seh_setframe`
+- `.seh_stackalloc`
+
 
 ##### x86
 
 On x86, the following additional directives are guaranteed to be supported:
-```as
-.nops
-```
+- `.nops`
 
 On x86 for `global_asm!` only, the following additional directives are guaranteed to be supported (it is unspecified whether `.code16` or `.code32` are supported for `asm!()`):
-```as
-.code16
-.code32
-```
+
+- `.code16`
+- `.code32`
+
 
 ##### ARM
 
 On ARM for `global_asm!` only, the following additional directives are guaranteed to be supported:
-```as
-.code 
-.thumb
-.thumb_func
-```
+
+- `.code`
+- `.thumb`
+- `.thumb_func`
+
 
 On ARM, the following additional directives are guaranteed to be supported:
-```as
-.fnstart
-.fnend
-.save
-.movsp
-```
+
+- `.fnstart`
+- `.fnend`
+- `.save`
+- `.movsp`

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -87,7 +87,7 @@ On x86, the `.intel_syntax noprefix` mode of GAS is used by default.
 On ARM, the `.syntax unified` mode is used.
 These targets impose an additional restriction on the assembly code: any assembler state (e.g. the current section which can be changed with `.section`) must be restored to its original value at the end of the asm string.
 Assembly code that does not conform to the GAS syntax will result in assembler-specific behavior. 
-Further constraints on the directives used by the assembly are indicated by [Directives Support](#directives-support). 
+Further constraints on the directives used by inline assembly are indicated by [Directives Support](#directives-support). 
 
 [format-syntax]: ../std/fmt/index.html#syntax
 [rfc-2795]: https://github.com/rust-lang/rfcs/pull/2795
@@ -481,8 +481,10 @@ To avoid undefined behavior, these rules must be followed when using function-sc
 
 ### Directives Support
 
-Inline ASM supports a subset of the directives supported by both GNU AS and LLVM's internal assembler, given as follows.
+Inline assembly supports a subset of the directives supported by both GNU AS and LLVM's internal assembler, given as follows.
 The result of using other directives is assembler-specific (and may cause an error, or may be accepted as-is).
+
+If inline assembly includes any "stateful" directive that modifies how subsequent assembly is processed, the block must undo the effects of any such directives before the inline assembly ends.
 
 The following directives are guaranteed to be supported by the assembler:
 
@@ -515,6 +517,7 @@ The following directives are guaranteed to be supported by the assembler:
 - `.section`
 - `.pushsection`
 - `.popsection`
+- `.subsection`
 - `.text`
 - `.bss`
 - `.data`
@@ -584,9 +587,9 @@ On targets with structured exception Handling, the following additional directiv
 - `.seh_stackalloc`
 
 
-##### x86
+##### x86 (32-bit and 64-bit)
 
-On x86, the following additional directives are guaranteed to be supported:
+On x86 targets, both 32-bit and 64-bit, the following additional directives are guaranteed to be supported:
 - `.nops`
 
 On x86 for `global_asm!` only, the following additional directives are guaranteed to be supported (it is unspecified whether `.code16` or `.code32` are supported for `asm!()`):
@@ -610,3 +613,4 @@ On ARM, the following additional directives are guaranteed to be supported:
 - `.fnend`
 - `.save`
 - `.movsp`
+- `.even`

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -87,7 +87,7 @@ On x86, the `.intel_syntax noprefix` mode of GAS is used by default.
 On ARM, the `.syntax unified` mode is used.
 These targets impose an additional restriction on the assembly code: any assembler state (e.g. the current section which can be changed with `.section`) must be restored to its original value at the end of the asm string.
 Assembly code that does not conform to the GAS syntax will result in assembler-specific behavior. 
-Further constraints on the directives used by the assembly are indicated by [Directives Support](#directives-support). 
+Further constraints on the directives used by inline assembly are indicated by [Directives Support](#directives-support). 
 
 [format-syntax]: ../std/fmt/index.html#syntax
 [rfc-2795]: https://github.com/rust-lang/rfcs/pull/2795
@@ -481,11 +481,12 @@ To avoid undefined behavior, these rules must be followed when using function-sc
 
 ### Directives Support
 
-Inline ASM supports a subset of the directives supported by both GNU AS and LLVM's internal assembler, given as follows.
+Inline assembly supports a subset of the directives supported by both GNU AS and LLVM's internal assembler, given as follows.
 The result of using other directives is assembler-specific (and may cause an error, or may be accepted as-is).
 
-The following directives are guaranteed to be supported by the assembler:
+If inline assembly includes any "stateful" directive that modifies how subsequent assembly is processed, the block must undo the effects of any such directives before the inline assembly ends.
 
+The following directives are guaranteed to be supported by the assembler:
 
 - `.2byte`
 - `.4byte`
@@ -531,8 +532,6 @@ The following directives are guaranteed to be supported by the assembler:
 - `.text`
 - `.uleb128`
 - `.word`
-
-
 
 The following directives are guaranteed to be supported for `global_asm` only:
 
@@ -587,21 +586,22 @@ On targets with structured exception Handling, the following additional directiv
 - `.seh_stackalloc`
 
 
-##### x86
+##### x86 (32-bit and 64-bit)
 
-On x86, the following additional directives are guaranteed to be supported:
+On x86 targets, both 32-bit and 64-bit, the following additional directives are guaranteed to be supported:
 - `.att_syntax`
 - `.intel_syntax`
 - `.nops`
 
 Use of the `.att_syntax` and `.intel_syntax` with no parameters is supported, but the syntax must be restored to the option at entry (`.intel_syntax` without the `att_syntax` asm option, or `.att_syntax` with that option) or the behaviour is undefined (the output of the compiler may be corrupted as a result). Use of `.att_syntax` and `.intel_syntax` with an option (such as `.intel_syntax prefix` or `.att_syntax noprefix`) is unsupported and results in assembler-dependant behaviour. If operand interpolations are used between setting the syntax mode with one of these directives, and restoring it to the block's default, the behaviour is undefined.
 
-On x86 for `global_asm!` only, the following additional directives are guaranteed to be supported:
+On x86 for `global_asm!` only, the following additional directives are guaranteed to be supported (it is unspecified whether `.code16` or `.code32` are supported for `asm!()`):
+
 - `.code16`
 - `.code32`
 
 
-##### ARM (32-bit only)
+##### ARM
 
 On ARM for `global_asm!` only, the following additional directives are guaranteed to be supported:
 
@@ -615,6 +615,6 @@ On ARM, the following additional directives are guaranteed to be supported:
 - `.even`
 - `.fnstart`
 - `.fnend`
-- `.movsp`
 - `.save`
+- `.movsp`
 

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -534,7 +534,10 @@ The following directives are guaranteed to be supported by the assembler:
 - `.align`
 - `.inst`
 - `.p2align`
-
+- `.bundle_align_mode`
+- `.bundle_lock`
+- `.bundle_unlock`
+- `.symver`
 
 The following directives are guaranteed to be supported for `global_asm` only:
 

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -528,6 +528,7 @@ The following directives are guaranteed to be supported by the assembler:
 - `.set`
 - `.align`
 - `.inst`
+- `.p2align`
 
 
 The following directives are guaranteed to be supported for `global_asm` only:
@@ -536,6 +537,8 @@ The following directives are guaranteed to be supported for `global_asm` only:
 - `.private_extern`
 - `.globl`
 - `.global`
+- `.size`
+- `.type`
 
 
 #### Target Specific Directive Support

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -547,7 +547,6 @@ On x86, the following additional directives are guaranteed to be supported:
 ```
 
 On x86 for `global_asm!` only, the following additional directives are guaranteed to be supported (it is unspecified whether `.code16` or `.code32` are supported for `asm!()`):
-
 ```as
 .code16
 .code32

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -86,7 +86,8 @@ Currently, all supported targets follow the assembly code syntax used by LLVM's 
 On x86, the `.intel_syntax noprefix` mode of GAS is used by default.
 On ARM, the `.syntax unified` mode is used.
 These targets impose an additional restriction on the assembly code: any assembler state (e.g. the current section which can be changed with `.section`) must be restored to its original value at the end of the asm string.
-Assembly code that does not conform to the GAS syntax will result in assembler-specific behavior.
+Assembly code that does not conform to the GAS syntax will result in assembler-specific behavior. 
+Further constraints on the directives used by the assembly are indicated by [Directives Support](#directives-support). 
 
 [format-syntax]: ../std/fmt/index.html#syntax
 [rfc-2795]: https://github.com/rust-lang/rfcs/pull/2795
@@ -477,3 +478,76 @@ To avoid undefined behavior, these rules must be followed when using function-sc
   - The compiler is currently unable to detect this due to the way inline assembly is compiled, but may catch and reject this in the future.
 
 > **Note**: As a general rule, the flags covered by `preserves_flags` are those which are *not* preserved when performing a function call.
+
+### Directives Support
+
+Inline ASM supports a subset of the directives supported by both GNU AS and LLVM's internal assembler, given as follows.
+The result of using other directives is assembler-specific (and may cause an error, or may be accepted as-is).
+
+The following directives are guaranteed to be supported by the assembler:
+
+```as
+.2byte
+.4byte
+.8byte
+.byte
+.word
+.long
+.quad
+.float
+.double
+.octa
+.sleb128
+.uleb128
+.ascii
+.asciz
+.string
+.skip
+.space
+.balign
+.balignl
+.balignw
+.balign
+.balignl
+.balignw
+.section
+.pushsection
+.popsection
+.text
+.bss
+.data
+.cfi_adjust_cfa_offset
+.cfi_def_cfa
+.cfi_def_cfa_offset
+.cfi_def_cfa_register
+.cfi_endproc
+.cfi_escape
+.cfi_lsda
+.cfi_offset
+.cfi_personality
+.cfi_register
+.cfi_rel_offset
+.cfi_remember_state
+.cfi_restore
+.cfi_restore_state
+.cfi_return_column
+.cfi_same_value
+.cfi_sections
+.cfi_signal_frame
+.cfi_startproc
+.cfi_undefined
+.cfi_window_save
+.comm
+.lcomm
+```
+
+On x86, the following additional directives are guaranteed to be supported:
+```as
+.nops
+```
+
+On x86 for `global_asm!` only, the following additional directives are guaranteed to be supported (it is unspecified whether `.code16` or `.code32` are supported for `asm!()`):
+```
+.code16
+.code32
+```

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -86,8 +86,8 @@ Currently, all supported targets follow the assembly code syntax used by LLVM's 
 On x86, the `.intel_syntax noprefix` mode of GAS is used by default.
 On ARM, the `.syntax unified` mode is used.
 These targets impose an additional restriction on the assembly code: any assembler state (e.g. the current section which can be changed with `.section`) must be restored to its original value at the end of the asm string.
-Assembly code that does not conform to the GAS syntax will result in assembler-specific behavior. 
-Further constraints on the directives used by inline assembly are indicated by [Directives Support](#directives-support). 
+Assembly code that does not conform to the GAS syntax will result in assembler-specific behavior.
+Further constraints on the directives used by inline assembly are indicated by [Directives Support](#directives-support).
 
 [format-syntax]: ../std/fmt/index.html#syntax
 [rfc-2795]: https://github.com/rust-lang/rfcs/pull/2795
@@ -594,10 +594,12 @@ On x86 targets, both 32-bit and 64-bit, the following additional directives are 
 - `.code32`
 - `.code64`
 
-Use of the `.att_syntax` and `.intel_syntax` directives with no parameters (or with parameters equivalent to the defaults) is supported, but the syntax must be restored to the option at entry (`.intel_syntax` without the `att_syntax` asm option, or `.att_syntax` with that option) or the behavior is undefined (the compiled output may be corrupted as a result). Use of `.att_syntax` and `.intel_syntax` with a non-default option (such as `.intel_syntax prefix` or `.att_syntax noprefix`) is unsupported. If operand interpolations are used between setting the syntax mode with one of these directives, and restoring it to the block's default, the behaviour is undefined.
+Use of the `.att_syntax` and `.intel_syntax` directives with no parameters (or with parameters equivalent to the defaults) is supported, but the syntax must be restored to the option at entry (`.intel_syntax` without the `att_syntax` asm option, or `.att_syntax` with that option) or the behavior is undefined (the compiled output may be corrupted as a result).
+Use of `.att_syntax` and `.intel_syntax` with a non-default option (such as `.intel_syntax prefix` or `.att_syntax noprefix`) is unsupported.
+If operand interpolations are used between setting the syntax mode with one of these directives, and restoring it to the block's default, the behaviour is undefined.
 
 Use of `.code16`, `.code32`, and `.code64` directives are only supported if the state is reset to the default before exiting the assembly block.
-32-bit x86 uses `.code32` by default, and x86_64 uses `.code64` by default. 
+32-bit x86 uses `.code32` by default, and x86_64 uses `.code64` by default.
 
 
 ##### ARM (32-bit)
@@ -612,5 +614,3 @@ On ARM, the following additional directives are guaranteed to be supported:
 - `.code`
 - `.thumb`
 - `.thumb_func`
-
-

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -547,7 +547,8 @@ On x86, the following additional directives are guaranteed to be supported:
 ```
 
 On x86 for `global_asm!` only, the following additional directives are guaranteed to be supported (it is unspecified whether `.code16` or `.code32` are supported for `asm!()`):
-```
+
+```as
 .code16
 .code32
 ```

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -510,6 +510,7 @@ The following directives are guaranteed to be supported by the assembler:
 .balign
 .balignl
 .balignw
+.fill
 .section
 .pushsection
 .popsection

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -494,6 +494,7 @@ The following directives are guaranteed to be supported by the assembler:
 - `.align`
 - `.ascii`
 - `.asciz`
+- `.alt_entry`
 - `.balign`
 - `.balignl`
 - `.balignw`
@@ -512,11 +513,14 @@ The following directives are guaranteed to be supported by the assembler:
 - `.eqv`
 - `.fill`
 - `.float`
+- `.globl`
+- `.global`
 - `.lcomm`
 - `.inst`
 - `.long`
 - `.octa`
 - `.option`
+- `.private_extern`
 - `.p2align`
 - `.pushsection`
 - `.popsection`
@@ -525,22 +529,16 @@ The following directives are guaranteed to be supported by the assembler:
 - `.section`
 - `.set`
 - `.short`
+- `.size`
 - `.skip`
 - `.sleb128`
 - `.space`
 - `.string`
 - `.text`
+- `.type`
 - `.uleb128`
 - `.word`
 
-The following directives are guaranteed to be supported for `global_asm` only:
-
-- `.alt_entry`
-- `.globl`
-- `.global`
-- `.private_extern`
-- `.size`
-- `.type`
 
 
 #### Target Specific Directive Support
@@ -592,23 +590,17 @@ On x86 targets, both 32-bit and 64-bit, the following additional directives are 
 - `.att_syntax`
 - `.intel_syntax`
 - `.nops`
+- `.code16`
+- `.code32`
+- `.code64`
 
 Use of the `.att_syntax` and `.intel_syntax` directives with no parameters (or with parameters equivalent to the defaults) is supported, but the syntax must be restored to the option at entry (`.intel_syntax` without the `att_syntax` asm option, or `.att_syntax` with that option) or the behavior is undefined (the compiled output may be corrupted as a result). Use of `.att_syntax` and `.intel_syntax` with a non-default option (such as `.intel_syntax prefix` or `.att_syntax noprefix`) is unsupported. If operand interpolations are used between setting the syntax mode with one of these directives, and restoring it to the block's default, the behaviour is undefined.
 
-On x86 for `global_asm!` only, the following additional directives are guaranteed to be supported (it is unspecified whether `.code16` or `.code32` are supported for `asm!()`):
-
-- `.code16`
-- `.code32`
+Use of `.code16`, `.code32`, and `.code64` directives are only supported if the state is reset to the default before exiting the assembly block.
+32-bit x86 uses `.code32` by default, and x86_64 uses `.code64` by default. 
 
 
 ##### ARM (32-bit)
-
-On ARM for `global_asm!` only, the following additional directives are guaranteed to be supported:
-
-- `.code`
-- `.thumb`
-- `.thumb_func`
-
 
 On ARM, the following additional directives are guaranteed to be supported:
 
@@ -617,4 +609,8 @@ On ARM, the following additional directives are guaranteed to be supported:
 - `.fnend`
 - `.save`
 - `.movsp`
+- `.code`
+- `.thumb`
+- `.thumb_func`
+
 

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -517,6 +517,29 @@ The following directives are guaranteed to be supported by the assembler:
 .text
 .bss
 .data
+.def
+.endef
+.scl
+.comm
+.lcomm
+.option
+```
+
+The following directives are guaranteed to be supported for `global_asm` only:
+```as
+.alt_entry
+.private_extern
+.globl
+.global
+```
+
+#### Target Specific Directive Support
+
+##### Dwarf Unwinding
+
+The following directives are supported on ELF targets that support DWARF unwind info:
+
+```as
 .cfi_adjust_cfa_offset
 .cfi_def_cfa
 .cfi_def_cfa_offset
@@ -538,9 +561,22 @@ The following directives are guaranteed to be supported by the assembler:
 .cfi_startproc
 .cfi_undefined
 .cfi_window_save
-.comm
-.lcomm
 ```
+
+##### Structured Exception Handling
+
+On targets with structured exception Handling, the following additional directives are guaranteed to be supported:
+```as
+.seh_endproc
+.seh_endprologue
+.seh_proc
+.seh_pushreg
+.seh_savereg
+.seh_setframe
+.seh_stackalloc
+```
+
+##### x86
 
 On x86, the following additional directives are guaranteed to be supported:
 ```as
@@ -551,4 +587,21 @@ On x86 for `global_asm!` only, the following additional directives are guarantee
 ```as
 .code16
 .code32
+```
+
+##### ARM
+
+On ARM for `global_asm!` only, the following additional directives are guaranteed to be supported:
+```as
+.code 
+.thumb
+.thumb_func
+```
+
+On ARM, the following additional directives are guaranteed to be supported:
+```as
+.fnstart
+.fnend
+.save
+.movsp
 ```

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -87,7 +87,7 @@ On x86, the `.intel_syntax noprefix` mode of GAS is used by default.
 On ARM, the `.syntax unified` mode is used.
 These targets impose an additional restriction on the assembly code: any assembler state (e.g. the current section which can be changed with `.section`) must be restored to its original value at the end of the asm string.
 Assembly code that does not conform to the GAS syntax will result in assembler-specific behavior. 
-Further constraints on the directives used by inline assembly are indicated by [Directives Support](#directives-support). 
+Further constraints on the directives used by the assembly are indicated by [Directives Support](#directives-support). 
 
 [format-syntax]: ../std/fmt/index.html#syntax
 [rfc-2795]: https://github.com/rust-lang/rfcs/pull/2795
@@ -481,10 +481,8 @@ To avoid undefined behavior, these rules must be followed when using function-sc
 
 ### Directives Support
 
-Inline assembly supports a subset of the directives supported by both GNU AS and LLVM's internal assembler, given as follows.
+Inline ASM supports a subset of the directives supported by both GNU AS and LLVM's internal assembler, given as follows.
 The result of using other directives is assembler-specific (and may cause an error, or may be accepted as-is).
-
-If inline assembly includes any "stateful" directive that modifies how subsequent assembly is processed, the block must undo the effects of any such directives before the inline assembly ends.
 
 The following directives are guaranteed to be supported by the assembler:
 
@@ -492,59 +490,56 @@ The following directives are guaranteed to be supported by the assembler:
 - `.2byte`
 - `.4byte`
 - `.8byte`
-- `.byte`
-- `.short`
-- `.word`
-- `.long`
-- `.quad`
-- `.float`
-- `.double`
-- `.octa`
-- `.sleb128`
-- `.uleb128`
+- `.align`
 - `.ascii`
 - `.asciz`
-- `.string`
-- `.skip`
-- `.space`
 - `.balign`
 - `.balignl`
 - `.balignw`
 - `.balign`
 - `.balignl`
 - `.balignw`
-- `.fill`
-- `.section`
-- `.pushsection`
-- `.popsection`
-- `.subsection`
-- `.text`
 - `.bss`
+- `.byte`
+- `.comm`
 - `.data`
 - `.def`
+- `.double`
 - `.endef`
-- `.scl`
-- `.comm`
-- `.lcomm`
-- `.option`
 - `.equ`
 - `.equiv`
 - `.eqv`
-- `.set`
-- `.align`
+- `.fill`
+- `.float`
+- `.lcomm`
 - `.inst`
+- `.long`
+- `.octa`
+- `.option`
 - `.p2align`
-- `.bundle_align_mode`
-- `.bundle_lock`
-- `.bundle_unlock`
-- `.symver`
+- `.pushsection`
+- `.popsection`
+- `.quad`
+- `.scl`
+- `.section`
+- `.set`
+- `.short`
+- `.skip`
+- `.sleb128`
+- `.space`
+- `.string`
+- `.text`
+- `.uleb128`
+- `.word`
+
+
 
 The following directives are guaranteed to be supported for `global_asm` only:
 
 - `.alt_entry`
-- `.private_extern`
 - `.globl`
 - `.global`
+- `.private_extern`
 - `.size`
 - `.type`
 
@@ -592,18 +587,21 @@ On targets with structured exception Handling, the following additional directiv
 - `.seh_stackalloc`
 
 
-##### x86 (32-bit and 64-bit)
+##### x86
 
-On x86 targets, both 32-bit and 64-bit, the following additional directives are guaranteed to be supported:
+On x86, the following additional directives are guaranteed to be supported:
+- `.att_syntax`
+- `.intel_syntax`
 - `.nops`
 
-On x86 for `global_asm!` only, the following additional directives are guaranteed to be supported (it is unspecified whether `.code16` or `.code32` are supported for `asm!()`):
+Use of the `.att_syntax` and `.intel_syntax` with no parameters is supported, but the syntax must be restored to the option at entry (`.intel_syntax` without the `att_syntax` asm option, or `.att_syntax` with that option) or the behaviour is undefined (the output of the compiler may be corrupted as a result). Use of `.att_syntax` and `.intel_syntax` with an option (such as `.intel_syntax prefix` or `.att_syntax noprefix`) is unsupported and results in assembler-dependant behaviour. 
 
+On x86 for `global_asm!` only, the following additional directives are guaranteed to be supported:
 - `.code16`
 - `.code32`
 
 
-##### ARM
+##### ARM (32-bit only)
 
 On ARM for `global_asm!` only, the following additional directives are guaranteed to be supported:
 
@@ -614,8 +612,9 @@ On ARM for `global_asm!` only, the following additional directives are guarantee
 
 On ARM, the following additional directives are guaranteed to be supported:
 
+- `.even`
 - `.fnstart`
 - `.fnend`
-- `.save`
 - `.movsp`
-- `.even`
+- `.save`
+

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -594,7 +594,7 @@ On x86, the following additional directives are guaranteed to be supported:
 - `.intel_syntax`
 - `.nops`
 
-Use of the `.att_syntax` and `.intel_syntax` with no parameters is supported, but the syntax must be restored to the option at entry (`.intel_syntax` without the `att_syntax` asm option, or `.att_syntax` with that option) or the behaviour is undefined (the output of the compiler may be corrupted as a result). Use of `.att_syntax` and `.intel_syntax` with an option (such as `.intel_syntax prefix` or `.att_syntax noprefix`) is unsupported and results in assembler-dependant behaviour. 
+Use of the `.att_syntax` and `.intel_syntax` with no parameters is supported, but the syntax must be restored to the option at entry (`.intel_syntax` without the `att_syntax` asm option, or `.att_syntax` with that option) or the behaviour is undefined (the output of the compiler may be corrupted as a result). Use of `.att_syntax` and `.intel_syntax` with an option (such as `.intel_syntax prefix` or `.att_syntax noprefix`) is unsupported and results in assembler-dependant behaviour. If operand interpolations are used between setting the syntax mode with one of these directives, and restoring it to the block's default, the behaviour is undefined.
 
 On x86 for `global_asm!` only, the following additional directives are guaranteed to be supported:
 - `.code16`

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -528,6 +528,8 @@ The following directives are guaranteed to be supported by the assembler:
 - `.lcomm`
 - `.option`
 - `.equ`
+- `.equiv`
+- `.eqv`
 - `.set`
 - `.align`
 - `.inst`

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -601,7 +601,7 @@ On x86 for `global_asm!` only, the following additional directives are guarantee
 - `.code32`
 
 
-##### ARM
+##### ARM (32-bit)
 
 On ARM for `global_asm!` only, the following additional directives are guaranteed to be supported:
 


### PR DESCRIPTION
This seeks to limit the directives guaranteed to be supported by inline assembly to a subset of those supported by LLVM and GNU AS. The list is chosen as a compromise between utility and implementability, and may be increased in the future.

See discussions here:
<https://rust-lang.zulipchat.com/#narrow/stream/213817-t-lang/topic/asm!.20and.20backends> and <https://rust-lang.zulipchat.com/#narrow/stream/216763-project-inline-asm/topic/Defect.20Report.3A.20GNU.20AS.20support>

CC: @joshtriplett 