### PR TITLE
Fixed inconsistency in the usage of semicolon at end of scopes

### DIFF
--- a/theme/reference.css
+++ b/theme/reference.css
@@ -42,12 +42,12 @@ main .warning p::before {
 .coal main .warning p,
 .navy main .warning p,
 .ayu main .warning p {
-    background: #542626
+    background: #542626;
 }
 
 /* Make the links higher contrast on dark themes */
 .coal main .warning p a,
 .navy main .warning p a,
 .ayu main .warning p a {
-    color: #80d0d0
+    color: #80d0d0;
 }


### PR DESCRIPTION
Other scopes have a semicolon at end of their scopes, but these two do not have one.