### PR TITLE
Guarantee that raw pointer conversions preserve slice element count

### DIFF
--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -480,7 +480,7 @@ assert_eq!(values[1], 3);
 
 #### Slice DST pointer to pointer cast
 
-When `T` and `U` are both "slice DSTs" - ie, slice types or types whose trailing field
+When `T` and `U` are both "slice DSTs" - i.e., slice types or types whose trailing field
 is a slice type - the raw pointer types `*const T`, `*mut T`, `*const U`, and `*mut U`
 encode the number of elements in this slice. Casts between these raw pointer types
 preserve the number of elements. Note that, as a consequence, such casts do *not*

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -480,12 +480,15 @@ assert_eq!(values[1], 3);
 
 #### Slice DST pointer to pointer cast
 
-For slice types like `[T]` and `[U]`, the raw pointer types `*const [T]`, `*mut [T]`, `*const [U]`, and `*mut [U]`
-encode the number of elements in this slice. Casts between these raw pointer types
-preserve the number of elements. Note that, as a consequence, such casts do *not*
-necessarily preserve the size of the pointer's referent (e.g., casting `*const [u16]`
-to `*const [u8]` will result in a raw pointer which refers to an object of half the size
-of the original).
+For slice types like `[T]` and `[U]`, the raw pointer types `*const [T]`, `*mut [T]`,
+`*const [U]`, and `*mut [U]` encode the number of elements in this slice. Casts between
+these raw pointer types preserve the number of elements. Note that, as a consequence,
+such casts do *not* necessarily preserve the size of the pointer's referent (e.g.,
+casting `*const [u16]` to `*const [u8]` will result in a raw pointer which refers to an
+object of half the size of the original). The same holds for `str` and any compound type
+whose unsized tail is a slice type, such as struct `Foo(i32, [u8])` or `(u64, Foo)`.
+
+
 
 ## Assignment expressions
 

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -480,8 +480,7 @@ assert_eq!(values[1], 3);
 
 #### Slice DST pointer to pointer cast
 
-When `T` and `U` are both "slice DSTs" - i.e., slice types or types whose trailing field
-is a slice type - the raw pointer types `*const T`, `*mut T`, `*const U`, and `*mut U`
+For slice types like `[T]` and `[U]`, the raw pointer types `*const [T]`, `*mut [T]`, `*const [U]`, and `*mut [U]`
 encode the number of elements in this slice. Casts between these raw pointer types
 preserve the number of elements. Note that, as a consequence, such casts do *not*
 necessarily preserve the size of the pointer's referent (e.g., casting `*const [u16]`

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -478,6 +478,16 @@ unsafe {
 assert_eq!(values[1], 3);
 ```
 
+#### Slice DST pointer to pointer cast
+
+When `T` and `U` are both "slice DSTs" - ie, slice types or types whose trailing field
+is a slice type - the raw pointer types `*const T`, `*mut T`, `*const U`, and `*mut U`
+encode the number of elements in this slice. Casts between these raw pointer types
+preserve the number of elements. Note that, as a consequence, such casts do *not*
+necessarily preserve the size of the pointer's referent (e.g., casting `*const [u16]`
+to `*const [u8]` will result in a raw pointer which refers to an object of half the size
+of the original).
+
 ## Assignment expressions
 
 > **<sup>Syntax</sup>**\

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -488,8 +488,6 @@ casting `*const [u16]` to `*const [u8]` will result in a raw pointer which refer
 object of half the size of the original). The same holds for `str` and any compound type
 whose unsized tail is a slice type, such as struct `Foo(i32, [u8])` or `(u64, Foo)`.
 
-
-
 ## Assignment expressions
 
 > **<sup>Syntax</sup>**\

--- a/src/type-coercions.md
+++ b/src/type-coercions.md
@@ -156,6 +156,16 @@ Coercion is allowed between the following types:
 
 * `!` to any `T`
 
+#### Slice DST raw pointer conversions
+
+When `T` and `U` are both "slice DSTs" - ie, slice types or types whose trailing field
+is a slice type - the raw pointer types `*const T`, `*mut T`, `*const U`, and `*mut U`
+encode the number of elements in this slice. Coercions between these raw pointer types
+preserve the number of elements. Note that, as a consequence, such coercions do *not*
+necessarily preserve the size of the pointer's referent (e.g., coercing `*const [u16]`
+to `*const [u8]` will result in a raw pointer which refers to an object of half the size
+of the original).
+
 ### Unsized Coercions
 
 The following coercions are called `unsized coercions`, since they

--- a/src/type-coercions.md
+++ b/src/type-coercions.md
@@ -156,16 +156,6 @@ Coercion is allowed between the following types:
 
 * `!` to any `T`
 
-#### Slice DST raw pointer conversions
-
-When `T` and `U` are both "slice DSTs" - ie, slice types or types whose trailing field
-is a slice type - the raw pointer types `*const T`, `*mut T`, `*const U`, and `*mut U`
-encode the number of elements in this slice. Coercions between these raw pointer types
-preserve the number of elements. Note that, as a consequence, such coercions do *not*
-necessarily preserve the size of the pointer's referent (e.g., coercing `*const [u16]`
-to `*const [u8]` will result in a raw pointer which refers to an object of half the size
-of the original).
-
 ### Unsized Coercions
 
 The following coercions are called `unsized coercions`, since they


### PR DESCRIPTION
This encodes the behavior agreed upon in https://github.com/rust-lang/unsafe-code-guidelines/issues/288.