### PR TITLE
Operator expressions: make the note about division by zero clearer.

### DIFF
--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -258,7 +258,7 @@ The operands of all of these operators are evaluated in [value expression contex
 \*\*\* Arithmetic right shift on signed integer types, logical right shift on
 unsigned integer types.
 
-† Division by zero panics.
+† For integer types, division by zero panics.
 
 Here are examples of these operators being used.
 


### PR DESCRIPTION
Say that the note applies to integer division only (compare the note about rounding to zero).

Addresses #1375
