### PR TITLE
Fix inconsistent formatting of Disambiguating Function Calls example

### DIFF
--- a/src/expressions/call-expr.md
+++ b/src/expressions/call-expr.md
@@ -48,7 +48,7 @@ trait Pretty {
 }
 
 trait Ugly {
-  fn print(&self);
+    fn print(&self);
 }
 
 struct Foo;


### PR DESCRIPTION
Before:

![inconsistency in formatting before the change](https://github.com/rust-lang/reference/assets/5955761/84e6289b-bc2b-45f5-a37c-31b08d3be103)

After:

![inconsistency in formatting after the change](https://github.com/rust-lang/reference/assets/5955761/2a9d5c72-cafb-4652-9f9f-4523cf216b32)

