### PR TITLE
Fix parsing of doc comments which are turned into raw strings

### DIFF
--- a/src/comments.md
+++ b/src/comments.md
@@ -44,8 +44,8 @@ Non-doc comments are interpreted as a form of whitespace.
 Line doc comments beginning with exactly _three_ slashes (`///`), and block
 doc comments (`/** ... */`), both inner doc comments, are interpreted as a
 special syntax for [`doc` attributes]. That is, they are equivalent to writing
-`#[doc="..."]` around the body of the comment, i.e., `/// Foo` turns into
-`#[doc="Foo"]` and `/** Bar */` turns into `#[doc="Bar"]`.
+`#[doc=r"..."]` around the body of the comment, i.e., `/// Foo` turns into
+`#[doc=r"Foo"]` and `/** Bar */` turns into `#[doc=r"Bar"]`.
 
 Line comments beginning with `//!` and block comments `/*! ... */` are
 doc comments that apply to the parent of the comment, rather than the item


### PR DESCRIPTION
PR prompted by https://github.com/dtolnay/syn/issues/771

```rust
macro_rules! m {
    (#[doc = $tt:tt]) => { stringify!($tt) };
}

fn main() {
    println!(m! {
        ///test
    });
   // output: r"test"
}
```

Will also open a PR for rustdoc