### PR TITLE
Reword "expression for a match arm"

### DIFF
--- a/src/destructors.md
+++ b/src/destructors.md
@@ -162,7 +162,6 @@ smallest scope that contains the expression and is one of the following:
 * The `else` block of an `if` expression.
 * The condition expression of an `if` or `while` expression, or a `match`
   guard.
-* The expression for a match arm.
 * The second operand of a [lazy boolean expression].
 
 > **Notes**:

--- a/src/destructors.md
+++ b/src/destructors.md
@@ -162,6 +162,7 @@ smallest scope that contains the expression and is one of the following:
 * The `else` block of an `if` expression.
 * The condition expression of an `if` or `while` expression, or a `match`
   guard.
+* The body expression for a match arm.
 * The second operand of a [lazy boolean expression].
 
 > **Notes**:


### PR DESCRIPTION
It's unclear what this bullet means. If it means a match guard, that is covered in the line above. If it referred to the scrutinee, that would be wrong. I don't think it's possible to embed an expression inside of a match arm _pattern_.

This came up in the [lang team triage meeting][meeting].

[meeting]: https://hackmd.io/JACzq-ssT4qtH0DS3B8nQQ?both#%E2%80%9CIntroduce-terminating-scope-for-tail-expressions-of-breakable-scopes%E2%80%9D-rust106493