### PR TITLE
update aliasing rules section of the reference

### DIFF
--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -28,7 +28,7 @@ code.
   (e.g. `addr_of!(&*expr)`).
 * Breaking the [pointer aliasing rules]. `Box<T>`, `&mut T` and `&T` follow
   LLVM’s scoped [noalias] model, except if the `&T` contains an
-  [`UnsafeCell<U>`]. References and boxes must not be dangling while they are
+  [`UnsafeCell<U>`]. References and boxes must not be [dangling] while they are
   live. The exact liveness duration is not specified, but some bounds exist:
   * For references, the liveness duration is upper-bounded by the syntactic
     lifetime assigned by the borrow checker; it cannot be live any *longer* than

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -31,7 +31,8 @@ code.
   [`UnsafeCell<U>`]. References and boxes must not be dangling while they are
   live. The exact liveness duration is not specified, but some bounds exist:
   * For references, the liveness duration is upper-bounded by the syntactic
-    lifetime assigned by the borrow checker.
+    lifetime assigned by the borrow checker; it cannot be live any *longer* than
+    that lifetime.
   * Each time a reference or box is passed to or returned from a function, it is
     considered live.
   * When a reference (but not a `Box`!) is passed to a function, it is live at

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -26,8 +26,15 @@ code.
 * Evaluating a [dereference expression] (`*expr`) on a raw pointer that is
   [dangling] or unaligned, even in [place expression context]
   (e.g. `addr_of!(&*expr)`).
-* Breaking the [pointer aliasing rules]. `&mut T` and `&T` follow LLVM’s scoped
-  [noalias] model, except if the `&T` contains an [`UnsafeCell<U>`].
+* Breaking the [pointer aliasing rules]. `Box<T>`, `&mut T` and `&T` follow LLVM’s
+  scoped noalias model, except if the `&T` contains an [`UnsafeCell<U>`].
+  References must not be dangling while they are live. (The exact liveness
+  duration is not specified, but it is certainly upper-bounded by the syntactic
+  lifetime assigned by the borrow checker. When a reference is passed to a
+  function, it is live at least as long as that function call, again except if
+  the `&T` contains an [`UnsafeCell<U>`].) All this also applies when values of
+  these types are passed in a (nested) field of a compound type, but not behind
+  pointer indirections.
 * Mutating immutable data. All data inside a [`const`] item is immutable. Moreover, all
   data reached through a shared reference or data owned by an immutable binding
   is immutable, unless that data is contained within an [`UnsafeCell<U>`].

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -27,7 +27,7 @@ code.
   [dangling] or unaligned, even in [place expression context]
   (e.g. `addr_of!(&*expr)`).
 * Breaking the [pointer aliasing rules]. `Box<T>`, `&mut T` and `&T` follow LLVM’s
-  scoped noalias model, except if the `&T` contains an [`UnsafeCell<U>`].
+  scoped [noalias] model, except if the `&T` contains an [`UnsafeCell<U>`].
   References must not be dangling while they are live. (The exact liveness
   duration is not specified, but it is certainly upper-bounded by the syntactic
   lifetime assigned by the borrow checker. When a reference is passed to a

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -26,14 +26,20 @@ code.
 * Evaluating a [dereference expression] (`*expr`) on a raw pointer that is
   [dangling] or unaligned, even in [place expression context]
   (e.g. `addr_of!(&*expr)`).
-* Breaking the [pointer aliasing rules]. `Box<T>`, `&mut T` and `&T` follow LLVM’s
-  scoped [noalias] model, except if the `&T` contains an [`UnsafeCell<U>`].
-  References must not be dangling while they are live. (The exact liveness
-  duration is not specified, but it is certainly upper-bounded by the syntactic
-  lifetime assigned by the borrow checker. When a reference is passed to a
-  function, it is live at least as long as that function call, again except if
-  the `&T` contains an [`UnsafeCell<U>`].) All this also applies when values of
-  these types are passed in a (nested) field of a compound type, but not behind
+* Breaking the [pointer aliasing rules]. `Box<T>`, `&mut T` and `&T` follow
+  LLVM’s scoped [noalias] model, except if the `&T` contains an
+  [`UnsafeCell<U>`]. References and boxes must not be dangling while they are
+  live. The exact liveness duration is not specified, but some bounds exist:
+  * For references, the liveness duration is upper-bounded by the syntactic
+    lifetime assigned by the borrow checker.
+  * Each time a reference or box is passed to or returned from a function, it is
+    considered live.
+  * When a reference (but not a `Box`!) is passed to a function, it is live at
+    least as long as that function call, again except if the `&T` contains an
+    [`UnsafeCell<U>`].
+
+  All this also applies when values of these
+  types are passed in a (nested) field of a compound type, but not behind
   pointer indirections.
 * Mutating immutable data. All data inside a [`const`] item is immutable. Moreover, all
   data reached through a shared reference or data owned by an immutable binding


### PR DESCRIPTION
This makes explicit some de-facto rules that existed at least since Rust 1.0:
- Boxes also have aliasing requirements.
- References must outlive functions they are passed to. (It is not *entirely* clear that this was intended when the `dereferenceable` attribute was added, given that the attribute was also added to `Box` which can definitely be deallocated by functions they are passed to. But when that got fixed in https://github.com/rust-lang/rust/issues/66600, nobody suggested to also remove the attribute from references.)

Irrespective of whether we actually *want* these rules, they *do* reflect our current requirements and code not following them risks miscompilations. As such I think we should document them here and consider them the baseline for changes to the aliasing model. It's not great to have a baseline that was never carefully reviewed or designed, but for better or worse that's where we are at.

Also incorporates https://github.com/rust-lang/rust/pull/98017.

[Rendered](https://github.com/RalfJung/reference/blob/aliasing/src/behavior-considered-undefined.md)

Cc @rust-lang/lang