### PR TITLE
Remove uses of the phrase "in Rust"

### DIFF
--- a/src/comments.md
+++ b/src/comments.md
@@ -34,7 +34,7 @@
 
 ## Non-doc comments
 
-Comments in Rust code follow the general C++ style of line (`//`) and
+Comments follow the general C++ style of line (`//`) and
 block (`/* ... */`) comment forms. Nested block comments are supported.
 
 Non-doc comments are interpreted as a form of whitespace.

--- a/src/interior-mutability.md
+++ b/src/interior-mutability.md
@@ -6,7 +6,7 @@ mutability if its internal state can be changed through a [shared reference] to
 it. This goes against the usual [requirement][ub] that the value pointed to by a
 shared reference is not mutated.
 
-[`std::cell::UnsafeCell<T>`] type is the only allowed way in Rust to disable
+[`std::cell::UnsafeCell<T>`] type is the only allowed way to disable
 this requirement. When `UnsafeCell<T>` is immutably aliased, it is still safe to
 mutate, or obtain a mutable reference to, the `T` it contains. As with all
 other types, it is undefined behavior to have multiple `&mut UnsafeCell<T>`

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -175,7 +175,7 @@ is equivalent to:
 extern "Rust" fn foo() {}
 ```
 
-Functions in Rust can be called by foreign code, and using an ABI that
+Functions can be called by foreign code, and using an ABI that
 differs from Rust allows, for example, to provide functions that can be
 called from other programming languages like C:
 

--- a/src/statements-and-expressions.md
+++ b/src/statements-and-expressions.md
@@ -7,5 +7,5 @@ each other kind of expression, and rules for evaluation of expressions involve
 specifying both the value produced by the expression and the order in which its
 sub-expressions are themselves evaluated.
 
-In contrast, statements in Rust serve _mostly_ to contain and explicitly
+In contrast, statements serve _mostly_ to contain and explicitly
 sequence expression evaluation.

--- a/src/types/pointer.md
+++ b/src/types/pointer.md
@@ -1,6 +1,6 @@
 # Pointer types
 
-All pointers in Rust are explicit first-class values.
+All pointers are explicit first-class values.
 They can be moved or copied, stored into data structs, and returned from functions.
 
 ## References (`&` and `&mut`)
@@ -38,7 +38,7 @@ For example `*const i32` means a raw pointer to a 32-bit integer.
 Copying or dropping a raw pointer has no effect on the lifecycle of any other value.
 Dereferencing a raw pointer is an [`unsafe` operation].
 This can also be used to convert a raw pointer to a reference by reborrowing it (`&*` or `&mut *`).
-Raw pointers are generally discouraged in Rust code;
+Raw pointers are generally discouraged;
 they exist to support interoperability with foreign code, and writing performance-critical or low-level functions.
 
 When comparing raw pointers they are compared by their address, rather than by what they point to.

--- a/src/visibility-and-privacy.md
+++ b/src/visibility-and-privacy.md
@@ -22,7 +22,7 @@ of an item to see whether it should be allowed or not. This is where privacy
 warnings are generated, or otherwise "you used a private item of another module
 and weren't allowed to."
 
-By default, everything in Rust is *private*, with two exceptions: Associated
+By default, everything is *private*, with two exceptions: Associated
 items in a `pub` Trait are public by default; Enum variants
 in a `pub` enum are also public by default. When an item is declared as `pub`,
 it can be thought of as being accessible to the outside world. For example:


### PR DESCRIPTION
This is mentioned specifically in the style guide.