### PR TITLE
Specify bit validity and padding of some types

### DIFF
--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -58,11 +58,11 @@ aligned to 32 bits.
 
 For the primitive numeric types (`u8`, `i8`, `u16`, `i16`, `u32`, `i32`, `u64`,
 `i64`, `u128`, `i128`, `usize`, `isize`, `f32`, and `f64`), every bit pattern
-represents a valid instance of the type (in other words,
-`transmute::<[u8; size_of::<T>()], T>(...)` is always sound). For the primitive
-numeric types and also for `bool` and `char`, every byte is guaranteed to be
-initialized (in other words, `transmute::<T, [u8; size_of::<T>()]>(...)` is always
-sound).
+represents a valid instance of the type (in other words, for every primitive numeric
+type, `T`, `transmute::<[u8; size_of::<T>()], T>(...)` is always sound). For the
+primitive numeric types and also for `bool` and `char`, every byte is guaranteed to be
+initialized (in other words, for every such type, `T`,
+`transmute::<T, [u8; size_of::<T>()]>(...)` is always sound).
 
 ## Pointers and References Layout
 

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -64,9 +64,9 @@ a valid `u8`. A byte at any offset in a reference or pointer type may not be a
 valid `u8` (the semantics of transmuting a reference or pointer to a non-pointer
 type is currently undecided).
 
-For the primitive numeric types and also for `bool` and `char`, every byte is
+For `bool` and `char`, every byte is
 guaranteed to be initialized (in other words, for every such type, `T`,
-`transmute::<T, [u8; size_of::<T>()]>(...)` is always sound).
+`transmute::<T, [u8; size_of::<T>()]>(...)` is always sound -- but the inverse is not).
 
 ## Pointers and References Layout
 

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -60,9 +60,9 @@ For every primitive numeric type (`u8`, `i8`, `u16`, `i16`, `u32`, `i32`, `u64`,
 `i64`, `u128`, `i128`, `usize`, `isize`, `f32`, and `f64`), `T`, the bit validity
 of `T` is equivalent to the bit validity of `[u8; size_of::<T>()]`. `u8` has 256
 valid representations (namely, every 8-bit sequence). An uninitialized byte is not
-a valid u8. A byte at any offset in a reference or pointer type may not be a valid
-u8 (the semantics of transmuting a reference or pointer to a non-pointer type is
-currently undecided).
+a valid `u8`. A byte at any offset in a reference or pointer type may not be a
+valid `u8` (the semantics of transmuting a reference or pointer to a non-pointer
+type is currently undecided).
 
 For the primitive numeric types and also for `bool` and `char`, every byte is
 guaranteed to be initialized (in other words, for every such type, `T`,

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -61,7 +61,7 @@ For the primitive numeric types (`u8`, `i8`, `u16`, `i16`, `u32`, `i32`, `u64`,
 represents a valid instance of the type (in other words,
 `transmute::<[u8; size_of::<T>()], T>(...)` is always sound). For the primitive
 numeric types and also for `bool` and `char`, every byte is guaranteed to be
-initialized (in other words, `transmute::<T, [u8; size_of::<T>()]>(...) is always
+initialized (in other words, `transmute::<T, [u8; size_of::<T>()]>(...)` is always
 sound).
 
 ## Pointers and References Layout

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -56,12 +56,16 @@ Most primitives are generally aligned to their size, although this is
 platform-specific behavior. In particular, on x86 u64 and f64 are only
 aligned to 32 bits.
 
-For the primitive numeric types (`u8`, `i8`, `u16`, `i16`, `u32`, `i32`, `u64`,
-`i64`, `u128`, `i128`, `usize`, `isize`, `f32`, and `f64`), every bit pattern
-represents a valid instance of the type (in other words, for every primitive numeric
-type, `T`, `transmute::<[u8; size_of::<T>()], T>(...)` is always sound). For the
-primitive numeric types and also for `bool` and `char`, every byte is guaranteed to be
-initialized (in other words, for every such type, `T`,
+For every primitive numeric type (`u8`, `i8`, `u16`, `i16`, `u32`, `i32`, `u64`,
+`i64`, `u128`, `i128`, `usize`, `isize`, `f32`, and `f64`), `T`, the bit validity
+of `T` is equivalent to the bit validity of `[u8; size_of::<T>()]`. `u8` has 256
+valid representations (namely, every 8-bit sequence). An uninitialized byte is not
+a valid u8. A byte at any offset in a reference or pointer type may not be a valid
+u8 (the semantics of transmuting a reference or pointer to a non-pointer type is
+currently undecided).
+
+For the primitive numeric types and also for `bool` and `char`, every byte is
+guaranteed to be initialized (in other words, for every such type, `T`,
 `transmute::<T, [u8; size_of::<T>()]>(...)` is always sound).
 
 ## Pointers and References Layout
@@ -69,10 +73,7 @@ initialized (in other words, for every such type, `T`,
 Pointers and references have the same layout. Mutability of the pointer or
 reference does not change the layout.
 
-Pointers to sized types have the same size and alignment as `usize`. Every
-byte of a pointer to a sized type and of a reference to a sized type is
-initialized (in other words, for such a pointer or reference type, `P`,
-`transmute::<P, [u8; size_of::<P>()]>(...)` is always sound).
+Pointers to sized types have the same size and alignment as `usize`.
 
 Pointers to unsized types are sized. The size and alignment is guaranteed to be
 at least equal to the size and alignment of a pointer.

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -56,17 +56,6 @@ Most primitives are generally aligned to their size, although this is
 platform-specific behavior. In particular, on x86 u64 and f64 are only
 aligned to 32 bits.
 
-For every primitive numeric type (`u8`, `i8`, `u16`, `i16`, `u32`, `i32`, `u64`,
-`i64`, `u128`, `i128`, `usize`, `isize`, `f32`, and `f64`), `T`, the bit validity
-of `T` is equivalent to the bit validity of `[u8; size_of::<T>()]`. An
-uninitialized byte is not a valid `u8`. A byte at any offset in a reference or
-pointer type may not be a valid `u8` (the semantics of transmuting a reference or
-pointer to a non-pointer type is currently undecided).
-
-For `bool` and `char`, every byte is
-guaranteed to be initialized (in other words, for every such type, `T`,
-`transmute::<T, [u8; size_of::<T>()]>(...)` is always sound -- but the inverse is not).
-
 ## Pointers and References Layout
 
 Pointers and references have the same layout. Mutability of the pointer or

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -58,11 +58,10 @@ aligned to 32 bits.
 
 For every primitive numeric type (`u8`, `i8`, `u16`, `i16`, `u32`, `i32`, `u64`,
 `i64`, `u128`, `i128`, `usize`, `isize`, `f32`, and `f64`), `T`, the bit validity
-of `T` is equivalent to the bit validity of `[u8; size_of::<T>()]`. `u8` has 256
-valid representations (namely, every 8-bit sequence). An uninitialized byte is not
-a valid `u8`. A byte at any offset in a reference or pointer type may not be a
-valid `u8` (the semantics of transmuting a reference or pointer to a non-pointer
-type is currently undecided).
+of `T` is equivalent to the bit validity of `[u8; size_of::<T>()]`. An
+uninitialized byte is not a valid `u8`. A byte at any offset in a reference or
+pointer type may not be a valid `u8` (the semantics of transmuting a reference or
+pointer to a non-pointer type is currently undecided).
 
 For `bool` and `char`, every byte is
 guaranteed to be initialized (in other words, for every such type, `T`,

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -56,12 +56,23 @@ Most primitives are generally aligned to their size, although this is
 platform-specific behavior. In particular, on x86 u64 and f64 are only
 aligned to 32 bits.
 
+For the primitive numeric types (`u8`, `i8`, `u16`, `i16`, `u32`, `i32`, `u64`,
+`i64`, `u128`, `i128`, `usize`, `isize`, `f32`, and `f64`), every bit pattern
+represents a valid instance of the type (in other words,
+`transmute::<[u8; size_of::<T>()], T>(...)` is always sound). For the primitive
+numeric types and also for `bool` and `char`, every byte is guaranteed to be
+initialized (in other words, `transmute::<T, [u8; size_of::<T>()]>(...) is always
+sound).
+
 ## Pointers and References Layout
 
 Pointers and references have the same layout. Mutability of the pointer or
 reference does not change the layout.
 
-Pointers to sized types have the same size and alignment as `usize`.
+Pointers to sized types have the same size and alignment as `usize`. Every
+byte of a pointer to a sized type and of a reference to a sized type is
+initialized (in other words, for such a pointer or reference type, `P`,
+`transmute::<P, [u8; size_of::<P>()]>(...)` is always sound).
 
 Pointers to unsized types are sized. The size and alignment is guaranteed to be
 at least equal to the size and alignment of a pointer.

--- a/src/types/boolean.md
+++ b/src/types/boolean.md
@@ -92,6 +92,12 @@ boolean type for its operands, they evaluate using the rules of [boolean logic].
 * `a < b` is the same as `!(a >= b)`
 * `a <= b` is the same as `a == b | a < b`
 
+## Bit validity
+
+The single byte of a `bool` is guaranteed to be initialized (in other words,
+`transmute::<bool, u8>(...)` is always sound -- but since some bit patterns
+are invalid `bool`s, the inverse is not always sound).
+
 [boolean logic]: https://en.wikipedia.org/wiki/Boolean_algebra
 [enumerated type]: enum.md
 [expressions]: ../expressions.md

--- a/src/types/numeric.md
+++ b/src/types/numeric.md
@@ -45,3 +45,8 @@ within an object along with one byte past the end.
 > `isize` are either 32-bit or 64-bit. As a consequence, 16-bit
 > pointer support is limited and may require explicit care and acknowledgment
 > from a library to support.
+
+## Bit validity
+
+For every numeric type, `T`, the bit validity of `T` is equivalent to the bit
+validity of `[u8; size_of::<T>()]`. An uninitialized byte is not a valid `u8`.

--- a/src/types/pointer.md
+++ b/src/types/pointer.md
@@ -50,6 +50,12 @@ Raw pointers can be created directly using [`core::ptr::addr_of!`] for `*const` 
 
 The standard library contains additional 'smart pointer' types beyond references and raw pointers.
 
+## Bit validity
+
+Despite pointers and references being similar to `usize`s in the machine code emitted on most platforms,
+the semantics of transmuting a reference or pointer type to a non-pointer type is currently undecided.
+Thus, it may not be valid to transmute a pointer or reference type, `P`, to a `[u8; size_of::<P>()]`.
+
 [`core::ptr::addr_of!`]: ../../core/ptr/macro.addr_of.html
 [`core::ptr::addr_of_mut!`]: ../../core/ptr/macro.addr_of_mut.html
 [Interior mutability]: ../interior-mutability.md

--- a/src/types/pointer.md
+++ b/src/types/pointer.md
@@ -56,6 +56,10 @@ Despite pointers and references being similar to `usize`s in the machine code em
 the semantics of transmuting a reference or pointer type to a non-pointer type is currently undecided.
 Thus, it may not be valid to transmute a pointer or reference type, `P`, to a `[u8; size_of::<P>()]`.
 
+For thin raw pointers (i.e., for `<T as Pointee>::Metadata == ()` and `P = *const T` or `P = *mut T`),
+the inverse direction (transmuting from an integer or array of integers to `P`) is always valid.
+However, the pointer produced via such a transmutation may not be dereferenced (not even if `T` has size zero).
+
 [`core::ptr::addr_of!`]: ../../core/ptr/macro.addr_of.html
 [`core::ptr::addr_of_mut!`]: ../../core/ptr/macro.addr_of_mut.html
 [Interior mutability]: ../interior-mutability.md

--- a/src/types/pointer.md
+++ b/src/types/pointer.md
@@ -56,7 +56,7 @@ Despite pointers and references being similar to `usize`s in the machine code em
 the semantics of transmuting a reference or pointer type to a non-pointer type is currently undecided.
 Thus, it may not be valid to transmute a pointer or reference type, `P`, to a `[u8; size_of::<P>()]`.
 
-For thin raw pointers (i.e., for `<T as Pointee>::Metadata == ()` and `P = *const T` or `P = *mut T`),
+For thin raw pointers (i.e., for `P = *const T` or `P = *mut T` for `T: Sized`),
 the inverse direction (transmuting from an integer or array of integers to `P`) is always valid.
 However, the pointer produced via such a transmutation may not be dereferenced (not even if `T` has size zero).
 

--- a/src/types/textual.md
+++ b/src/types/textual.md
@@ -17,6 +17,12 @@ is valid UTF-8. Calling a `str` method with a non-UTF-8 buffer can cause
 Since `str` is a [dynamically sized type], it can only be instantiated through a
 pointer type, such as `&str`.
 
+## Bit validity
+
+Every byte of a `char` is guaranteed to be initialized (in other words,
+`transmute::<char, [u8; size_of::<char>()]>(...)` is always sound -- but since
+some bit patterns are invalid `char`s, the inverse is not always sound).
+
 [Unicode scalar value]: http://www.unicode.org/glossary/#unicode_scalar_value
 [Undefined Behavior]: ../behavior-considered-undefined.md
 [dynamically sized type]: ../dynamically-sized-types.md


### PR DESCRIPTION
Specify the bit validity and padding of the primitive numeric  types, bool, char, and pointer and reference types.

Closes #1291