### PR TITLE
Add an entry for macro_rules in the "Weak keywords" lexer block

### DIFF
--- a/src/keywords.md
+++ b/src/keywords.md
@@ -111,6 +111,7 @@ is possible to declare a variable or method with the name `union`.
   Beginning in the 2018 edition, `dyn` has been promoted to a strict keyword.
 
 > **<sup>Lexer</sup>**\
+> KW_MACRO_RULES    : `macro_rules`\
 > KW_UNION          : `union`\
 > KW_STATICLIFETIME : `'static`
 >


### PR DESCRIPTION
Closes #1348

There are no other two-word keywords, so I'm not sure whether `KW_MACRO_RULES` or `KW_MACRORULES` is better; I used the former.

