### PR TITLE
Remove OuterAttributes for `StructPatternEtCetera`

### DIFF
--- a/src/patterns.md
+++ b/src/patterns.md
@@ -585,7 +585,6 @@ Reference patterns are always irrefutable.
 > &nbsp;&nbsp; )
 >
 > _StructPatternEtCetera_ :\
-> &nbsp;&nbsp; [_OuterAttribute_] <sup>\*</sup>\
 > &nbsp;&nbsp; `..`
 
 [_OuterAttribute_]: attributes.md


### PR DESCRIPTION
Rust in stable and nightly treats outer attributes above `..` as whitespace.
Running `cargo fmt` even removes it.

Snippet:
```rust
struct Foo {
	a: u8
}

fn main() {
	let Foo { #[rest_attribute] .. } = Foo { a: 1 };
	let Foo { #[prop_attribute] a  } = Foo { a: 1 };
}
```

`cargo run`:
rest_attribute is ignored
```md
error: cannot find attribute `prop_attribute` in this scope
 --> src\main.rs:7:14
  |
7 |     let Foo { #[prop_attribute] a  } = Foo { a: 1 };
  |                 ^^^^^^^^^^^^^^
```

`cargo fmt`:
rest_attribute is removed
```rs
struct Foo {
    a: u8,
}

fn main() {
    let Foo { .. } = Foo { a: 1 };
    let Foo {
        #[prop_attribute]
        a,
    } = Foo { a: 1 };
}

```