### PR TITLE
Document native library modifier `verbatim`

### DIFF
--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -201,6 +201,22 @@ The default for this modifier is `-whole-archive`.
 More implementation details about this modifier can be found in
 [`whole-archive` documentation for rustc].
 
+### Linking modifiers: `verbatim`
+
+This modifier is compatible with all linking kinds.
+
+`+verbatim` means that rustc itself won't add any target-specified library prefixes or suffixes
+(like `lib` or `.a`) to the library name, and will try its best to ask for the same thing from the
+linker.
+
+`-verbatim` means that rustc will either add a target-specific prefix and suffix to the library
+name before passing it to linker, or won't prevent linker from implicitly adding it.
+
+The default for this modifier is `-verbatim`.
+
+More implementation details about this modifier can be found in
+[`verbatim` documentation for rustc].
+
 #### `dylib` versus `raw-dylib`
 
 On Windows, linking against a dynamic library requires that an import library
@@ -288,4 +304,5 @@ restrictions as [regular function parameters].
 [regular function parameters]: functions.md#attributes-on-function-parameters
 [`bundle` documentation for rustc]: ../../rustc/command-line-arguments.html#linking-modifiers-bundle
 [`whole-archive` documentation for rustc]: ../../rustc/command-line-arguments.html#linking-modifiers-whole-archive
+[`verbatim` documentation for rustc]: ../../rustc/command-line-arguments.html#linking-modifiers-verbatim
 [`dylib` versus `raw-dylib`]: #dylib-versus-raw-dylib


### PR DESCRIPTION
This is an accompanying PR for `verbatim` stabilization in https://github.com/rust-lang/rust/pull/104360.