### PR TITLE
conditional-compilation.md: Mention the "none" target_os value

### DIFF
--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -129,6 +129,7 @@ Example values:
 * `"dragonfly"`
 * `"openbsd"`
 * `"netbsd"`
+* `"none"` (typical for embedded targets)
 
 ### `target_family`
 


### PR DESCRIPTION
As an embedded dev who uses Windows at work, it physically pains me when people use `#[cfg(target_os = "unix")]` when they actually mean `#[cfg(not(target_os = "none"))]`. Hopefully this will increase awareness that "none" is a valid `target_os`.