### PR TITLE
Syntax correction for trait-bounds.md

### DIFF
--- a/src/trait-bounds.md
+++ b/src/trait-bounds.md
@@ -27,7 +27,7 @@ provided on any type in a [where clause]. There are also shorter forms for
 certain common cases:
 
 * Bounds written after declaring a [generic parameter][generic]:
-  `fn f<A: Copy>() {}` is the same as `fn f<A> where A: Copy () {}`.
+  `fn f<A: Copy>() {}` is the same as `fn f<A>() where A: Copy {}`.
 * In trait declarations as [supertraits]: `trait Circle : Shape {}` is
   equivalent to `trait Circle where Self : Shape {}`.
 * In trait declarations as bounds on [associated types]:


### PR DESCRIPTION
```rs
fn f<A> where A: Copy () {} // ->
fn f<A>() where A: Copy {}
```

The former isn't valid Rust as far as I can tell, though I may be missing something.

```
   Compiling playground v0.0.1 (/playground)
error: expected `(`, found keyword `where`
 --> src/lib.rs:1:9
  |
1 | fn f<A> where A: Copy () {}
  |         ^^^^^ expected `(`

error: could not compile `playground` due to previous error
```