### PR TITLE
clarify that references size_of_val can never exceed isize::MAX

### DIFF
--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -78,11 +78,12 @@ reading uninitialized memory is permitted are inside `union`s and in "padding"
 A reference/pointer is "dangling" if it is null or not all of the bytes it
 points to are part of the same allocation (so in particular they all have to be
 part of *some* allocation). The span of bytes it points to is determined by the
-pointer value and the size of the pointee type (using `size_of_val`). As a
-consequence, if the span is empty, "dangling" is the same as "non-null". Note
-that slices and strings point to their entire range, so it is important that the length
-metadata is never too large. In particular, allocations and therefore slices and strings
-cannot be bigger than `isize::MAX` bytes.
+pointer value and the size of the pointee type (using `size_of_val`).
+
+Note that dynamically sized types (such as slices and strings) point to their
+entire range, so it is important that the length metadata is never too large. In
+particular, the dynamic size of a Rust value (as determined by `size_of_val`)
+must never exceed `isize::MAX`.
 
 [`bool`]: types/boolean.md
 [`const`]: items/constant-items.md

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -76,9 +76,13 @@ reading uninitialized memory is permitted are inside `union`s and in "padding"
 [dangling]: #dangling-pointers
 
 A reference/pointer is "dangling" if it is null or not all of the bytes it
-points to are part of the same allocation (so in particular they all have to be
+points to are part of the same live allocation (so in particular they all have to be
 part of *some* allocation). The span of bytes it points to is determined by the
 pointer value and the size of the pointee type (using `size_of_val`).
+
+If the size is 0, then the pointer must either point inside of a live allocation
+(including pointing just after the last byte of the allocation), or it must be
+directly constructed from a non-zero integer literal.
 
 Note that dynamically sized types (such as slices and strings) point to their
 entire range, so it is important that the length metadata is never too large. In


### PR DESCRIPTION
This is the underlying UB that https://github.com/rust-lang/rust/pull/95252 and https://github.com/rust-lang/rust/pull/95295 fix.

I also removed the statement 
> if the span is empty, "dangling" is the same as "non-null"

since it contradicts what [the library docs](https://doc.rust-lang.org/nightly/std/ptr/index.html) say about zero-sized accesses/types.