### PR TITLE
Classify AsyncBlockExpression as ExpressionWithoutBlock

### DIFF
--- a/src/expressions.md
+++ b/src/expressions.md
@@ -22,6 +22,7 @@
 > &nbsp;&nbsp; &nbsp;&nbsp; | [_MethodCallExpression_]\
 > &nbsp;&nbsp; &nbsp;&nbsp; | [_FieldExpression_]\
 > &nbsp;&nbsp; &nbsp;&nbsp; | [_ClosureExpression_]\
+> &nbsp;&nbsp; &nbsp;&nbsp; | [_AsyncBlockExpression_]\
 > &nbsp;&nbsp; &nbsp;&nbsp; | [_ContinueExpression_]\
 > &nbsp;&nbsp; &nbsp;&nbsp; | [_BreakExpression_]\
 > &nbsp;&nbsp; &nbsp;&nbsp; | [_RangeExpression_]\
@@ -34,7 +35,6 @@
 > &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup>[†](#expression-attributes)\
 > &nbsp;&nbsp; (\
 > &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; [_BlockExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_AsyncBlockExpression_]\
 > &nbsp;&nbsp; &nbsp;&nbsp; | [_UnsafeBlockExpression_]\
 > &nbsp;&nbsp; &nbsp;&nbsp; | [_LoopExpression_]\
 > &nbsp;&nbsp; &nbsp;&nbsp; | [_IfExpression_]\


### PR DESCRIPTION
If rustc's behavior regarding async blocks is intentional, then this fixes #1267.

We might want to consult with the Async WG on this first. Edit: [Zulip topic](https://rust-lang.zulipchat.com/#narrow/stream/187312-wg-async/topic/syntax.20of.20async.20blocks/near/298263840).