### PR TITLE
fixed minor error in a comment that annotated output of a proc macro

### DIFF
--- a/src/procedural-macros.md
+++ b/src/procedural-macros.md
@@ -251,7 +251,7 @@ use my_macro::show_streams;
 #[show_streams]
 fn invoke1() {}
 // out: attr: ""
-// out: item: "fn invoke1() { }"
+// out: item: "fn invoke1() {}"
 
 // Example: Attribute with input
 #[show_streams(bar)]


### PR DESCRIPTION
A comment in the procedural macros chapter had a space that meant it was wrongly annotating what a piece of code would output.