### PR TITLE
Fix example code in `impl` docs

### DIFF
--- a/src/types/impl-trait.md
+++ b/src/types/impl-trait.md
@@ -31,15 +31,15 @@ The caller must provide a type that satisfies the bounds declared by the anonymo
 
 For example, these two forms are almost equivalent:
 
-```rust,ignore
+```rust
 trait Trait {}
 
 // generic type parameter
-fn foo<T: Trait>(arg: T) {
+fn with_generic_type<T: Trait>(arg: T) {
 }
 
 // impl Trait in argument position
-fn foo(arg: impl Trait) {
+fn with_impl_trait(arg: impl Trait) {
 }
 ```
 
@@ -96,8 +96,11 @@ With `impl Trait`, unlike with a generic type parameter, the function chooses th
 
 The function:
 
-```rust,ignore
+```rust
+# trait Trait {}
 fn foo<T: Trait>() -> T {
+    // ...
+# panic!()
 }
 ```
 
@@ -105,8 +108,11 @@ allows the caller to determine the return type, `T`, and the function returns th
 
 The function:
 
-```rust,ignore
+```rust
+# trait Trait {}
+# impl Trait for () {}
 fn foo() -> impl Trait {
+    // ...
 }
 ```
 

--- a/src/types/impl-trait.md
+++ b/src/types/impl-trait.md
@@ -98,6 +98,7 @@ The function:
 
 ```rust,ignore
 fn foo<T: Trait>() -> T {
+}
 ```
 
 allows the caller to determine the return type, `T`, and the function returns that type.
@@ -106,6 +107,7 @@ The function:
 
 ```rust,ignore
 fn foo() -> impl Trait {
+}
 ```
 
 doesn't allow the caller to determine the return type.


### PR DESCRIPTION
Tiny fixes for invalid code examples in the [`impl` docs](https://doc.rust-lang.org/reference/types/impl-trait.html#differences-between-generics-and-impl-trait-in-return-position).