### PR TITLE
Note that raw string literals are context-sensitive

### DIFF
--- a/src/tokens.md
+++ b/src/tokens.md
@@ -216,6 +216,7 @@ a context-free language can't because the only way to express "counting" is
 as a destructive operation which forces you to forget the count. This allows
 for the "comparison" of two counts (such (as (balanced) (parens))) but not 3+.
 
+See [the proof for more formal details](https://github.com/rust-lang/rust/blob/5187be620c76a313a19b9b596e1bce3a80a345dd/src/grammar/raw-string-literal-ambiguity.md).
 Examples for string literals:
 
 ```rust

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -217,6 +217,7 @@ as a destructive operation which forces you to forget the count. This allows
 for the "comparison" of two counts (such (as (balanced) (parens))) but not 3+.
 
 See [the proof for more formal details](https://github.com/rust-lang/rust/blob/5187be620c76a313a19b9b596e1bce3a80a345dd/src/grammar/raw-string-literal-ambiguity.md).
+
 Examples for string literals:
 
 ```rust

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -208,6 +208,14 @@ the characters `U+0022` (double-quote) (except when followed by at least as
 many `U+0023` (`#`) characters as were used to start the raw string literal) or
 `U+005C` (`\`) do not have any special meaning.
 
+**Note that this is a _context-sensitive_ grammar, as opposed to _context-free_.**
+This is because strings like `r###"I contain only 2 "##s so I'm ok"###` require
+a parser to properly count the number of opening #'s and compare that count to two
+different values. In practical terms this is very easy for a parser to do, but
+a context-free language can't because the only way to express "counting" is
+as a destructive operation which forces you to forget the count. This allows
+for the "comparison" of two counts (such (as (balanced) (parens))) but not 3+.
+
 Examples for string literals:
 
 ```rust


### PR DESCRIPTION
This was originally discussed with a full formal proof in 

https://github.com/rust-lang/rust/blob/5187be620c76a313a19b9b596e1bce3a80a345dd/src/grammar/raw-string-literal-ambiguity.md

but that file was removed as part of the "legacy" grammar of Rust. Over the years the file has been linked many times and is genuinely non-obvious and useful to know (because it means any [attempt to express Rust in entirely EBNF](https://github.com/ron-rs/ron/pull/171) is futile). I don't think the full formal proof is actually necessary, we can just appeal to an example and mention the "context-free languages can't compare 3 numbers" rule. To minimize confusion, I'm also including a note that the practical implications are relatively minor for an actual practical parser.

(Full disclosure I am the original author of the proof and it was my first contribution to Rust, so I am 100% sentimental about it, but also, it is just genuinely useful information.)