### PR TITLE
Clarify that free constants are always evaluated at compile time

### DIFF
--- a/src/items/constant-items.md
+++ b/src/items/constant-items.md
@@ -89,10 +89,15 @@ m!(const _: () = (););
 // const _: () = ();
 ```
 
-Unnamed constants are always [evaluated][const_eval] at compile-time to surface
+## Evaluation
+
+[Free][free] constants are always [evaluated][const_eval] at compile-time to surface
 panics. This happens even within an unused function:
 
 ```rust,compile_fail
+// Compile-time panic
+const PANIC: () = std::unimplemented!();
+
 fn unused_generic_function<T>() {
     // A failing compile-time assertion
     const _: () = assert!(usize::BITS == 0);

--- a/src/items/constant-items.md
+++ b/src/items/constant-items.md
@@ -89,6 +89,17 @@ m!(const _: () = (););
 // const _: () = ();
 ```
 
+Unnamed constants are always [evaluated][const_eval] at compile-time to surface
+panics. This happens even within an unused function:
+
+```rust,compile_fail
+fn unused_generic_function<T>() {
+    // A failing compile-time assertion
+    const _: () = assert!(usize::BITS == 0);
+}
+```
+
+[const_eval]: ../const_eval.md
 [associated constant]: ../items/associated-items.md#associated-constants
 [constant value]: ../const_eval.md#constant-expressions
 [free]: ../glossary.md#free-item


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/93838
It seems like everyone is onboard with blessing this (useful) behavior as stable.
