### PR TITLE
Document that type parameter `Self` is unsized by default

### DIFF
--- a/src/special-types-and-traits.md
+++ b/src/special-types-and-traits.md
@@ -135,7 +135,7 @@ UnwindSafe>` is a valid type.
 ## `Sized`
 
 The [`Sized`] trait indicates that the size of this type is known at compile-time; that is, it's not a [dynamically sized type].
-[Type parameters] are `Sized` by default, as are [associated types].
+[Type parameters] (except `Self` in traits) are `Sized` by default, as are [associated types].
 `Sized` is always implemented automatically by the compiler, not by [implementation items].
 These implicit `Sized` bounds may be relaxed by using the special `?Sized` bound.
 


### PR DESCRIPTION
The (implicit) type parameter `Self` in traits is not `Sized` by default but the current documentation is not very clear about it.

> All type parameters have an implicit bound of `Sized`. […] The one exception is the implicit `Self` type of a trait.

Source: [Documentation of `std::marker::Sized`](https://doc.rust-lang.org/nightly/std/marker/trait.Sized.html):

It's *except `Self` **in traits*** specifically since e.g. the “sizedness” of `Self` in *structs* depends on the sizedness of the last field.

---

As an aside, in general not much is written about `Self` in the reference. That's why I chose this specific location in the docs.