### PR TITLE
Update macros-by-example.md

### DIFF
--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -23,7 +23,7 @@
 > _MacroMatch_ :\
 > &nbsp;&nbsp; &nbsp;&nbsp; [_Token_]<sub>_except `$` and [delimiters]_</sub>\
 > &nbsp;&nbsp; | _MacroMatcher_\
-> &nbsp;&nbsp; | `$` ( [IDENTIFIER_OR_KEYWORD] <sub>_except `crate`_</sub> | [RAW_IDENTIFIER] | `_` ) `:` _MacroFragSpec_\
+> &nbsp;&nbsp; | `$` ( [IDENTIFIER_OR_KEYWORD] <sub>_except `crate`_</sub> | [RAW_IDENTIFIER] | `_` ) `:` _MacroFragSpec_ _MacroRepOp_\
 > &nbsp;&nbsp; | `$` `(` _MacroMatch_<sup>+</sup> `)` _MacroRepSep_<sup>?</sup> _MacroRepOp_
 >
 > _MacroFragSpec_ :\


### PR DESCRIPTION
Seems like the parser wants MacroFragSpec at the end?
![image](https://github.com/rust-lang/reference/assets/93560662/67864cdc-f646-4ceb-973c-f3526125bc67)
