### PR TITLE
fix incorrect pattern syntax

### DIFF
--- a/src/patterns.md
+++ b/src/patterns.md
@@ -659,7 +659,8 @@ A struct pattern is refutable when one of its subpatterns is refutable.
 > &nbsp;&nbsp; [_PathInExpression_] `(` _TupleStructItems_<sup>?</sup> `)`
 >
 > _TupleStructItems_ :\
-> &nbsp;&nbsp; [_Pattern_]&nbsp;( `,` [_Pattern_] )<sup>\*</sup> `,`<sup>?</sup>
+> &nbsp;&nbsp; &nbsp;&nbsp; [_Pattern_] (`,` [_Pattern_])<sup>\*</sup> `,`<sup>?</sup>\
+> &nbsp;&nbsp; | ([_Pattern_] `,`)<sup>\*</sup> `..` (`,` [_Pattern_])<sup>\*</sup> `,`<sup>?</sup>
 
 Tuple struct patterns match tuple struct and enum values that match all criteria defined by its subpatterns.
 They are also used to [destructure](#destructuring) a tuple struct or enum value.
@@ -674,8 +675,8 @@ A tuple struct pattern is refutable when one of its subpatterns is refutable.
 >
 > _TuplePatternItems_ :\
 > &nbsp;&nbsp; &nbsp;&nbsp; [_Pattern_] `,`\
-> &nbsp;&nbsp; | [_RestPattern_]\
-> &nbsp;&nbsp; | [_Pattern_]&nbsp;(`,` [_Pattern_])<sup>+</sup> `,`<sup>?</sup>
+> &nbsp;&nbsp; | [_Pattern_]&nbsp;(`,` [_Pattern_])<sup>+</sup> `,`<sup>?</sup>\
+> &nbsp;&nbsp; | ([_Pattern_] `,`)<sup>\*</sup> `..` (`,` [_Pattern_])<sup>\*</sup> `,`<sup>?</sup>
 
 Tuple patterns match tuple values that match all criteria defined by its subpatterns.
 They are also used to [destructure](#destructuring) a tuple.


### PR DESCRIPTION
The current reference does not allow some valid tuple patterns. Here are all the patterns that have been added as valid according to the new syntax:

```rust
struct A(u8, u8, u8, u8);
struct B();

match A(1, 1, 1, 1) {
    A(10, 1, ..) => (),
    A(10, .., 10) => (),
    A(..) => (),
}
match B() {
    B() => (),
}

match (1, 1, 1, 1) {
    (10, 1, ..) => (),
    (10, .., 10) => (),
    (..) => (),
}
match (1, 1) {
    (..,) => (), // NOTE: Rust fmt removes the comma
}
``