### PR TITLE
Document RFC 2867: instruction_set attribute

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -297,7 +297,7 @@ The following is an index of all built-in attributes.
 [`global_allocator`]: runtime.md#the-global_allocator-attribute
 [`ignore`]: attributes/testing.md#the-ignore-attribute
 [`inline`]: attributes/codegen.md#the-inline-attribute
-[`instruction_set`]: attributes/codegen.md#the-instruction-set-attribute
+[`instruction_set`]: attributes/codegen.md#the-instruction_set-attribute
 [`link_name`]: items/external-blocks.md#the-link_name-attribute
 [`link_section`]: abi.md#the-link_section-attribute
 [`link`]: items/external-blocks.md#the-link-attribute

--- a/src/attributes.md
+++ b/src/attributes.md
@@ -297,6 +297,7 @@ The following is an index of all built-in attributes.
 [`global_allocator`]: runtime.md#the-global_allocator-attribute
 [`ignore`]: attributes/testing.md#the-ignore-attribute
 [`inline`]: attributes/codegen.md#the-inline-attribute
+[`instruction_set`]: attributes/codegen.md#the-instruction-set-attribute
 [`link_name`]: items/external-blocks.md#the-link_name-attribute
 [`link_section`]: abi.md#the-link_section-attribute
 [`link`]: items/external-blocks.md#the-link-attribute

--- a/src/attributes.md
+++ b/src/attributes.md
@@ -246,6 +246,7 @@ The following is an index of all built-in attributes.
   - [`no_builtins`] — Disables use of certain built-in functions.
   - [`target_feature`] — Configure platform-specific code generation.
   - [`track_caller`] - Pass the parent call location to `std::panic::Location::caller()`.
+  - [`instruction_set`] - Specify the instruction set used to generate a functions code
 - Documentation
   - `doc` — Specifies documentation. See [The Rustdoc Book] for more
     information. [Doc comments] are transformed into `doc` attributes.

--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -358,7 +358,7 @@ trait object whose methods are attributed.
 The `instruction_set` attribute may be applied to a function to enable code generation for a specific
 instruction set supported by the target architecture. Currently, this is only available for `ARMv4T`
 devices where the architecture has "ARM code" and "Thumb code" available and a single program may
-utilise both of these. If not specified the default instruction set for the target will be used.
+utilize both of these. If not specified the default instruction set for the target will be used.
 
 ```rust
 #[instruction_set(arm::a32)]

--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -366,7 +366,7 @@ The following values are available on targets for the `ARMv4` and ARMv5te` archi
 * `arm::t32` - Uses Thumb code.
 
 <!-- ignore: arm-only -->
-```rust
+```rust,ignore
 #[instruction_set(arm::a32)]
 fn foo_arm_code() {}
 

--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -352,3 +352,18 @@ trait object whose methods are attributed.
 [`core::intrinsics::caller_location`]: ../../core/intrinsics/fn.caller_location.html
 [`core::panic::Location::caller`]: ../../core/panic/struct.Location.html#method.caller
 [`Location`]: ../../core/panic/struct.Location.html
+
+## The `instruction_set` attribute
+
+The `instruction_set` attribute may be applied to a function to enable code generation for a specific
+instruction set supported by the target architecture. Currently, this is only available for `ARMv4T`
+devices where the architecture has "ARM code" and "Thumb code" available and a single program may
+utilise both of these. If not specified the default instruction set for the target will be used.
+
+```rust
+#[instruction_set(arm::a32)]
+fn foo_arm_code() {}
+
+#[instruction_set(arm::t32)]
+fn bar_thumb_code() {}
+```

--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -360,7 +360,7 @@ instruction set supported by the target architecture. It uses the [_MetaListPath
 comprised of the architecture and instruction set to specify how to generate the code for
 architectures where a single program may utilize multiple instruction sets. 
 
-The following values are available on targets for the `ARMv4` architecture:
+The following values are available on targets for the `ARMv4` and ARMv5te` architectures:
 
 * `arm::a32` - Uses ARM code.
 * `arm::t32` - Uses Thumb code.

--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -358,7 +358,7 @@ trait object whose methods are attributed.
 The *`instruction_set` attribute* may be applied to a function to enable code generation for a specific
 instruction set supported by the target architecture. It uses the [_MetaListPath_] syntax and a path
 comprised of the architecture and instruction set to specify how to generate the code for
-architectures where a single program may utilize multiple instruction sets. 
+architectures where a single program may utilize multiple instruction sets.
 
 The following values are available on targets for the `ARMv4` and ARMv5te` architectures:
 

--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -360,7 +360,7 @@ instruction set supported by the target architecture. It uses the [_MetaListPath
 comprised of the architecture and instruction set to specify how to generate the code for
 architectures where a single program may utilize multiple instruction sets.
 
-The following values are available on targets for the `ARMv4` and ARMv5te` architectures:
+The following values are available on targets for the `ARMv4` and `ARMv5te` architectures:
 
 * `arm::a32` - Uses ARM code.
 * `arm::t32` - Uses Thumb code.

--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -355,11 +355,17 @@ trait object whose methods are attributed.
 
 ## The `instruction_set` attribute
 
-The `instruction_set` attribute may be applied to a function to enable code generation for a specific
-instruction set supported by the target architecture. Currently, this is only available for `ARMv4T`
-devices where the architecture has "ARM code" and "Thumb code" available and a single program may
-utilize both of these. If not specified the default instruction set for the target will be used.
+The *`instruction_set` attribute* may be applied to a function to enable code generation for a specific
+instruction set supported by the target architecture. It uses the [_MetaListPath_] syntax and a path
+comprised of the architecture and instruction set to specify how to generate the code for
+architectures where a single program may utilize multiple instruction sets. 
 
+The following values are available on targets for the `ARMv4` architecture:
+
+* `arm::a32` - Uses ARM code.
+* `arm::t32` - Uses Thumb code.
+
+<!-- ignore: arm-only -->
 ```rust
 #[instruction_set(arm::a32)]
 fn foo_arm_code() {}
@@ -367,3 +373,5 @@ fn foo_arm_code() {}
 #[instruction_set(arm::t32)]
 fn bar_thumb_code() {}
 ```
+
+[_MetaListPath_]: ../attributes.md#meta-item-attribute-syntax


### PR DESCRIPTION
As part of the stabilisation work: https://github.com/rust-lang/rust/issues/74727 this PR adds some documentation for the instruction set attribute. I've popped this in the codegen attributes as that seemed rather self-explanatory. It's currently fairly brief but feels "enough" to me, enough at least to get some feedback on iterate on.