### PR TITLE
#[non_exhaustive] on variant blocks cross-crate as casts

### DIFF
--- a/src/attributes/type_system.md
+++ b/src/attributes/type_system.md
@@ -127,7 +127,7 @@ match message {
 }
 ```
 
-It's also impossible to cast non-exhaustive types from foreign crates.
+It's also not allowed to cast non-exhaustive types from foreign crates.
 ```rust, ignore
 use othercrate::NonExhaustiveEnum;
 

--- a/src/attributes/type_system.md
+++ b/src/attributes/type_system.md
@@ -127,6 +127,14 @@ match message {
 }
 ```
 
+It's also impossible to cast non-exhaustive types from foreign crates.
+```rust, ignore
+use othercrate::NonExhaustiveEnum;
+
+// Cannot cast a non-exhaustive enum outside of its defining crate.
+let _ = NonExhaustiveEnum::default() as u8;
+```
+
 Non-exhaustive types are always considered inhabited in downstream crates.
 
 [_MetaWord_]: ../attributes.md#meta-item-attribute-syntax


### PR DESCRIPTION
Fixes: #1250 

Adding missing documentation after changing in rust-lang/rust#91161 (rust-lang/rust#92744)