### PR TITLE
Set type when purposely discarding return type

### DIFF
--- a/src/attributes/diagnostics.md
+++ b/src/attributes/diagnostics.md
@@ -291,14 +291,14 @@ When used on a function in a trait implementation, the attribute does nothing.
 > ```
 
 > Note: It is idiomatic to use a [let statement] with a pattern of `_`
-> when a must-used value is purposely discarded.
+> when a must-used value is purposely discarded. It is good practice to explicitely set the expected return type, so that in case of refactoring you need to validate discarding the new return type.
 >
 > ```rust
 > #[must_use]
 > fn five() -> i32 { 5i32 }
 >
 > // Does not violate the unused_must_use lint.
-> let _ = five();
+> let _: i32 = five();
 > ```
 
 [Clippy]: https://github.com/rust-lang/rust-clippy


### PR DESCRIPTION
Raised by https://github.com/rust-lang/rust-clippy/issues/6841, as it is safer in case of refactoring.

It does not catch all, and for complex type return is probably not worth it in terms of readability but still think it's a good addition.

Wording can probably be improved.