### PR TITLE
fix(trait docs): remove unnecessary `where Self: Sized` clause

### DIFF
--- a/src/items/traits.md
+++ b/src/items/traits.md
@@ -116,7 +116,7 @@ trait NonDispatchable {
     // `other` may be a different concrete type of the receiver.
     fn param(&self, other: Self) where Self: Sized {}
     // Generics are not compatible with vtables.
-    fn typed<T>(&self, x: T) where Self: Sized {}
+    fn typed<T>(&self, x: T) {}
 }
 
 struct S;


### PR DESCRIPTION
This is probably the result of a copy-paste but it's unnecessary for the purpose of the example and leads to the error returned by the playground to be about `where Self: Sized` first instead of the generic type `T`, making the example confusing for this error.