### PR TITLE
Reference wildcard patterns from underscore expr

### DIFF
--- a/src/expressions/underscore-expr.md
+++ b/src/expressions/underscore-expr.md
@@ -8,7 +8,7 @@ Underscore expressions, denoted with the symbol `_`, are used to signify a
 placeholder in a destructuring assignment. They may only appear in the left-hand
 side of an assignment.
 
-Note that this is distinct from the [wildcard pattern](../patterns.html#wildcard-pattern).
+Note that this is distinct from the [wildcard pattern](../patterns.md#wildcard-pattern).
 
 An example of an `_` expression:
 

--- a/src/expressions/underscore-expr.md
+++ b/src/expressions/underscore-expr.md
@@ -8,6 +8,8 @@ Underscore expressions, denoted with the symbol `_`, are used to signify a
 placeholder in a destructuring assignment. They may only appear in the left-hand
 side of an assignment.
 
+Note that this is distinct from the [wildcard pattern](../patterns.html#wildcard-pattern).
+
 An example of an `_` expression:
 
 ```rust


### PR DESCRIPTION
These appear in nearly identical locations in source code and have subtly different semantics, so cross link them.

I'm not sure if this is the correct link path?