### PR TITLE
Fix grammar for TypePathFn

### DIFF
--- a/src/paths.md
+++ b/src/paths.md
@@ -128,7 +128,7 @@ S::f();  // Calls the inherent impl.
 > &nbsp;&nbsp; _PathIdentSegment_ (`::`<sup>?</sup> ([_GenericArgs_] | _TypePathFn_))<sup>?</sup>
 >
 > _TypePathFn_ :\
-> `(` _TypePathFnInputs_<sup>?</sup> `)` (`->` [_Type_])<sup>?</sup>
+> `(` _TypePathFnInputs_<sup>?</sup> `)` (`->` [_TypeNoBounds_])<sup>?</sup>
 >
 > _TypePathFnInputs_ :\
 > [_Type_] (`,` [_Type_])<sup>\*</sup> `,`<sup>?</sup>
@@ -395,6 +395,7 @@ mod without { // crate::without
 [_LiteralExpression_]: expressions/literal-expr.md
 [_SimplePathSegment_]: #simple-paths
 [_Type_]: types.md#type-expressions
+[_TypeNoBounds_]: types.md#type-expressions
 [literal]: expressions/literal-expr.md
 [item]: items.md
 [variable]: variables.md


### PR DESCRIPTION
The grammar for _TypePathFn_ was changed in https://github.com/rust-lang/rust/pull/45294 (Rust 1.25) to require parenthesis if there is more than one bound. [Here](https://github.com/ehuss/rust/blob/be1c7aad723126b2ea65543b4ceed54167b841a2/compiler/rustc_parse/src/parser/path.rs#L297-L298) is where the return type is parsed (notice that it has the `AllowPlus::No` restriction). 