### PR TITLE
Clearly specify the `instruction_set` effects

### DIFF
--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -361,6 +361,10 @@ It uses the [_MetaListPath_] syntax, and a path comprised of the architecture fa
 
 [_MetaListPath_]: ../attributes.md#meta-item-attribute-syntax
 
+It is a compilation error to use the `instruction_set` attribute on a target that does not support it.
+
+### On ARM
+
 For the `ARMv4T` and `ARMv5te` architectures, the following are supported:
 
 * `arm::a32` - Generate the function as A32 "ARM" code.
@@ -375,9 +379,7 @@ fn foo_arm_code() {}
 fn bar_thumb_code() {}
 ```
 
-If your function has neither the `instruction_set` attribute nor inline assembly, then the code you write within that function should not presume any particular instruction set.
-This ends up creating a limitation to how often code is inlined:
+Using the `instruction_set` attribute has the following effects:
 
-* If a function has an `instruction_set` attribute it won't inline into a function of another instruction set.
-* If a function does not have an `instruction_set` attribute but *does* contain inline assembly, then the inline assembly is assumed to require the default instruction set of the build target, and so inlining between different instruction sets won't happen.
-* Otherwise, inlining happens normally.
+* If the address of the function is taken as a function pointer, the low bit of the address will be set to 0 (arm) or 1 (thumb) depending on the instruction set.
+* Any inline assembly in the function must use the specified instruction set instead of the target default.

--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -355,15 +355,16 @@ trait object whose methods are attributed.
 
 ## The `instruction_set` attribute
 
-The *`instruction_set` attribute* may be applied to a function to enable code generation for a specific
-instruction set supported by the target architecture. It uses the [_MetaListPath_] syntax and a path
-comprised of the architecture and instruction set to specify how to generate the code for
-architectures where a single program may utilize multiple instruction sets.
+On some CPU architectures it is possible to mix more than one instruction set into a single program.
+The `instruction_set` attribute lets you control which instruction set a particular function will be generated for.
+It uses the [_MetaListPath_] syntax, and a path comprised of the architecture family name and instruction set name.
 
-The following values are available on targets for the `ARMv4` and `ARMv5te` architectures:
+[_MetaListPath_]: ../attributes.md#meta-item-attribute-syntax
 
-* `arm::a32` - Uses ARM code.
-* `arm::t32` - Uses Thumb code.
+For the `ARMv4T` and `ARMv5te` architectures, the following are supported:
+
+* `arm::a32` - Generate the function as A32 "ARM" code.
+* `arm::t32` - Generate the function as T32 "Thumb" code.
 
 <!-- ignore: arm-only -->
 ```rust,ignore
@@ -374,4 +375,8 @@ fn foo_arm_code() {}
 fn bar_thumb_code() {}
 ```
 
-[_MetaListPath_]: ../attributes.md#meta-item-attribute-syntax
+The rules for inlining functions using the `instruction_set` attribute are slightly more strict than normal:
+
+* If a function has an `instruction_set` attribute, then the function is assumed to require the given instruction set and it won't inline into a function of another instruction set.
+* If a function does not have an `instruction_set` attribute but *does* contain inline assembly, then the inline assembly is assumed to require the default instruction set of the build target and so inlining between instruction sets won't happen.
+* Otherwise, a function is assumed to not rely on a particular instruction set and the function *may* be inlined into any calling function (all other restrictions on inlining still apply).

--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -375,8 +375,9 @@ fn foo_arm_code() {}
 fn bar_thumb_code() {}
 ```
 
-The rules for inlining functions using the `instruction_set` attribute are slightly more strict than normal:
+If your function has neither the instruction_set attribute nor inline assembly, then the code you write within that function should not presume any particular instruction set.
+This ends up creating a limitation to how often code is inlined:
 
-* If a function has an `instruction_set` attribute, then the function is assumed to require the given instruction set and it won't inline into a function of another instruction set.
-* If a function does not have an `instruction_set` attribute but *does* contain inline assembly, then the inline assembly is assumed to require the default instruction set of the build target and so inlining between instruction sets won't happen.
-* Otherwise, a function is assumed to not rely on a particular instruction set and the function *may* be inlined into any calling function (all other restrictions on inlining still apply).
+* If a function has an `instruction_set` attribute it won't inline into a function of another instruction set.
+* If a function does not have an `instruction_set` attribute but *does* contain inline assembly, then the inline assembly is assumed to require the default instruction set of the build target, and so inlining between different instruction sets won't happen.
+* Otherwise, inlining happens normally.

--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -375,7 +375,7 @@ fn foo_arm_code() {}
 fn bar_thumb_code() {}
 ```
 
-If your function has neither the instruction_set attribute nor inline assembly, then the code you write within that function should not presume any particular instruction set.
+If your function has neither the `instruction_set` attribute nor inline assembly, then the code you write within that function should not presume any particular instruction set.
 This ends up creating a limitation to how often code is inlined:
 
 * If a function has an `instruction_set` attribute it won't inline into a function of another instruction set.

--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -355,8 +355,8 @@ trait object whose methods are attributed.
 
 ## The `instruction_set` attribute
 
-On some CPU architectures it is possible to mix more than one instruction set into a single program.
-The `instruction_set` attribute lets you control which instruction set a particular function will be generated for.
+The *`instruction_set` [attribute]* may be applied to a function to control which instruction set the function will be generated for.
+This allows mixing more than one instruction set in a single program on CPU architectures that support it.
 It uses the [_MetaListPath_] syntax, and a path comprised of the architecture family name and instruction set name.
 
 [_MetaListPath_]: ../attributes.md#meta-item-attribute-syntax


### PR DESCRIPTION
~~This updates the `instruction_set` attribute entry to more clearly explain the additional restrictions that the attribute places on inlining. Since Rust performance heavily relies on inlining, it's actually a fairly big deal to document it.~~

~~Pinging @pnkfelix as the liaison for the `instruction_set` attribute during its development.~~

~~This explanation is actually slightly looser than the explanation given in the RFC: this explanation allows inlining between no-attribute code without inline asm and other code. So, T-lang should likely approve the update with an FCP or similar process. The intent is that once this is approved as the documentation for how the attribute works then https://github.com/rust-lang/rust/pull/104121 (which updates the MIR inliner to match these rules) will be easier to land.~~

Updates the attributes page to specify what the `instruction_set` attribute does and where you can use it.