### PR TITLE
fix incorrect syntax for type-paths

### DIFF
--- a/src/paths.md
+++ b/src/paths.md
@@ -125,7 +125,7 @@ S::f();  // Calls the inherent impl.
 > &nbsp;&nbsp; `::`<sup>?</sup> _TypePathSegment_ (`::` _TypePathSegment_)<sup>\*</sup>
 >
 > _TypePathSegment_ :\
-> &nbsp;&nbsp; _PathIdentSegment_ `::`<sup>?</sup> ([_GenericArgs_] | _TypePathFn_)<sup>?</sup>
+> &nbsp;&nbsp; _PathIdentSegment_ (`::`<sup>?</sup> ([_GenericArgs_] | _TypePathFn_))<sup>?</sup>
 >
 > _TypePathFn_ :\
 > `(` _TypePathFnInputs_<sup>?</sup> `)` (`->` [_Type_])<sup>?</sup>


### PR DESCRIPTION
The current syntax allows for invalid paths, such as:

- `hello::world::` as the trailing `::` would be caught by the incorrectly mapped option
- `hello::::world` as the first `::` would be caught by the incorrectly mapped option

This PR fixes these ambiguities.