### PR TITLE
Numeric literal expressions and literal suffixes

### DIFF
--- a/src/expressions/literal-expr.md
+++ b/src/expressions/literal-expr.md
@@ -59,6 +59,18 @@ let a: u64 = 123;                  // type u64
 0usize;                            // type usize
 ```
 
+The value of the expression is determined from the string representation of the token as follows:
+
+* An integer radix is chosen by inspecting the first two characters of the string: `0b` indicates radix 2, `0o` indicates radix 8, `0x` indicates radix 16; otherwise the radix is 10.
+
+* If the radix is not 10, the first two characters are removed from the string.
+
+* Any underscores are removed from the string.
+
+* The string is converted to a `u128` value as if by [`u128::from_str_radix`] with the chosen radix.
+
+* The `u128` value is converted to the expression's type via a [numeric cast].
+
 ## Floating-point literal expressions
 
 A floating-point literal expression consists of a single [FLOAT_LITERAL] token.
@@ -87,8 +99,10 @@ let x: f64 = 2.; // type f64
 [constant expression]: ../const_eval.md#constant-expressions
 [floating-point types]: ../types/numeric.md#floating-point-types
 [literal tokens]: ../tokens.md#literals
+[numeric cast]: operator-expr.md#numeric-cast
 [numeric types]: ../types/numeric.md
 [suffix]: ../tokens.md#suffixes
+[`u128::from_str_radix`]: ../../core/primitive.u128.md#method.from_str_radix
 [CHAR_LITERAL]: ../tokens.md#character-literals
 [STRING_LITERAL]: ../tokens.md#string-literals
 [RAW_STRING_LITERAL]: ../tokens.md#raw-string-literals

--- a/src/expressions/literal-expr.md
+++ b/src/expressions/literal-expr.md
@@ -108,6 +108,10 @@ The value of the expression is determined from the string representation of the 
 
 * The string is converted to the expression's type as if by [`f32::from_str`] or [`f64::from_str`].
 
+> **Note**: `inf` and `NaN` are not literal tokens.
+> The [`f32::INFINITY`], [`f64::INFINITY`], [`f32::NAN`], and [`f64::NAN`] constants can be used instead of literal expressions.
+> A literal large enough to be evaluated as infinite will trigger the `overflowing_literals` lint check.
+
 [constant expression]: ../const_eval.md#constant-expressions
 [floating-point types]: ../types/numeric.md#floating-point-types
 [lint check]: ../attributes/diagnostics.md#lint-check-attributes
@@ -116,7 +120,11 @@ The value of the expression is determined from the string representation of the 
 [numeric types]: ../types/numeric.md
 [suffix]: ../tokens.md#suffixes
 [`f32::from_str`]: ../../core/primitive.f32.md#method.from_str
+[`f32::INFINITY`]: ../../core/primitive.f32.md#associatedconstant.INFINITY
+[`f32::NAN`]: ../../core/primitive.f32.md#associatedconstant.NAN
 [`f64::from_str`]: ../../core/primitive.f64.md#method.from_str
+[`f64::INFINITY`]: ../../core/primitive.f64.md#associatedconstant.INFINITY
+[`f64::NAN`]: ../../core/primitive.f64.md#associatedconstant.NAN
 [`u128::from_str_radix`]: ../../core/primitive.u128.md#method.from_str_radix
 [CHAR_LITERAL]: ../tokens.md#character-literals
 [STRING_LITERAL]: ../tokens.md#string-literals

--- a/src/expressions/literal-expr.md
+++ b/src/expressions/literal-expr.md
@@ -74,6 +74,9 @@ If the value does not fit in `u128`, the expression is rejected by the parser.
 
 * The `u128` value is converted to the expression's type via a [numeric cast].
 
+> **Note**: The final cast will truncate the value of the literal if it does not fit in the expression's type.
+> There is a [lint check] named `overflowing_literals`, defaulting to `deny`, which rejects expressions where this occurs.
+
 ## Floating-point literal expressions
 
 A floating-point literal expression consists of a single [FLOAT_LITERAL] token.
@@ -101,6 +104,7 @@ let x: f64 = 2.; // type f64
 
 [constant expression]: ../const_eval.md#constant-expressions
 [floating-point types]: ../types/numeric.md#floating-point-types
+[lint check]: ../attributes/diagnostics.md#lint-check-attributes
 [literal tokens]: ../tokens.md#literals
 [numeric cast]: operator-expr.md#numeric-cast
 [numeric types]: ../types/numeric.md

--- a/src/expressions/literal-expr.md
+++ b/src/expressions/literal-expr.md
@@ -75,7 +75,7 @@ If the value does not fit in `u128`, the expression is rejected by the parser.
 * The `u128` value is converted to the expression's type via a [numeric cast].
 
 > **Note**: The final cast will truncate the value of the literal if it does not fit in the expression's type.
-> There is a [lint check] named `overflowing_literals`, defaulting to `deny`, which rejects expressions where this occurs.
+> `rustc` includes a [lint check] named `overflowing_literals`, defaulting to `deny`, which rejects expressions where this occurs.
 
 > **Note**: `-1i8`, for example, is an application of the [negation operator] to the literal expression `1i8`, not a single integer literal expression.
 
@@ -114,7 +114,7 @@ The value of the expression is determined from the string representation of the 
 
 > **Note**: `inf` and `NaN` are not literal tokens.
 > The [`f32::INFINITY`], [`f64::INFINITY`], [`f32::NAN`], and [`f64::NAN`] constants can be used instead of literal expressions.
-> A literal large enough to be evaluated as infinite will trigger the `overflowing_literals` lint check.
+> In `rustc`, a literal large enough to be evaluated as infinite will trigger the `overflowing_literals` lint check.
 
 [constant expression]: ../const_eval.md#constant-expressions
 [floating-point types]: ../types/numeric.md#floating-point-types

--- a/src/expressions/literal-expr.md
+++ b/src/expressions/literal-expr.md
@@ -63,7 +63,12 @@ let a: u64 = 123;                  // type u64
 
 The value of the expression is determined from the string representation of the token as follows:
 
-* An integer radix is chosen by inspecting the first two characters of the string: `0b` indicates radix 2, `0o` indicates radix 8, `0x` indicates radix 16; otherwise the radix is 10.
+* An integer radix is chosen by inspecting the first two characters of the string, as follows:
+
+    * `0b` indicates radix 2
+    * `0o` indicates radix 8
+    * `0x` indicates radix 16
+    * otherwise the radix is 10.
 
 * If the radix is not 10, the first two characters are removed from the string.
 

--- a/src/expressions/literal-expr.md
+++ b/src/expressions/literal-expr.md
@@ -59,7 +59,33 @@ let a: u64 = 123;                  // type u64
 0usize;                            // type usize
 ```
 
+## Floating-point literal expressions
+
+A floating-point literal expression consists of a single [FLOAT_LITERAL] token.
+
+If the token has a [suffix], the suffix will be the name of one of the [primitive floating-point types][floating-point types]: `f32` or `f64`, and the expression has that type.
+
+If the token has no suffix, the expression's type is determined by type inference:
+
+* If a floating-point type can be _uniquely_ determined from the surrounding program context, the expression has that type.
+
+* If the program context under-constrains the type, it defaults to `f64`.
+
+* If the program context over-constrains the type, it is considered a static type error.
+
+Examples of floating-point literal expressions:
+
+```rust
+123.0f64;        // type f64
+0.1f64;          // type f64
+0.1f32;          // type f32
+12E+99_f64;      // type f64
+5f32;            // type f32
+let x: f64 = 2.; // type f64
+```
+
 [constant expression]: ../const_eval.md#constant-expressions
+[floating-point types]: ../types/numeric.md#floating-point-types
 [literal tokens]: ../tokens.md#literals
 [numeric types]: ../types/numeric.md
 [suffix]: ../tokens.md#suffixes

--- a/src/expressions/literal-expr.md
+++ b/src/expressions/literal-expr.md
@@ -102,6 +102,12 @@ Examples of floating-point literal expressions:
 let x: f64 = 2.; // type f64
 ```
 
+The value of the expression is determined from the string representation of the token as follows:
+
+* Any underscores are removed from the string.
+
+* The string is converted to the expression's type as if by [`f32::from_str`] or [`f64::from_str`].
+
 [constant expression]: ../const_eval.md#constant-expressions
 [floating-point types]: ../types/numeric.md#floating-point-types
 [lint check]: ../attributes/diagnostics.md#lint-check-attributes
@@ -109,6 +115,8 @@ let x: f64 = 2.; // type f64
 [numeric cast]: operator-expr.md#numeric-cast
 [numeric types]: ../types/numeric.md
 [suffix]: ../tokens.md#suffixes
+[`f32::from_str`]: ../../core/primitive.f32.md#method.from_str
+[`f64::from_str`]: ../../core/primitive.f64.md#method.from_str
 [`u128::from_str_radix`]: ../../core/primitive.u128.md#method.from_str_radix
 [CHAR_LITERAL]: ../tokens.md#character-literals
 [STRING_LITERAL]: ../tokens.md#string-literals

--- a/src/expressions/literal-expr.md
+++ b/src/expressions/literal-expr.md
@@ -77,6 +77,8 @@ If the value does not fit in `u128`, the expression is rejected by the parser.
 > **Note**: The final cast will truncate the value of the literal if it does not fit in the expression's type.
 > There is a [lint check] named `overflowing_literals`, defaulting to `deny`, which rejects expressions where this occurs.
 
+> **Note**: `-1i8`, for example, is an application of the [negation operator] to the literal expression `1i8`, not a single integer literal expression.
+
 ## Floating-point literal expressions
 
 A floating-point literal expression consists of a single [FLOAT_LITERAL] token.
@@ -108,6 +110,8 @@ The value of the expression is determined from the string representation of the 
 
 * The string is converted to the expression's type as if by [`f32::from_str`] or [`f64::from_str`].
 
+> **Note**: `-1.0`, for example, is an application of the [negation operator] to the literal expression `1.0`, not a single floating-point literal expression.
+
 > **Note**: `inf` and `NaN` are not literal tokens.
 > The [`f32::INFINITY`], [`f64::INFINITY`], [`f32::NAN`], and [`f64::NAN`] constants can be used instead of literal expressions.
 > A literal large enough to be evaluated as infinite will trigger the `overflowing_literals` lint check.
@@ -119,6 +123,7 @@ The value of the expression is determined from the string representation of the 
 [numeric cast]: operator-expr.md#numeric-cast
 [numeric types]: ../types/numeric.md
 [suffix]: ../tokens.md#suffixes
+[negation operator]: operator-expr.md#negation-operators
 [`f32::from_str`]: ../../core/primitive.f32.md#method.from_str
 [`f32::INFINITY`]: ../../core/primitive.f32.md#associatedconstant.INFINITY
 [`f32::NAN`]: ../../core/primitive.f32.md#associatedconstant.NAN

--- a/src/expressions/literal-expr.md
+++ b/src/expressions/literal-expr.md
@@ -12,8 +12,11 @@
 > &nbsp;&nbsp; | [FLOAT_LITERAL]\
 > &nbsp;&nbsp; | [BOOLEAN_LITERAL]
 
-A _literal expression_ consists of one of the [literal](../tokens.md#literals) forms described earlier.
-It directly describes a number, character, string, or boolean value.
+A _literal expression_ is an expression consisting of a single token, rather than a sequence of tokens, that immediately and directly denotes the value it evaluates to, rather than referring to it by name or some other evaluation rule.
+
+A literal is a form of [constant expression], so is evaluated (primarily) at compile time.
+
+Each of the lexical [literal][literal tokens] forms described earlier can make up a literal expression.
 
 ```rust
 "hello";   // string type
@@ -21,6 +24,8 @@ It directly describes a number, character, string, or boolean value.
 5;         // integer type
 ```
 
+[constant expression]: ../const_eval.md#constant-expressions
+[literal tokens]: ../tokens.md#literals
 [CHAR_LITERAL]: ../tokens.md#character-literals
 [STRING_LITERAL]: ../tokens.md#string-literals
 [RAW_STRING_LITERAL]: ../tokens.md#raw-string-literals

--- a/src/expressions/literal-expr.md
+++ b/src/expressions/literal-expr.md
@@ -26,6 +26,30 @@ Each of the lexical [literal][literal tokens] forms described earlier can make u
 5;         // integer type
 ```
 
+## Character literal expressions
+
+A character literal expression consists of a single [CHAR_LITERAL] token.
+
+> **Note**: This section is incomplete.
+
+## String literal expressions
+
+A string literal expression consists of a single [STRING_LITERAL] or [RAW_STRING_LITERAL] token.
+
+> **Note**: This section is incomplete.
+
+## Byte literal expressions
+
+A byte literal expression consists of a single [BYTE_LITERAL] token.
+
+> **Note**: This section is incomplete.
+
+## Byte string literal expressions
+
+A string literal expression consists of a single [BYTE_STRING_LITERAL] or [RAW_BYTE_STRING_LITERAL] token.
+
+> **Note**: This section is incomplete.
+
 ## Integer literal expressions
 
 An integer literal expression consists of a single [INTEGER_LITERAL] token.
@@ -120,6 +144,12 @@ The value of the expression is determined from the string representation of the 
 > **Note**: `inf` and `NaN` are not literal tokens.
 > The [`f32::INFINITY`], [`f64::INFINITY`], [`f32::NAN`], and [`f64::NAN`] constants can be used instead of literal expressions.
 > In `rustc`, a literal large enough to be evaluated as infinite will trigger the `overflowing_literals` lint check.
+
+## Boolean literal expressions
+
+A boolean literal expression consists of a single [BOOLEAN_LITERAL] token.
+
+> **Note**: This section is incomplete.
 
 [constant expression]: ../const_eval.md#constant-expressions
 [floating-point types]: ../types/numeric.md#floating-point-types

--- a/src/expressions/literal-expr.md
+++ b/src/expressions/literal-expr.md
@@ -8,9 +8,11 @@
 > &nbsp;&nbsp; | [BYTE_LITERAL]\
 > &nbsp;&nbsp; | [BYTE_STRING_LITERAL]\
 > &nbsp;&nbsp; | [RAW_BYTE_STRING_LITERAL]\
-> &nbsp;&nbsp; | [INTEGER_LITERAL]\
+> &nbsp;&nbsp; | [INTEGER_LITERAL][^out-of-range]\
 > &nbsp;&nbsp; | [FLOAT_LITERAL]\
 > &nbsp;&nbsp; | [BOOLEAN_LITERAL]
+>
+> [^out-of-range]: A value ≥ 2<sup>128</sup> is not allowed.
 
 A _literal expression_ is an expression consisting of a single token, rather than a sequence of tokens, that immediately and directly denotes the value it evaluates to, rather than referring to it by name or some other evaluation rule.
 
@@ -68,6 +70,7 @@ The value of the expression is determined from the string representation of the 
 * Any underscores are removed from the string.
 
 * The string is converted to a `u128` value as if by [`u128::from_str_radix`] with the chosen radix.
+If the value does not fit in `u128`, the expression is rejected by the parser.
 
 * The `u128` value is converted to the expression's type via a [numeric cast].
 

--- a/src/expressions/literal-expr.md
+++ b/src/expressions/literal-expr.md
@@ -24,8 +24,45 @@ Each of the lexical [literal][literal tokens] forms described earlier can make u
 5;         // integer type
 ```
 
+## Integer literal expressions
+
+An integer literal expression consists of a single [INTEGER_LITERAL] token.
+
+If the token has a [suffix], the suffix will be the name of one of the [primitive integer types][numeric types]: `u8`, `i8`, `u16`, `i16`, `u32`, `i32`, `u64`, `i64`, `u128`, `i128`, `usize`, or `isize`, and the expression has that type.
+
+If the token has no suffix, the expression's type is determined by type inference:
+
+* If an integer type can be _uniquely_ determined from the surrounding program context, the expression has that type.
+
+* If the program context under-constrains the type, it defaults to the signed 32-bit integer `i32`.
+
+* If the program context over-constrains the type, it is considered a static type error.
+
+Examples of integer literal expressions:
+
+```rust
+123;                               // type i32
+123i32;                            // type i32
+123u32;                            // type u32
+123_u32;                           // type u32
+let a: u64 = 123;                  // type u64
+
+0xff;                              // type i32
+0xff_u8;                           // type u8
+
+0o70;                              // type i32
+0o70_i16;                          // type i16
+
+0b1111_1111_1001_0000;             // type i32
+0b1111_1111_1001_0000i64;          // type i64
+
+0usize;                            // type usize
+```
+
 [constant expression]: ../const_eval.md#constant-expressions
 [literal tokens]: ../tokens.md#literals
+[numeric types]: ../types/numeric.md
+[suffix]: ../tokens.md#suffixes
 [CHAR_LITERAL]: ../tokens.md#character-literals
 [STRING_LITERAL]: ../tokens.md#string-literals
 [RAW_STRING_LITERAL]: ../tokens.md#raw-string-literals

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -487,9 +487,13 @@ Note that `-1.0`, for example, is analyzed as two tokens: `-` followed by `1.0`.
 
 > **<sup>Lexer</sup>**\
 > NUMBER_PSEUDOLITERAL :\
-> &nbsp;&nbsp; &nbsp;&nbsp; DEC_LITERAL ( . DEC_LITERAL)? FLOAT_EXPONENT NUMBER_PSEUDOLITERAL_SUFFIX\
-> &nbsp;&nbsp; | DEC_LITERAL ( . DEC_LITERAL)? NUMBER_PSEUDOLITERAL_SUFFIX_NO_E\
-> &nbsp;&nbsp; | ( BIN_LITERAL | OCT_LITERAL | HEX_LITERAL ) NUMBER_PSEUDOLITERAL_SUFFIX_NO_E
+> &nbsp;&nbsp; &nbsp;&nbsp; DEC_LITERAL ( . DEC_LITERAL )<sup>?</sup> FLOAT_EXPONENT\
+> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; ( NUMBER_PSEUDOLITERAL_SUFFIX | INTEGER_SUFFIX )\
+> &nbsp;&nbsp; | DEC_LITERAL . DEC_LITERAL\
+> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; ( NUMBER_PSEUDOLITERAL_SUFFIX_NO_E | INTEGER SUFFIX )\
+> &nbsp;&nbsp; | DEC_LITERAL NUMBER_PSEUDOLITERAL_SUFFIX_NO_E\
+> &nbsp;&nbsp; | ( BIN_LITERAL | OCT_LITERAL | HEX_LITERAL )\
+> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; ( NUMBER_PSEUDOLITERAL_SUFFIX_NO_E | FLOAT_SUFFIX )
 >
 > NUMBER_PSEUDOLITERAL_SUFFIX :\
 > &nbsp;&nbsp; IDENTIFIER_OR_KEYWORD <sub>_not matching INTEGER_SUFFIX or FLOAT_SUFFIX_</sub>
@@ -509,6 +513,8 @@ Examples of such tokens:
 2e5f80;
 2e5e6;
 2.0e5e6;
+1.3e10u64;
+0b1111_f32;
 ```
 
 #### Reserved forms similar to number literals

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -359,43 +359,29 @@ An _integer literal_ has one of four forms:
   (`0b`) and continues as any mixture (with at least one digit) of binary digits
   and underscores.
 
-Like any literal, an integer literal may be followed (immediately,
-without any spaces) by an _integer suffix_, which forcibly sets the
-type of the literal. The integer suffix must be the name of one of the
-integral types: `u8`, `i8`, `u16`, `i16`, `u32`, `i32`, `u64`, `i64`,
-`u128`, `i128`, `usize`, or `isize`.
-
-The type of an _unsuffixed_ integer literal is determined by type inference:
-
-* If an integer type can be _uniquely_ determined from the surrounding
-  program context, the unsuffixed integer literal has that type.
-
-* If the program context under-constrains the type, it defaults to the
-  signed 32-bit integer `i32`.
-
-* If the program context over-constrains the type, it is considered a
-  static type error.
+Like any literal, an integer literal may be followed (immediately, without any spaces) by an _integer suffix_, which must be the name of one of the [primitive integer types][numeric types]:
+`u8`, `i8`, `u16`, `i16`, `u32`, `i32`, `u64`, `i64`, `u128`, `i128`, `usize`, or `isize`.
+See [literal expressions] for the effect of these suffixes.
 
 Examples of integer literals of various forms:
 
 ```rust
-123;                               // type i32
-123i32;                            // type i32
-123u32;                            // type u32
-123_u32;                           // type u32
-let a: u64 = 123;                  // type u64
+123;
+123i32;
+123u32;
+123_u32;
 
-0xff;                              // type i32
-0xff_u8;                           // type u8
+0xff;
+0xff_u8;
 
-0o70;                              // type i32
-0o70_i16;                          // type i16
+0o70;
+0o70_i16;
 
-0b1111_1111_1001_0000;             // type i32
-0b1111_1111_1001_0000i64;          // type i64
-0b________1;                       // type i32
+0b1111_1111_1001_0000;
+0b1111_1111_1001_0000i64;
+0b________1;
 
-0usize;                            // type usize
+0usize;
 ```
 
 Examples of invalid integer literals:
@@ -671,6 +657,7 @@ Similarly the `r`, `b`, and `br` prefixes used in raw string literals, byte lite
 [negation]: expressions/operator-expr.md#negation-operators
 [negative impls]: items/implementations.md
 [never type]: types/never.md
+[numeric types]: types/numeric.md
 [paths]: paths.md
 [patterns]: patterns.md
 [question]: expressions/operator-expr.md#the-question-mark-operator

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -430,8 +430,6 @@ Note that the Rust syntax considers `-1i8` as an application of the [unary minus
 operator] to an integer literal `1i8`, rather than
 a single integer literal.
 
-[unary minus operator]: expressions/operator-expr.md#negation-operators
-
 #### Tuple index
 
 > **<sup>Lexer</sup>**\
@@ -542,8 +540,6 @@ Lifetime parameters and [loop labels] use LIFETIME_OR_LABEL tokens. Any
 LIFETIME_TOKEN will be accepted by the lexer, and for example, can be used in
 macros.
 
-[loop labels]: expressions/loop-expr.md
-
 ## Punctuation
 
 Punctuation symbol tokens are listed here for completeness. Their individual
@@ -609,57 +605,6 @@ them are referred to as "token trees" in [macros].  The three types of brackets 
 | `[` `]` | Square brackets |
 | `(` `)` | Parentheses     |
 
-
-[Inferred types]: types/inferred.md
-[Range patterns]: patterns.md#range-patterns
-[Reference patterns]: patterns.md#reference-patterns
-[Subpattern binding]: patterns.md#identifier-patterns
-[Wildcard patterns]: patterns.md#wildcard-pattern
-[arith]: expressions/operator-expr.md#arithmetic-and-logical-binary-operators
-[array types]: types/array.md
-[assignment]: expressions/operator-expr.md#assignment-expressions
-[attributes]: attributes.md
-[borrow]: expressions/operator-expr.md#borrow-operators
-[closures]: expressions/closure-expr.md
-[comparison]: expressions/operator-expr.md#comparison-operators
-[compound]: expressions/operator-expr.md#compound-assignment-expressions
-[constants]: items/constant-items.md
-[dereference]: expressions/operator-expr.md#the-dereference-operator
-[destructuring assignment]: expressions/underscore-expr.md
-[extern crates]: items/extern-crates.md
-[extern]: items/external-blocks.md
-[field]: expressions/field-expr.md
-[function pointer type]: types/function-pointer.md
-[functions]: items/functions.md
-[generics]: items/generics.md
-[identifier]: identifiers.md
-[if let]: expressions/if-expr.md#if-let-expressions
-[keywords]: keywords.md
-[lazy-bool]: expressions/operator-expr.md#lazy-boolean-operators
-[machine types]: types/numeric.md
-[macros]: macros-by-example.md
-[match]: expressions/match-expr.md
-[negation]: expressions/operator-expr.md#negation-operators
-[negative impls]: items/implementations.md
-[never type]: types/never.md
-[paths]: paths.md
-[patterns]: patterns.md
-[question]: expressions/operator-expr.md#the-question-mark-operator
-[range]: expressions/range-expr.md
-[rangepat]: patterns.md#range-patterns
-[raw pointers]: types/pointer.md#raw-pointers-const-and-mut
-[references]: types/pointer.md
-[sized]: trait-bounds.md#sized
-[struct expressions]: expressions/struct-expr.md
-[trait bounds]: trait-bounds.md
-[tuple index]: expressions/tuple-expr.md#tuple-indexing-expressions
-[tuple structs]: items/structs.md
-[tuple variants]: items/enumerations.md
-[tuples]: types/tuple.md
-[use declarations]: items/use-declarations.md
-[use wildcards]: items/use-declarations.md
-[while let]: expressions/loop-expr.md#predicate-pattern-loops
-
 ## Reserved prefixes
 
 > **<sup>Lexer 2021+</sup>**\
@@ -695,3 +640,55 @@ Similarly the `r`, `b`, and `br` prefixes used in raw string literals, byte lite
 > lexes!{continue'foo}
 > lexes!{match"..." {}}
 > ```
+
+[Inferred types]: types/inferred.md
+[Range patterns]: patterns.md#range-patterns
+[Reference patterns]: patterns.md#reference-patterns
+[Subpattern binding]: patterns.md#identifier-patterns
+[Wildcard patterns]: patterns.md#wildcard-pattern
+[arith]: expressions/operator-expr.md#arithmetic-and-logical-binary-operators
+[array types]: types/array.md
+[assignment]: expressions/operator-expr.md#assignment-expressions
+[attributes]: attributes.md
+[borrow]: expressions/operator-expr.md#borrow-operators
+[closures]: expressions/closure-expr.md
+[comparison]: expressions/operator-expr.md#comparison-operators
+[compound]: expressions/operator-expr.md#compound-assignment-expressions
+[constants]: items/constant-items.md
+[dereference]: expressions/operator-expr.md#the-dereference-operator
+[destructuring assignment]: expressions/underscore-expr.md
+[extern crates]: items/extern-crates.md
+[extern]: items/external-blocks.md
+[field]: expressions/field-expr.md
+[function pointer type]: types/function-pointer.md
+[functions]: items/functions.md
+[generics]: items/generics.md
+[identifier]: identifiers.md
+[if let]: expressions/if-expr.md#if-let-expressions
+[keywords]: keywords.md
+[lazy-bool]: expressions/operator-expr.md#lazy-boolean-operators
+[loop labels]: expressions/loop-expr.md
+[machine types]: types/numeric.md
+[macros]: macros-by-example.md
+[match]: expressions/match-expr.md
+[negation]: expressions/operator-expr.md#negation-operators
+[negative impls]: items/implementations.md
+[never type]: types/never.md
+[paths]: paths.md
+[patterns]: patterns.md
+[question]: expressions/operator-expr.md#the-question-mark-operator
+[range]: expressions/range-expr.md
+[rangepat]: patterns.md#range-patterns
+[raw pointers]: types/pointer.md#raw-pointers-const-and-mut
+[references]: types/pointer.md
+[sized]: trait-bounds.md#sized
+[struct expressions]: expressions/struct-expr.md
+[trait bounds]: trait-bounds.md
+[tuple index]: expressions/tuple-expr.md#tuple-indexing-expressions
+[tuple structs]: items/structs.md
+[tuple variants]: items/enumerations.md
+[tuples]: types/tuple.md
+[unary minus operator]: expressions/operator-expr.md#negation-operators
+[use declarations]: items/use-declarations.md
+[use wildcards]: items/use-declarations.md
+[while let]: expressions/loop-expr.md#predicate-pattern-loops

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -374,6 +374,8 @@ Examples of integer literals of various forms:
 
 0xff;
 0xff_u8;
+0x01_f32; // integer 7986, not floating-point 1.0
+0x01_e3;  // integer 483, not floating-point 1000.0
 
 0o70;
 0o70_i16;

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -444,7 +444,7 @@ let horse = example.0b10;  // ERROR no field named `0b10`
 > **<sup>Lexer</sup>**\
 > FLOAT_LITERAL :\
 > &nbsp;&nbsp; &nbsp;&nbsp; DEC_LITERAL `.`
->   _(not immediately followed by `.`, `_` or an [identifier]_)\
+>   _(not immediately followed by `.`, `_` or an [identifier] or [keyword][keywords]_)\
 > &nbsp;&nbsp; | DEC_LITERAL FLOAT_EXPONENT\
 > &nbsp;&nbsp; | DEC_LITERAL `.` DEC_LITERAL FLOAT_EXPONENT<sup>?</sup>\
 > &nbsp;&nbsp; | DEC_LITERAL (`.` DEC_LITERAL)<sup>?</sup>

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -366,6 +366,7 @@ See [literal expressions] for the effect of these suffixes.
 Examples of integer literals of various forms:
 
 ```rust
+# #![allow(overflowing_literals)]
 123;
 123i32;
 123u32;
@@ -382,6 +383,12 @@ Examples of integer literals of various forms:
 0b________1;
 
 0usize;
+
+// These are too big for their type, but are still valid tokens
+
+128_i8;
+256_u8;
+
 ```
 
 Note that `-1i8`, for example, is analyzed as two tokens: `-` followed by `1i8`.
@@ -398,11 +405,6 @@ Examples of invalid integer literals:
 123AFB43;
 0b0102;
 0o0581;
-
-// integers too big for their type (they overflow)
-
-128_i8;
-256_u8;
 
 // bin, hex, and octal literals must have at least one digit
 

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -501,7 +501,8 @@ Note that `-1.0`, for example, is analyzed as two tokens: `-` followed by `1.0`.
 > NUMBER_PSEUDOLITERAL_SUFFIX_NO_E :\
 > &nbsp;&nbsp; NUMBER_PSEUDOLITERAL_SUFFIX <sub>_not beginning with `e` or `E`_</sub>
 
-As described [above](#suffixes), tokens with the same form as numeric literals other than in the content of their suffix are accepted by the lexer (with the exception of some reserved forms described below).
+Tokenization of numeric literals allows arbitrary suffixes as described in the grammar above.
+These values generate valid tokens, but are not valid [literal expressions], so are usually an error except as macro arguments.
 
 Examples of such tokens:
 ```rust,compile_fail
@@ -531,7 +532,8 @@ Examples of such tokens:
 > &nbsp;&nbsp; | `0x` `_`<sup>\*</sup> _end of input or not HEX_DIGIT_\
 > &nbsp;&nbsp; | DEC_LITERAL ( . DEC_LITERAL)<sup>?</sup> (`e`|`E`) (`+`|`-`)<sup>?</sup> _end of input or not DEC_DIGIT_
 
-The following lexical forms similar to number literals are _reserved forms_:
+The following lexical forms similar to number literals are _reserved forms_.
+Due to the possible ambiguity these raise, they are rejected by the tokenizer instead of being interpreted as separate tokens.
 
 * An unsuffixed binary or octal literal followed, without intervening whitespace, by a decimal digit out of the range for its radix.
 
@@ -542,8 +544,6 @@ The following lexical forms similar to number literals are _reserved forms_:
 * Input which begins with one of the radix prefixes but is not a valid binary, octal, or hexadecimal literal (because it contains no digits).
 
 * Input which has the form of a floating-point literal with no digits in the exponent.
-
-Any input containing one of these reserved forms is reported as an error by the lexer.
 
 Examples of reserved forms:
 

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -448,7 +448,7 @@ let horse = example.0b10;  // ERROR no field named `0b10`
 >                    FLOAT_EXPONENT<sup>?</sup> FLOAT_SUFFIX
 >
 > FLOAT_EXPONENT :\
-> &nbsp;&nbsp; (`e`|`E`) (`+`|`-`)?
+> &nbsp;&nbsp; (`e`|`E`) (`+`|`-`)<sup>?</sup>
 >               (DEC_DIGIT|`_`)<sup>\*</sup> DEC_DIGIT (DEC_DIGIT|`_`)<sup>\*</sup>
 >
 > FLOAT_SUFFIX :\
@@ -529,7 +529,7 @@ Examples of such tokens:
 > &nbsp;&nbsp; | `0b` `_`<sup>\*</sup> _end of input or not BIN_DIGIT_\
 > &nbsp;&nbsp; | `0o` `_`<sup>\*</sup> _end of input or not OCT_DIGIT_\
 > &nbsp;&nbsp; | `0x` `_`<sup>\*</sup> _end of input or not HEX_DIGIT_\
-> &nbsp;&nbsp; | DEC_LITERAL ( . DEC_LITERAL)? (`e`|`E`) (`+`|`-`)? _end of input or not DEC_DIGIT_
+> &nbsp;&nbsp; | DEC_LITERAL ( . DEC_LITERAL)<sup>?</sup> (`e`|`E`) (`+`|`-`)<sup>?</sup> _end of input or not DEC_DIGIT_
 
 The following lexical forms similar to number literals are _reserved forms_:
 

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -515,8 +515,8 @@ Examples of such tokens:
 
 > **<sup>Lexer</sup>**\
 > RESERVED_NUMBER :\
-> &nbsp;&nbsp; &nbsp;&nbsp; BIN_LITERAL \[`2`-`9`]\
-> &nbsp;&nbsp; | OCT_LITERAL \[`8`-`9`]\
+> &nbsp;&nbsp; &nbsp;&nbsp; BIN_LITERAL \[`2`-`9`&ZeroWidthSpace;]\
+> &nbsp;&nbsp; | OCT_LITERAL \[`8`-`9`&ZeroWidthSpace;]\
 > &nbsp;&nbsp; | ( BIN_LITERAL | OCT_LITERAL | HEX_LITERAL ) `.` \
 > &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; _(not immediately followed by `.`, `_` or an [identifier] or [keyword][keywords]_)\
 > &nbsp;&nbsp; | ( BIN_LITERAL | OCT_LITERAL ) `e`\

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -457,11 +457,12 @@ let horse = example.0b10;  // ERROR no field named `0b10`
 > FLOAT_SUFFIX :\
 > &nbsp;&nbsp; `f32` | `f64`
 
-A _floating-point literal_ has one of two forms:
+A _floating-point literal_ has one of three forms:
 
 * A _decimal literal_ followed by a period character `U+002E` (`.`). This is
   optionally followed by another decimal literal, with an optional _exponent_.
 * A single _decimal literal_ followed by an _exponent_.
+* A single _decimal literal_ (in which case a suffix is required).
 
 Like integer literals, a floating-point literal may be followed by a
 suffix, so long as the pre-suffix part does not end with `U+002E` (`.`).

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -384,6 +384,8 @@ Examples of integer literals of various forms:
 0usize;
 ```
 
+Note that `-1i8`, for example, is analyzed as two tokens: `-` followed by `1i8`.
+
 Examples of invalid integer literals:
 
 ```rust,compile_fail
@@ -407,10 +409,6 @@ Examples of invalid integer literals:
 0b_;
 0b____;
 ```
-
-Note that the Rust syntax considers `-1i8` as an application of the [unary minus
-operator] to an integer literal `1i8`, rather than
-a single integer literal.
 
 #### Tuple index
 
@@ -482,6 +480,8 @@ let x: f64 = 2.;
 This last example is different because it is not possible to use the suffix
 syntax with a floating point literal ending in a period. `2.f64` would attempt
 to call a method named `f64` on `2`.
+
+Note that `-1.0`, for example, is analyzed as two tokens: `-` followed by `1.0`.
 
 ### Boolean literals
 

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -398,13 +398,8 @@ Note that `-1i8`, for example, is analyzed as two tokens: `-` followed by `1i8`.
 Examples of invalid integer literals:
 
 ```rust,compile_fail
-// invalid suffixes
-
-0invalidSuffix;
-
 // uses numbers of the wrong base
 
-123AFB43;
 0b0102;
 0o0581;
 
@@ -487,6 +482,42 @@ syntax with a floating point literal ending in a period. `2.f64` would attempt
 to call a method named `f64` on `2`.
 
 Note that `-1.0`, for example, is analyzed as two tokens: `-` followed by `1.0`.
+
+#### Number pseudoliterals
+
+> **<sup>Lexer</sup>**\
+> NUMBER_PSEUDOLITERAL :\
+> &nbsp;&nbsp; &nbsp;&nbsp; DEC_LITERAL ( . DEC_LITERAL)? FLOAT_EXPONENT NUMBER_PSEUDOLITERAL_SUFFIX\
+> &nbsp;&nbsp; | DEC_LITERAL ( . DEC_LITERAL)? NUMBER_PSEUDOLITERAL_SUFFIX_NO_E\
+> &nbsp;&nbsp; | ( BIN_LITERAL | OCT_LITERAL | HEX_LITERAL ) NUMBER_PSEUDOLITERAL_SUFFIX_NO_E
+>
+> NUMBER_PSEUDOLITERAL_SUFFIX :\
+> &nbsp;&nbsp; IDENTIFIER_OR_KEYWORD <sub>_not matching INTEGER_SUFFIX or FLOAT_SUFFIX_</sub>
+>
+> NUMBER_PSEUDOLITERAL_SUFFIX_NO_E :\
+> &nbsp;&nbsp; NUMBER_PSEUDOLITERAL_SUFFIX <sub>_not beginning with `e` or `E`_</sub>
+
+As described [above](#suffixes), tokens with the same form as numeric literals other than in the content of their suffix are accepted by the lexer, with the exception of some cases in which the suffix begins with `e` or `E`.
+
+Examples of such tokens:
+```rust,compile_fail
+0invalidSuffix;
+123AFB43;
+0b010a;
+0xAB_CD_EF_GH;
+2.0f80;
+2e5f80;
+2e5e6;
+2.0e5e6;
+
+// Lexer errors:
+2e;
+2.0e;
+0b101e;
+2em;
+2.0em;
+0b101em;
+```
 
 ### Boolean literals
 

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -465,39 +465,23 @@ A _floating-point literal_ has one of two forms:
 
 Like integer literals, a floating-point literal may be followed by a
 suffix, so long as the pre-suffix part does not end with `U+002E` (`.`).
-The suffix forcibly sets the type of the literal. There are two valid
-_floating-point suffixes_, `f32` and `f64` (the 32-bit and 64-bit floating point
-types), which explicitly determine the type of the literal.
-
-The type of an _unsuffixed_ floating-point literal is determined by
-type inference:
-
-* If a floating-point type can be _uniquely_ determined from the
-  surrounding program context, the unsuffixed floating-point literal
-  has that type.
-
-* If the program context under-constrains the type, it defaults to `f64`.
-
-* If the program context over-constrains the type, it is considered a
-  static type error.
+There are two valid _floating-point suffixes_: `f32` and `f64` (the names of the 32-bit and 64-bit [primitive floating-point types][floating-point types]).
+See [literal expressions] for the effect of these suffixes.
 
 Examples of floating-point literals of various forms:
 
 ```rust
-123.0f64;        // type f64
-0.1f64;          // type f64
-0.1f32;          // type f32
-12E+99_f64;      // type f64
-5f32;            // type f32
-let x: f64 = 2.; // type f64
+123.0f64;
+0.1f64;
+0.1f32;
+12E+99_f64;
+5f32;
+let x: f64 = 2.;
 ```
 
 This last example is different because it is not possible to use the suffix
 syntax with a floating point literal ending in a period. `2.f64` would attempt
 to call a method named `f64` on `2`.
-
-The representation semantics of floating-point numbers are described in
-["Machine Types"][machine types].
 
 ### Boolean literals
 
@@ -642,6 +626,7 @@ Similarly the `r`, `b`, and `br` prefixes used in raw string literals, byte lite
 [extern crates]: items/extern-crates.md
 [extern]: items/external-blocks.md
 [field]: expressions/field-expr.md
+[floating-point types]: types/numeric.md#floating-point-types
 [function pointer type]: types/function-pointer.md
 [functions]: items/functions.md
 [generics]: items/generics.md
@@ -651,7 +636,6 @@ Similarly the `r`, `b`, and `br` prefixes used in raw string literals, byte lite
 [lazy-bool]: expressions/operator-expr.md#lazy-boolean-operators
 [literal expressions]: expressions/literal-expr.md
 [loop labels]: expressions/loop-expr.md
-[machine types]: types/numeric.md
 [macros]: macros-by-example.md
 [match]: expressions/match-expr.md
 [negation]: expressions/operator-expr.md#negation-operators

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -18,11 +18,7 @@ table production] form, and appear in `monospace` font.
 
 ## Literals
 
-A literal is an expression consisting of a single token, rather than a sequence
-of tokens, that immediately and directly denotes the value it evaluates to,
-rather than referring to it by name or some other evaluation rule. A literal is
-a form of [constant expression](const_eval.md#constant-expressions), so is
-evaluated (primarily) at compile time.
+Literals are tokens used in [literal expressions].
 
 ### Examples
 
@@ -667,6 +663,7 @@ Similarly the `r`, `b`, and `br` prefixes used in raw string literals, byte lite
 [if let]: expressions/if-expr.md#if-let-expressions
 [keywords]: keywords.md
 [lazy-bool]: expressions/operator-expr.md#lazy-boolean-operators
+[literal expressions]: expressions/literal-expr.md
 [loop labels]: expressions/loop-expr.md
 [machine types]: types/numeric.md
 [macros]: macros-by-example.md

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -441,7 +441,7 @@ let horse = example.0b10;  // ERROR no field named `0b10`
 > **<sup>Lexer</sup>**\
 > FLOAT_LITERAL :\
 > &nbsp;&nbsp; &nbsp;&nbsp; DEC_LITERAL `.`
->   _(not immediately followed by `.`, `_` or an [identifier] or [keyword][keywords]_)\
+>   _(not immediately followed by `.`, `_` or an XID_Start character)_\
 > &nbsp;&nbsp; | DEC_LITERAL FLOAT_EXPONENT\
 > &nbsp;&nbsp; | DEC_LITERAL `.` DEC_LITERAL FLOAT_EXPONENT<sup>?</sup>\
 > &nbsp;&nbsp; | DEC_LITERAL (`.` DEC_LITERAL)<sup>?</sup>
@@ -524,7 +524,7 @@ Examples of such tokens:
 > &nbsp;&nbsp; &nbsp;&nbsp; BIN_LITERAL \[`2`-`9`&ZeroWidthSpace;]\
 > &nbsp;&nbsp; | OCT_LITERAL \[`8`-`9`&ZeroWidthSpace;]\
 > &nbsp;&nbsp; | ( BIN_LITERAL | OCT_LITERAL | HEX_LITERAL ) `.` \
-> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; _(not immediately followed by `.`, `_` or an [identifier] or [keyword][keywords]_)\
+> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; _(not immediately followed by `.`, `_` or an XID_Start character)_\
 > &nbsp;&nbsp; | ( BIN_LITERAL | OCT_LITERAL ) `e`\
 > &nbsp;&nbsp; | `0b` `_`<sup>\*</sup> _end of input or not BIN_DIGIT_\
 > &nbsp;&nbsp; | `0o` `_`<sup>\*</sup> _end of input or not OCT_DIGIT_\


### PR DESCRIPTION
This documents integer and floating-point literal expressions, and improves the docs for integer and floating-point literal tokens.

Covers some of #939, for integer and floating-point literals.

Covers the RFC 0879 part of #298, and some of the RFC 0463 part (ie, for numeric literals but not string literals).

The details of floating-point conversion deserve a more throrough description, but maybe that needs looking at together with the standard library docs.

I had a false-positive error from linkchecker; the last commit is a workaround for that, but I think the right thing would be an addition to `LINKCHECK_EXCEPTIONS` in `linkcheck/main.rs`.

