### PR TITLE
Moved the option variant imports

### DIFF
--- a/src/items/use-declarations.md
+++ b/src/items/use-declarations.md
@@ -35,13 +35,15 @@ Use declarations support a number of convenient shortcuts:
 An example of `use` declarations:
 
 ```rust
-use std::option::Option::{Some, None};
 use std::collections::hash_map::{self, HashMap};
 
 fn foo<T>(_: T){}
 fn bar(map1: HashMap<String, usize>, map2: hash_map::HashMap<String, usize>){}
 
 fn main() {
+    // use declarations can also exist inside of functions
+    use std::option::Option::{Some, None};
+
     // Equivalent to 'foo(vec![std::option::Option::Some(1.0f64),
     // std::option::Option::None]);'
     foo(vec![Some(1.0f64), None]);


### PR DESCRIPTION
#1115 asks for an example of a `use` declaration inside of a function. I think the easiest way to do that is to move the already existing declaration inside of the `main` function.

Closes #1115