### PR TITLE
Primitive bit validity and padding guarantees

### DIFF
--- a/src/types/boolean.md
+++ b/src/types/boolean.md
@@ -17,6 +17,9 @@ value false has the bit pattern `0x00` and the value true has the bit pattern
 `0x01`. It is [undefined behavior] for an object with the boolean type to have
 any other bit pattern.
 
+The boolean type contains no padding or otherwise uninitialized bytes. In other
+words, `transmute::<bool, u8>(...)` is guaranteed to be sound.
+
 The boolean type is the type of many operands in various [expressions]:
 
 * The condition operand in [if expressions] and [while expressions]

--- a/src/types/numeric.md
+++ b/src/types/numeric.md
@@ -45,3 +45,11 @@ within an object along with one byte past the end.
 > `isize` are either 32-bit or 64-bit. As a consequence, 16-bit
 > pointer support is limited and may require explicit care and acknowledgment
 > from a library to support.
+
+## Bit validity and padding
+
+For each primitive integer and floating-point type, `T`:
+- Any sequence of `size_of::<T>()` bytes is a valid instance of `T` (in other
+  words, `transmute::<[u8; size_of::<T>()], T>(...)` is guaranteed to be sound).
+- `T` contains no padding or otherwise uninitialized bytes (in other words,
+  `transmute::<T, [u8; size_of::<T>()]>(...)` is guaranteed to be sound).

--- a/src/types/textual.md
+++ b/src/types/textual.md
@@ -8,8 +8,8 @@ or 0xE000 to 0x10FFFF range. It is immediate [Undefined Behavior] to create a
 `char` that falls outside this range. A `[char]` is effectively a UCS-4 / UTF-32
 string of length 1.
 
-The `char` type has no padding or otherwise uninitialized bytes. In other words,
-`transmute::<char, [u8; 4]>(...)` is guaranteed to be sound.
+The `char` type contains no padding or otherwise uninitialized bytes. In other
+words, `transmute::<char, [u8; 4]>(...)` is guaranteed to be sound.
 
 A value of type `str` is represented the same way as `[u8]`: it is a slice of
 8-bit unsigned bytes. However, the Rust standard library makes extra assumptions

--- a/src/types/textual.md
+++ b/src/types/textual.md
@@ -8,7 +8,10 @@ or 0xE000 to 0x10FFFF range. It is immediate [Undefined Behavior] to create a
 `char` that falls outside this range. A `[char]` is effectively a UCS-4 / UTF-32
 string of length 1.
 
-A value of type `str` is represented the same way as `[u8]`, it is a slice of
+The `char` type has no padding or otherwise uninitialized bytes. In other words,
+`transmute::<char, [u8; 4]>(...)` is guaranteed to be sound.
+
+A value of type `str` is represented the same way as `[u8]`: it is a slice of
 8-bit unsigned bytes. However, the Rust standard library makes extra assumptions
 about `str`: methods working on `str` assume and ensure that the data in there
 is valid UTF-8. Calling a `str` method with a non-UTF-8 buffer can cause


### PR DESCRIPTION
Resolves https://github.com/rust-lang/reference/issues/1291