### PR TITLE
Use actual `ne` method in derive reference

### DIFF
--- a/src/attributes/derive.md
+++ b/src/attributes/derive.md
@@ -26,7 +26,7 @@ impl<T: PartialEq> PartialEq for Foo<T> {
     }
 
     fn ne(&self, other: &Foo<T>) -> bool {
-        self.a != other.a || self.b != other.b
+        !self.eq(other)
     }
 }
 ```


### PR DESCRIPTION
I noticed the expanded derive example was a lot more complicated than [what actually happens](https://doc.rust-lang.org/stable/src/core/cmp.rs.html#219-234), so I made this change to clarify.