### PR TITLE
Lifetime and scope clarification in `Closure types` reference.

### DIFF
--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -461,7 +461,8 @@ let z = &x;
 ```
 
 In this case, borrowing `x` mutably is not possible, because `x` is not `mut`.
-But at the same time, borrowing `x` immutably would make the assignment illegal, because a `& &mut` reference might not be unique, so it cannot safely be used to modify a value.
+But at the same time, borrowing `x` immutably would make the assignment illegal,
+because a `& &mut` reference might not be unique, so it cannot safely be used to modify a value.
 So a unique immutable borrow is used: it borrows `x` immutably, but like a mutable borrow, it must be unique.
 
 In the above example, uncommenting the declaration of `y` will produce an error because it would violate the uniqueness of the closure's borrow of `x`; the declaration of `z` is valid because the closure's lifetime has expired, i.e. there are no `c` calls after `z`, releasing the borrow.


### PR DESCRIPTION
As I understood so far, lifetime is affecting the borrowing rules enforcement, scope on the other hand, has to do with memory deallocation. 
The variables' lifetime ends the last time the compiler locates its usage, whereas the scope ends with a distinct symbol, i.e. right bracket.