### PR TITLE
Disallow newline directly following `//`

### DIFF
--- a/src/comments.md
+++ b/src/comments.md
@@ -2,7 +2,7 @@
 
 > **<sup>Lexer</sup>**\
 > LINE_COMMENT :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `//` (~\[`/` `!`] | `//`) ~`\n`<sup>\*</sup>\
+> &nbsp;&nbsp; &nbsp;&nbsp; `//` (~\[`/` `!` `\n`] | `//`) ~`\n`<sup>\*</sup>\
 > &nbsp;&nbsp; | `//`
 >
 > BLOCK_COMMENT :\


### PR DESCRIPTION
Currently this reference marks up e.g.
```rust
fn main() { //
    println!("Hello, world!");
}
```
as

```
fn main() { <comment-start>//
    println!("Hello, world!");<comment-end>
}
```
because the ~\[`/` `!`] rule allows a newline to sneak in before the ~`\n`*