### PR TITLE
Update aarch64 to use neon as fp

### DIFF
--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -148,7 +148,6 @@ Reference Manual], or elsewhere on [developer.arm.com].
 
 > ***Note***: The following pairs of features should both be marked as enabled
 > or disabled together if used:
-> - `fp` and `neon`, in order facilitate inlining in more places, among other reasons.
 > - `paca` and `pacg`, which LLVM currently implements as one feature.
 
 
@@ -167,15 +166,14 @@ Feature        | Implicitly Enables | Feature Name
 `fcma`         | `neon`         | FEAT_FCMA - Floating point complex number support
 `fhm`          | `fp16`         | FEAT_FHM - Half-precision FP FMLAL instructions
 `flagm`        |                | FEAT_FlagM - Conditional flag manipulation
-`fp`           |                | FEAT_FP - Floating point extension
-`fp16`         | `fp`, `neon`   | FEAT_FP16 - Half-precision FP data processing
+`fp16`         | `neon`         | FEAT_FP16 - Half-precision FP data processing
 `frintts`      |                | FEAT_FRINTTS - Floating-point to int helper instructions
 `i8mm`         |                | FEAT_I8MM - Int8 Matrix Multiplication
-`jsconv`       | `fp`, `neon`   | FEAT_JSCVT - JavaScript conversion instruction
+`jsconv`       | `neon`         | FEAT_JSCVT - JavaScript conversion instruction
 `lse`          |                | FEAT_LSE - Large System Extension
 `lor`          |                | FEAT_LOR - Limited Ordering Regions extension
 `mte`          |                | FEAT_MTE - Memory Tagging Extension
-`neon`         | `fp`           | FEAT_AdvSIMD - Advanced SIMD extension
+`neon`         |                | FEAT_FP & FEAT_AdvSIMD - Floating Point and Advanced SIMD extension
 `pan`          |                | FEAT_PAN - Privileged Access-Never extension
 `paca`         |                | FEAT_PAuth - Pointer Authentication (address authentication)
 `pacg`         |                | FEAT_PAuth - Pointer Authentication (generic authentication)

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -204,7 +204,7 @@ The availability of supported types for a particular register class may depend o
 | x86 | `mmx_reg` | N/A | Only clobbers |
 | x86 | `x87_reg` | N/A | Only clobbers |
 | AArch64 | `reg` | None | `i8`, `i16`, `i32`, `f32`, `i64`, `f64` |
-| AArch64 | `vreg` | `fp` | `i8`, `i16`, `i32`, `f32`, `i64`, `f64`, <br> `i8x8`, `i16x4`, `i32x2`, `i64x1`, `f32x2`, `f64x1`, <br> `i8x16`, `i16x8`, `i32x4`, `i64x2`, `f32x4`, `f64x2` |
+| AArch64 | `vreg` | `neon` | `i8`, `i16`, `i32`, `f32`, `i64`, `f64`, <br> `i8x8`, `i16x4`, `i32x2`, `i64x1`, `f32x2`, `f64x1`, <br> `i8x16`, `i16x8`, `i32x4`, `i64x2`, `f32x4`, `f64x2` |
 | AArch64 | `preg` | N/A | Only clobbers |
 | ARM | `reg` | None | `i8`, `i16`, `i32`, `f32` |
 | ARM | `sreg` | `vfp2` | `i32`, `f32` |


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/rust/pull/91608
At the very least, which feature to use for assembly should be clear.