### PR TITLE
Remove outdated restriction on recursive types

### DIFF
--- a/src/types.md
+++ b/src/types.md
@@ -104,9 +104,6 @@ itself. Such recursion has restrictions:
   Rec = &'static [Rec]` is not allowed.
 * The size of a recursive type must be finite; in other words the recursive
   fields of the type must be [pointer types].
-* Recursive type definitions can cross module boundaries, but not module
-  *visibility* boundaries, or crate boundaries (in order to simplify the module
-  system and type checker).
 
 An example of a *recursive* type and its use:
 


### PR DESCRIPTION
This sentence was written over a decade ago by Graydon: https://github.com/rust-lang/rust/commit/293678847b8c6291389826b1a7e9c5bda889c8d9#diff-dee91bf0fc1779efb1cef2b9bcb1f296c8cc0bcb6597a4f008b33e21a44a5ad3R986-R988

As far as I can tell, no such restriction has existed since Rust 1.0.