### PR TITLE
Add an anchor to the "forwarding macro fragments" paragraph

### DIFF
--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -76,7 +76,7 @@ delimiters for the matcher will match any pair of delimiters. Thus, for
 instance, the matcher `(())` will match `{()}` but not `{{}}`. The character
 `$` cannot be matched or transcribed literally.
 
-#### Forwarding a matched fragment
+### Forwarding a matched fragment
 
 When forwarding a matched fragment to another macro-by-example, matchers in
 the second macro will see an opaque AST of the fragment type. The second macro

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -76,6 +76,8 @@ delimiters for the matcher will match any pair of delimiters. Thus, for
 instance, the matcher `(())` will match `{()}` but not `{{}}`. The character
 `$` cannot be matched or transcribed literally.
 
+#### Forwarding a matched fragment
+
 When forwarding a matched fragment to another macro-by-example, matchers in
 the second macro will see an opaque AST of the fragment type. The second macro
 can't use literal tokens to match the fragments in the matcher, only a


### PR DESCRIPTION
Since this is a subtle idiosyncracy into which macro users sometimes bump, it can be incredibly helpful to give them a pin-pointed link to the exact paragraph talking about this. Hence the idea of adding some kind of header, and thus an anchor, to it. Since it's just a paragraph, I've gone for a very low header, such as h4.

cc @nilstrieb