### PR TITLE
Reflect changes about unsizing casts in const context

### DIFF
--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -42,9 +42,8 @@ to be run.
 * The [dereference operator] except for raw pointers.
 * [Grouped] expressions.
 * [Cast] expressions, except
-  * pointer to address casts,
-  * function pointer to address casts, and
-  * unsizing casts to trait objects.
+  * pointer to address casts and
+  * function pointer to address casts.
 * Calls of [const functions] and const methods.
 * [loop], [while] and [`while let`] expressions.
 * [if], [`if let`] and [match] expressions.


### PR DESCRIPTION
Since Rust 1.61.0 it is possible to do unsizing casts in const context, so reflect that in reference.