### PR TITLE
Add a note to the turbofish section about impl Trait

### DIFF
--- a/src/paths.md
+++ b/src/paths.md
@@ -81,6 +81,9 @@ arguments, then const arguments, then equality constraints.
 Const arguments must be surrounded by braces unless they are a
 [literal] or a single segment path.
 
+The synthetic type parameters corresponding to `impl Trait` types are implicit,
+and these cannot be explicitly specified.
+
 ## Qualified paths
 
 > **<sup>Syntax</sup>**\


### PR DESCRIPTION
This is part of the stabilisation process for [explicit_generic_args_with_impl_trait](https://github.com/rust-lang/rust/issues/83701); it will be legal to use turbofish in the presence of `impl Trait` argument types, but there is still no way to specify those types