### PR TITLE
Boolean literal expressions

### DIFF
--- a/src/expressions/literal-expr.md
+++ b/src/expressions/literal-expr.md
@@ -150,8 +150,12 @@ The value of the expression is determined from the string representation of the 
 
 A boolean literal expression consists of one of the keywords `true` or `false`.
 
-> **Note**: This section is incomplete.
+The expression's type is the primitive [boolean type], and its value is:
+ * true if the keyword is `true`
+ * false if the keyword is `false`
 
+
+[boolean type]: ../types/boolean.md
 [constant expression]: ../const_eval.md#constant-expressions
 [floating-point types]: ../types/numeric.md#floating-point-types
 [lint check]: ../attributes/diagnostics.md#lint-check-attributes

--- a/src/expressions/literal-expr.md
+++ b/src/expressions/literal-expr.md
@@ -10,7 +10,7 @@
 > &nbsp;&nbsp; | [RAW_BYTE_STRING_LITERAL]\
 > &nbsp;&nbsp; | [INTEGER_LITERAL][^out-of-range]\
 > &nbsp;&nbsp; | [FLOAT_LITERAL]\
-> &nbsp;&nbsp; | [BOOLEAN_LITERAL]
+> &nbsp;&nbsp; | `true` | `false`
 >
 > [^out-of-range]: A value ≥ 2<sup>128</sup> is not allowed.
 
@@ -18,7 +18,7 @@ A _literal expression_ is an expression consisting of a single token, rather tha
 
 A literal is a form of [constant expression], so is evaluated (primarily) at compile time.
 
-Each of the lexical [literal][literal tokens] forms described earlier can make up a literal expression.
+Each of the lexical [literal][literal tokens] forms described earlier can make up a literal expression, as can the keywords `true` and `false`.
 
 ```rust
 "hello";   // string type
@@ -148,7 +148,7 @@ The value of the expression is determined from the string representation of the 
 
 ## Boolean literal expressions
 
-A boolean literal expression consists of a single [BOOLEAN_LITERAL] token.
+A boolean literal expression consists of one of the keywords `true` or `false`.
 
 > **Note**: This section is incomplete.
 
@@ -176,4 +176,3 @@ A boolean literal expression consists of a single [BOOLEAN_LITERAL] token.
 [RAW_BYTE_STRING_LITERAL]: ../tokens.md#raw-byte-string-literals
 [INTEGER_LITERAL]: ../tokens.md#integer-literals
 [FLOAT_LITERAL]: ../tokens.md#floating-point-literals
-[BOOLEAN_LITERAL]: ../tokens.md#boolean-literals

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -122,7 +122,7 @@ if let (a, 3) = (1, 2) {           // "(a, 3)" is refutable, and will not match
 
 > **<sup>Syntax</sup>**\
 > _LiteralPattern_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [BOOLEAN_LITERAL]\
+> &nbsp;&nbsp; &nbsp;&nbsp; `true` | `false`\
 > &nbsp;&nbsp; | [CHAR_LITERAL]\
 > &nbsp;&nbsp; | [BYTE_LITERAL]\
 > &nbsp;&nbsp; | [STRING_LITERAL]\
@@ -132,7 +132,6 @@ if let (a, 3) = (1, 2) {           // "(a, 3)" is refutable, and will not match
 > &nbsp;&nbsp; | `-`<sup>?</sup> [INTEGER_LITERAL]\
 > &nbsp;&nbsp; | `-`<sup>?</sup> [FLOAT_LITERAL]
 
-[BOOLEAN_LITERAL]: tokens.md#boolean-literals
 [CHAR_LITERAL]: tokens.md#character-literals
 [BYTE_LITERAL]: tokens.md#byte-literals
 [STRING_LITERAL]: tokens.md#string-literals

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -560,15 +560,6 @@ Examples of reserved forms:
 2.0em;   // this is not a pseudoliteral, or `2.0` followed by `em`
 ```
 
-### Boolean literals
-
-> **<sup>Lexer</sup>**\
-> BOOLEAN_LITERAL :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `true`\
-> &nbsp;&nbsp; | `false`
-
-The two values of the boolean type are written `true` and `false`.
-
 ## Lifetimes and loop labels
 
 > **<sup>Lexer</sup>**\


### PR DESCRIPTION
Closes #1167

This removes the `BOOLEAN_LITERAL` token, as `true` and `false` are already listed as keywords.

Then fills in the "Boolean literal expressions" section (one more small piece of #939).

