### PR TITLE
Add basic GATs reference information

### DIFF
--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -224,7 +224,7 @@ The identifier is the name of the declared type alias. The optional trait bounds
 must be fulfilled by the implementations of the type alias.
 There is an implicit [`Sized`] bound on associated types that can be relaxed using the special `?Sized` bound.
 
-An *associated type definition* defines a type alias on for the implementation
+An *associated type definition* defines a type alias for the implementation
 of a trait on a type. They are written similarly to an *associated type declaration*,
 but cannot contain `Bounds`, but instead must contain a `Type`:
 

--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -211,6 +211,7 @@ lifetime or const parameters, `Bounds` is a plus-separated list of trait bounds
 on the associated type, and `WhereBounds` is a comma-separated list of bounds on
 parameters:
 
+<!-- ignore: illustrative example forms -->
 ```rust,ignore
 type Assoc;
 type Assoc: Bounds;
@@ -228,11 +229,12 @@ An *associated type definition* defines a type alias for the implementation
 of a trait on a type. They are written similarly to an *associated type declaration*,
 but cannot contain `Bounds`, but instead must contain a `Type`:
 
+<!-- ignore: illustrative example forms -->
 ```rust,ignore
 type Assoc = Type;
 type Assoc<Params> = Type; // the type `Type` here may reference `Params`
-type Assoc<Params> where WhereBounds = Type;
 type Assoc<Params> = Type where WhereBounds;
+type Assoc<Params> where WhereBounds = Type; // deprecated, prefer the form above
 ```
 
 If a type `Item` has an associated type `Assoc` from a trait `Trait`, then

--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -364,7 +364,7 @@ the union.
 trait Check<T> {
     type Checker<'x>;
     fn create_checker<'a>(item: &'a T) -> Self::Checker<'a>;
-    fn do_check(checker: Self::Checker<'a>);
+    fn do_check(checker: Self::Checker<'_>);
 }
 ```
 

--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -205,26 +205,46 @@ types cannot be defined in [inherent implementations] nor can they be given a
 default implementation in traits.
 
 An *associated type declaration* declares a signature for associated type
-definitions. It is written as `type`, then an [identifier], and
-finally an optional list of trait bounds.
+definitions. It is written in one of the following forms, where `Assoc` is the
+name of the associated type, `Params` is a comma-separated list of type,
+lifetime or const parameters, `Bounds` is a plus-separated list of trait bounds
+on the associated type, and `WhereBounds` is a comma-separated list of bounds on
+parameters:
+
+```rust,ignore
+type Assoc;
+type Assoc: Bounds;
+type Assoc<Params>;
+type Assoc<Params>: Bounds;
+type Assoc<Params> where WhereBounds;
+type Assoc<Params>: Bounds where WhereBounds;
+```
 
 The identifier is the name of the declared type alias. The optional trait bounds
 must be fulfilled by the implementations of the type alias.
 There is an implicit [`Sized`] bound on associated types that can be relaxed using the special `?Sized` bound.
 
-An *associated type definition* defines a type alias on another type. It is
-written as `type`, then an [identifier], then an `=`, and finally a [type].
+An *associated type definition* defines a type alias on for the implementation
+of a trait on a type. They are written similarly to an *associated type declaration*,
+but cannot contain `Bounds`, but instead must contain a `Type`:
+
+```rust,ignore
+type Assoc = Type;
+type Assoc<Params> = Type<Params>;
+type Assoc<Params> where WhereBounds = Type;
+type Assoc<Params> = Type where WhereBounds;
+```
 
 If a type `Item` has an associated type `Assoc` from a trait `Trait`, then
 `<Item as Trait>::Assoc` is a type that is an alias of the type specified in the
 associated type definition. Furthermore, if `Item` is a type parameter, then
 `Item::Assoc` can be used in type parameters.
 
-Associated types may include [generic parameters] or [where clauses]; these may
-be referred to as generic associated types, or GATs. If the type `Thing` has an
-associated type `Item` from a trait `Trait` with the generics `<'a>` , the type
-can be named like `<Thing as Trait>::Item<'x>`, where `'x` is some lifetime in
-scope. In this case, `'x` will be used wherever `'a` appears in the associated
+Associated types may include [generic parameters] and [where clauses]; these are
+often referred to as *generic associated types*, or *GATs*. If the type `Thing`
+has an associated type `Item` from a trait `Trait` with the generics `<'a>` , the
+type can be named like `<Thing as Trait>::Item<'x>`, where `'x` is some lifetime
+in scope. In this case, `'x` will be used wherever `'a` appears in the associated
 type definitions on impls.
 
 ```rust

--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -221,7 +221,7 @@ associated type definition. Furthermore, if `Item` is a type parameter, then
 `Item::Assoc` can be used in type parameters.
 
 Associated types may include [generic parameters] or [where clauses]; these may
-be referred to generic associated types, or GATs. If the type `Thing` has an
+be referred to as generic associated types, or GATs. If the type `Thing` has an
 associated type `Item` from a trait `Trait` with the generics `<'a>` , the type
 can be named like `<Thing as Trait>::Item<'x>`, where `'x` is some lifetime in
 scope. In this case, `'x` will be used wherever `'a` appears in the associated

--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -208,8 +208,8 @@ An *associated type declaration* declares a signature for associated type
 definitions. It is written in one of the following forms, where `Assoc` is the
 name of the associated type, `Params` is a comma-separated list of type,
 lifetime or const parameters, `Bounds` is a plus-separated list of trait bounds
-on the associated type, and `WhereBounds` is a comma-separated list of bounds on
-parameters:
+that the associated type must meet, and `WhereBounds` is a comma-separated list
+of bounds that the parameters must meet:
 
 <!-- ignore: illustrative example forms -->
 ```rust,ignore
@@ -336,6 +336,19 @@ impl<T> Container for Vec<T> {
     fn insert(&mut self, x: T) { self.push(x); }
 }
 ```
+
+### Relationship between `Bounds` and `WhereBounds`
+
+In this example:
+
+```rust
+# use std::fmt::Debug;
+trait Example {
+    type Output<T>: Ord where T: Debug;
+}
+```
+
+Given a reference to the associated type like `<X as Example>::Output<Y>`, the associated type itself must be `Ord`, and the type `Y` must be `Debug`.
 
 ### Required where clauses on generic associated types
 

--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -230,7 +230,7 @@ but cannot contain `Bounds`, but instead must contain a `Type`:
 
 ```rust,ignore
 type Assoc = Type;
-type Assoc<Params> = Type<Params>;
+type Assoc<Params> = Type; // the type `Type` here may reference `Params`
 type Assoc<Params> where WhereBounds = Type;
 type Assoc<Params> = Type where WhereBounds;
 ```
@@ -338,7 +338,9 @@ impl<T> Container for Vec<T> {
 ### Required where clauses on generic associated types
 
 Generic associated type declarations on traits currently may require a list of
-where clauses, dependent on functions in the trait and how the GAT is used.
+where clauses, dependent on functions in the trait and how the GAT is used. These
+rules may be loosened in the future; updates can be found [on the generic
+associated types initiative repository](https://rust-lang.github.io/generic-associated-types-initiative/explainer/required_bounds.html).
 
 In a few words, these where clauses are required in order to maximize the allowed
 definitions of the associated type in impls. To do this, any clauses that *can be

--- a/src/items/traits.md
+++ b/src/items/traits.md
@@ -70,6 +70,7 @@ Object safe traits can be the base trait of a [trait object]. A trait is
 * All [supertraits] must also be object safe.
 * `Sized` must not be a [supertrait][supertraits]. In other words, it must not require `Self: Sized`.
 * It must not have any associated constants.
+* It must not have any associated types with generics.
 * All associated functions must either be dispatchable from a trait object or be explicitly non-dispatchable:
     * Dispatchable functions require:
         * Not have any type parameters (although lifetime parameters are allowed),

--- a/src/items/type-aliases.md
+++ b/src/items/type-aliases.md
@@ -31,14 +31,14 @@ let _ = UseAlias(5); // OK
 let _ = TypeAlias(5); // Doesn't work
 ```
 
-A type alias without the [_Type_] specification may only appear as an
-[associated type] in a [trait].
+A type alias, when not used as an associated type, must include a [_Type_] and
+may not include [_TypeParamBounds_].
 
-A type alias with the [_Type_] specification may only appear as an
-[associated type] in a [trait impl].
+A type alias, when used as an [associated type] in a [trait], must not include a
+[_Type_] specification but may include [_TypeParamBounds_].
 
-A type alias with [_TypeParamBounds_] may only specified when used as
-an [associated type] in a [trait].
+A type alias, when used as an [associated type] in a [trait impl], must include
+a [_Type_] specification and may not include [_TypeParamBounds_].
 
 Where clauses before the equals sign on a type alias in a [trait impl] (like
 `type TypeAlias<T> where T: Foo = Bar<T>`) are deprecated. Where clauses after

--- a/src/items/type-aliases.md
+++ b/src/items/type-aliases.md
@@ -42,7 +42,7 @@ an [associated type] in a [trait].
 
 Where clauses before the equals sign on a type alias in a [trait impl] (like 
 `type TypeAlias<T> where T: Foo = Bar<T>`) are deprecated. Where clauses after
-the equals sign (like `type TypeAlias<T> where T: Foo = Bar<T>`) are preferred.
+the equals sign (like `type TypeAlias<T> = Bar<T> where T: Foo`) are preferred.
 
 [IDENTIFIER]: ../identifiers.md
 [_GenericParams_]: generics.md

--- a/src/items/type-aliases.md
+++ b/src/items/type-aliases.md
@@ -4,7 +4,7 @@
 > _TypeAlias_ :\
 > &nbsp;&nbsp; `type` [IDENTIFIER]&nbsp;[_GenericParams_]<sup>?</sup>
 >              ( `:` [_TypeParamBounds_] )<sup>?</sup>
->              [_WhereClause_]<sup>?</sup> ( `=` [_Type_] )<sup>?</sup> [_WhereClause_]<sup>?</sup> `;`
+>              [_WhereClause_]<sup>?</sup> ( `=` [_Type_] [_WhereClause_]<sup>?</sup>)<sup>?</sup> `;`
 
 A _type alias_ defines a new name for an existing [type]. Type aliases are
 declared with the keyword `type`. Every value has a single, specific type, but
@@ -34,11 +34,15 @@ let _ = TypeAlias(5); // Doesn't work
 A type alias without the [_Type_] specification may only appear as an
 [associated type] in a [trait].
 
+A type alias with the [_Type_] specification may only appear as an
+[associated type] in a [trait impl].
+
 A type alias with [_TypeParamBounds_] may only specified when used as
 an [associated type] in a [trait].
 
-A type alias with where clauses after the equals sign may only appear as an
-[associated type] in a [trait] or a [trait impl].
+Where clauses before the equals sign on a type alias in a [trait impl] (like 
+`type TypeAlias<T> where T: Foo = Bar<T>`) are deprecated. Where clauses after
+the equals sign (like `type TypeAlias<T> where T: Foo = Bar<T>`) are preferred.
 
 [IDENTIFIER]: ../identifiers.md
 [_GenericParams_]: generics.md

--- a/src/items/type-aliases.md
+++ b/src/items/type-aliases.md
@@ -40,7 +40,7 @@ A type alias with the [_Type_] specification may only appear as an
 A type alias with [_TypeParamBounds_] may only specified when used as
 an [associated type] in a [trait].
 
-Where clauses before the equals sign on a type alias in a [trait impl] (like 
+Where clauses before the equals sign on a type alias in a [trait impl] (like
 `type TypeAlias<T> where T: Foo = Bar<T>`) are deprecated. Where clauses after
 the equals sign (like `type TypeAlias<T> = Bar<T> where T: Foo`) are preferred.
 

--- a/src/items/type-aliases.md
+++ b/src/items/type-aliases.md
@@ -4,7 +4,7 @@
 > _TypeAlias_ :\
 > &nbsp;&nbsp; `type` [IDENTIFIER]&nbsp;[_GenericParams_]<sup>?</sup>
 >              ( `:` [_TypeParamBounds_] )<sup>?</sup>
->              [_WhereClause_]<sup>?</sup> ( `=` [_Type_] )<sup>?</sup> `;`
+>              [_WhereClause_]<sup>?</sup> ( `=` [_Type_] )<sup>?</sup> [_WhereClause_]<sup>?</sup> `;`
 
 A _type alias_ defines a new name for an existing [type]. Type aliases are
 declared with the keyword `type`. Every value has a single, specific type, but
@@ -37,6 +37,9 @@ A type alias without the [_Type_] specification may only appear as an
 A type alias with [_TypeParamBounds_] may only specified when used as
 an [associated type] in a [trait].
 
+A type alias with where clauses after the equals sign may only appear as an
+[associated type] in a [trait] or a [trait impl].
+
 [IDENTIFIER]: ../identifiers.md
 [_GenericParams_]: generics.md
 [_TypeParamBounds_]: ../trait-bounds.md
@@ -45,3 +48,4 @@ an [associated type] in a [trait].
 [associated type]: associated-items.md#associated-types
 [trait]: traits.md
 [type]: ../types.md
+[trait impl]: implementations.md#trait-implementations


### PR DESCRIPTION
There really isn't a *ton* to add here. Almost all of the syntax related to GATs falls out from existing syntax.