### PR TITLE
Document that <- is a single token

### DIFF
--- a/src/tokens.md
+++ b/src/tokens.md
@@ -608,6 +608,7 @@ usages and meanings are defined in the linked pages.
 | `::`   | PathSep     | [Path separator][paths]
 | `->`   | RArrow      | [Function return type][functions], [Closure return type][closures], [Function pointer type]
 | `=>`   | FatArrow    | [Match arms][match], [Macros]
+| `<-`   | LArrow      | The left arrow symbol has been unused since before Rust 1.0, but it is still treated as a single token
 | `#`    | Pound       | [Attributes]
 | `$`    | Dollar      | [Macros]
 | `?`    | Question    | [Question mark operator][question], [Questionably sized][sized], [Macro Kleene Matcher][macros]


### PR DESCRIPTION
`<-` was the "move operator", removed in Rust 0.5, but is still lexed as a single token.

So I think it should be listed in the Punctuation table (like the tilde token is).

Originally reported as ferrocene/specification#452

Fixes #583

