### PR TITLE
Don't use PathPattern in RangePattern bounds

### DIFF
--- a/src/patterns.md
+++ b/src/patterns.md
@@ -423,7 +423,7 @@ match tuple {
 > &nbsp;&nbsp; | [BYTE_LITERAL]\
 > &nbsp;&nbsp; | `-`<sup>?</sup> [INTEGER_LITERAL]\
 > &nbsp;&nbsp; | `-`<sup>?</sup> [FLOAT_LITERAL]\
-> &nbsp;&nbsp; | [_PathPattern_]
+> &nbsp;&nbsp; | [_PathExpression_]
 
 Range patterns match values within the range defined by their bounds. A range pattern may be
 closed or half-open. A range pattern is closed if it has both a lower and an upper bound, and


### PR DESCRIPTION
The use of `PathPattern` instead of `PathExpression` in `RangePattern` is IMO confusing, since these values are not patterns and are not represented as patterns in the AST.