### PR TITLE
Use semver-compliant example version

### DIFF
--- a/src/attributes/diagnostics.md
+++ b/src/attributes/diagnostics.md
@@ -184,7 +184,7 @@ Tuple struct fields are ignored.
 Here is an example:
 
 ```rust
-#[deprecated(since = "5.2", note = "foo was rarely used. Users should instead use bar")]
+#[deprecated(since = "5.2.0", note = "foo was rarely used. Users should instead use bar")]
 pub fn foo() {}
 
 pub fn bar() {}


### PR DESCRIPTION
Clippy warns if the `since` version in `#[deprecated]` isn't semver-compliant. This PR updates an example using `#[deprecated]` to make the version semver-compliant.