### PR TITLE
Stop saying that const functions cannot use 'extern'

### DIFF
--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -216,8 +216,7 @@ Functions qualified with the `const` keyword are [const functions], as are
 [tuple struct] and [tuple variant] constructors. _Const functions_  can be
 called from within [const contexts].
 
-Const functions are not allowed to be [async](#async-functions), and cannot
-use the [`extern` function qualifier](#extern-function-qualifier).
+Const functions are not allowed to be [async](#async-functions).
 
 ## Async functions
 

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -216,6 +216,8 @@ Functions qualified with the `const` keyword are [const functions], as are
 [tuple struct] and [tuple variant] constructors. _Const functions_  can be
 called from within [const contexts].
 
+Const functions may use the [`extern`] function qualifier, but only with the `"Rust"` and `"C"` ABIs.
+
 Const functions are not allowed to be [async](#async-functions).
 
 ## Async functions
@@ -382,6 +384,7 @@ fn foo_oof(#[some_inert_attribute] arg: u8) {
 [const functions]: ../const_eval.md#const-functions
 [tuple struct]: structs.md
 [tuple variant]: enumerations.md
+[`extern`]: #extern-function-qualifier
 [external block]: external-blocks.md
 [path]: ../paths.md
 [block]: ../expressions/block-expr.md


### PR DESCRIPTION
Closes #1197

I don't think there's anything to do other than remove the claim in the text that these are forbidden. The grammar already allows it.

rust-lang/rust#64926 says this is stabilised only for the "Rust" and "C" ABIs, but I think that would be better covered in documentation for particular ABIs, if/when that exists.
