### PR TITLE
add debug variance link

### DIFF
--- a/src/subtyping.md
+++ b/src/subtyping.md
@@ -83,6 +83,8 @@ struct Variance<'a, 'b, T, U: 'a> {
 }
 ```
 
+To debug variance of custom struct, see `src/test/ui/variance/variance-regions-direct.rs`.
+
 [function pointers]: types/function-pointer.md
 [Higher-ranked]: ../nomicon/hrtb.html
 [trait objects]: types/trait-object.md

--- a/src/subtyping.md
+++ b/src/subtyping.md
@@ -83,7 +83,7 @@ struct Variance<'a, 'b, T, U: 'a> {
 }
 ```
 
-To debug variance of custom struct, see `src/test/ui/variance/variance-regions-direct.rs`.
+To debug variance of custom struct, see `src/test/ui/variance/variance-types.rs`.
 
 [function pointers]: types/function-pointer.md
 [Higher-ranked]: ../nomicon/hrtb.html


### PR DESCRIPTION
I find `src/test/ui/variance/variance-types.rs ` quite helpful in debugging variance.
I want to put the link into the book.