### PR TITLE
Attempt to explain that &mut cannot alias 

### DIFF
--- a/src/types/pointer.md
+++ b/src/types/pointer.md
@@ -26,6 +26,11 @@ These also point to memory owned by some other value.
 A mutable reference type is written `&mut type` or `&'a mut type`.
 A mutable reference (that hasn't been borrowed) is the only way to access the value it points to, so is not `Copy`.
 
+While a mutable reference is alive, it is the only reference pointing to the referent; no other reference,
+mutable or shared, point to the same value. For the safe subset of the language, this constraint is
+verified by the compiler. For code that use `unsafe`, it's up to the programmer to follow this constraint to avoid
+[undefined behavior] for correctness.
+
 ## Raw pointers (`*const` and `*mut`)
 
 > **<sup>Syntax</sup>**\
@@ -58,3 +63,4 @@ The standard library contains additional 'smart pointer' types beyond references
 [`unsafe` operation]: ../unsafety.md
 [dynamically sized types]: ../dynamically-sized-types.md
 [temporary value]: ../expressions.md#temporaries
+[undefined behavior]: ../behavior-considered-undefined.md


### PR DESCRIPTION
This is a clumsy attempt at making the "`&mut` is an exclusive
reference" part of the aliasing rule more discoverable. I feel like this
is an inherent property of the type so I was surprised to not find that
information here. This is echoing parts of the docs for [UnsafeCell] and
[ptr::as_mut], so another place where a newcomer could potentially get
this info.

I think it's easy for learners to assume that `&mut` can alias since
many popular languages have comparatively lax aliasing rules.

---

Do you also think adding this here make sense? Maybe I only think so because I've been thinking about this recently. 

[UnsafeCell]: https://doc.rust-lang.org/stable/std/cell/struct.UnsafeCell.html
[ptr::as_mut]: https://doc.rust-lang.org/std/primitive.pointer.html#method.as_mut-1