### PR TITLE
Lone `self` in a method body resolves to the self parameter

### DIFF
--- a/src/paths.md
+++ b/src/paths.md
@@ -202,10 +202,19 @@ mod b {
 `self` resolves the path relative to the current module. `self` can only be used as the
 first segment, without a preceding `::`.
 
+In a method body, a path which consists of a single `self` segment resolves to the method's self parameter.
+
+
 ```rust
 fn foo() {}
 fn bar() {
     self::foo();
+}
+struct S(bool);
+impl S {
+  fn baz(self) {
+        self.0;
+    }
 }
 # fn main() {}
 ```


### PR DESCRIPTION
In a method body, a path expression consisting only of the keyword `self` resolves to the method's 'self parameter'.

(I checked PR #1052 and I think it doesn't add this case.)
