### PR TITLE
type-layout: be more specific about 32-bit alignments

### DIFF
--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -53,8 +53,8 @@ target platform. For example, on a 32 bit target, this is 4 bytes and on a 64
 bit target, this is 8 bytes.
 
 Most primitives are generally aligned to their size, although this is
-platform-specific behavior. In particular, on x86 u64 and f64 are only
-aligned to 32 bits.
+platform-specific behavior. In particular, on many 32-bit platforms `u64`
+and `f64` are only aligned to 32 bits.
 
 ## Pointers and References Layout
 


### PR DESCRIPTION
The rust-reference implies that 64-bit types are aligned to 32-bit for platforms with 32-bit addresses. This is not necessarily correct. Fix the wording.

Note that there is no general rule how data-types greater than the native address size are aligned. On most Unix'y systems, they use the native alignment of the platform. However, the Windows ABI aligns them to their size (up to at least 64-bit).

There are advantages for either of those decisions. But we should at least make clear that there is no fixed rule for 32-bit platforms.