### PR TITLE
Remove outdated note about non-Copy union fields

### DIFF
--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -359,8 +359,6 @@ struct MyCFields { x: u32, y: u8 }
 struct MyDFields;
 ```
 
-> Note: `union`s with non-`Copy` fields are unstable, see [55149].
-
 ### Primitive representations
 
 The *primitive representations* are the representations with the same names as


### PR DESCRIPTION
Unions with non-Copy fields are now stable.