### PR TITLE
Add `\r\n` to string_continue grammar

### DIFF
--- a/src/tokens.md
+++ b/src/tokens.md
@@ -148,7 +148,7 @@ which must be _escaped_ by a preceding `U+005C` character (`\`).
 > &nbsp;&nbsp; )<sup>\*</sup> `"` SUFFIX<sup>?</sup>
 >
 > STRING_CONTINUE :\
-> &nbsp;&nbsp; `\` _followed by_ \\n
+> &nbsp;&nbsp; `\` _followed by_ \\n _or_ \\r\\n
 
 A _string literal_ is a sequence of any Unicode characters enclosed within two
 `U+0022` (double-quote) characters, with the exception of `U+0022` itself,


### PR DESCRIPTION
Not sure if this is necessary, but I wasn't 100% sure that crlf line endings would be supported (though in hindsight would be strange if they weren't)