### PR TITLE
Fix merge queue building twice.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,5 @@
 name: CI
 on:
-  push:
-    branches-ignore: [master]
   pull_request:
   merge_group:
 


### PR DESCRIPTION
The merge queue is currently firing off two jobs in parallel doing the exact same thing. My understanding is that this is because there is one trigger (merge_group) for the creation of the merge queue entry, and another trigger (push) for the push that GitHub does to a temporary branch to do the merge.

The solution here is to just drop the "push" trigger. I don't think that trigger is very useful now with the merge queue. It only makes sense if someone is creating new branches directly in this repo, and wanting to run CI jobs directly on those branches. For one, I don't think people should be creating branches here. Second, even if they do, I don't think they really need to run CI (PRs are good enough for that).
