### PR TITLE
inline-asm.md. Fix `.intel_syntax` directive

### DIFF
--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -587,19 +587,15 @@ On targets with structured exception Handling, the following additional directiv
 ##### x86 (32-bit and 64-bit)
 
 On x86 targets, both 32-bit and 64-bit, the following additional directives are guaranteed to be supported:
-- `.att_syntax`
-- `.intel_syntax`
 - `.nops`
 - `.code16`
 - `.code32`
 - `.code64`
 
-Use of the `.att_syntax` and `.intel_syntax` directives with the default parameters (`prefix` for `.att_syntax`, `noprefix` for `.intel_syntax`) is supported, but the syntax must be restored to the option at entry (`.intel_syntax noprefix` without the `att_syntax` asm option, or `.att_syntax prefix` with that option) or the behavior is undefined (the compiled output may be corrupted as a result).
-Use of `.att_syntax` and `.intel_syntax` with a non-default option or without an option (such as `.intel_syntax prefix` or `.att_syntax noprefix`) is unsupported, and has assembler specific behaviour.
-If operand interpolations are used between setting the syntax mode with one of these directives, and restoring it to the block's default, the behaviour is undefined.
 
 Use of `.code16`, `.code32`, and `.code64` directives are only supported if the state is reset to the default before exiting the assembly block.
 32-bit x86 uses `.code32` by default, and x86_64 uses `.code64` by default.
+
 
 
 ##### ARM (32-bit)

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -594,8 +594,8 @@ On x86 targets, both 32-bit and 64-bit, the following additional directives are 
 - `.code32`
 - `.code64`
 
-Use of the `.att_syntax` and `.intel_syntax` directives with no parameters (or with parameters equivalent to the defaults) is supported, but the syntax must be restored to the option at entry (`.intel_syntax` without the `att_syntax` asm option, or `.att_syntax` with that option) or the behavior is undefined (the compiled output may be corrupted as a result).
-Use of `.att_syntax` and `.intel_syntax` with a non-default option (such as `.intel_syntax prefix` or `.att_syntax noprefix`) is unsupported.
+Use of the `.att_syntax` and `.intel_syntax` directives with the default parameters (`prefix` for `.att_syntax`, `noprefix` for `.intel_syntax`) is supported, but the syntax must be restored to the option at entry (`.intel_syntax noprefix` without the `att_syntax` asm option, or `.att_syntax prefix` with that option) or the behavior is undefined (the compiled output may be corrupted as a result).
+Use of `.att_syntax` and `.intel_syntax` with a non-default option or without an option (such as `.intel_syntax prefix` or `.att_syntax noprefix`) is unsupported, and has assembler specific behaviour.
 If operand interpolations are used between setting the syntax mode with one of these directives, and restoring it to the block's default, the behaviour is undefined.
 
 Use of `.code16`, `.code32`, and `.code64` directives are only supported if the state is reset to the default before exiting the assembly block.


### PR DESCRIPTION
See: https://rust-lang.zulipchat.com/#narrow/stream/216763-project-inline-asm

The current supported directives list has `.intel_syntax` and `.att_syntax` without options supported, and claims them to be the default option (for no `att_syntax` option vs. `att_syntax` option). However, the default behaviour of the `.intel_syntax` directive differ between llvm-mc and gnu as, and GNU AS differs from the guaranteed behaviour: See https://godbolt.org/z/3js4Pfds7 (GNU AS) vs. https://godbolt.org/z/rKhqPxKvr (llvm-mc).

This PR removes the guaranteed support for the no-parameter form of`.intel_syntax`, and from `.att_syntax` as well to mirror.
