### PR TITLE
Clarify semantics of the various pointer to pointer casts

### DIFF
--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -695,3 +695,17 @@ See [this test] for an example of using this dependency.
 [_TypeNoBounds_]: ../types.md#type-expressions
 [_RangeExpression_]: ./range-expr.md
 [_UnderscoreExpression_]: ./underscore-expr.md
+
+<script>
+(function() {
+    var fragments = {
+        "#slice-dst-pointer-to-pointer-cast": "operator-expr.html#pointer-to-pointer-cast",
+    };
+    var target = fragments[window.location.hash];
+    if (target) {
+        var url = window.location.toString();
+        var base = url.substring(0, url.lastIndexOf('/'));
+        window.location.replace(base + "/" + target);
+    }
+})();
+</script>

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -478,15 +478,23 @@ unsafe {
 assert_eq!(values[1], 3);
 ```
 
-#### Slice DST pointer to pointer cast
+#### Pointer-to-pointer cast
 
-For slice types like `[T]` and `[U]`, the raw pointer types `*const [T]`, `*mut [T]`,
-`*const [U]`, and `*mut [U]` encode the number of elements in this slice. Casts between
-these raw pointer types preserve the number of elements. Note that, as a consequence,
-such casts do *not* necessarily preserve the size of the pointer's referent (e.g.,
-casting `*const [u16]` to `*const [u8]` will result in a raw pointer which refers to an
-object of half the size of the original). The same holds for `str` and any compound type
-whose unsized tail is a slice type, such as struct `Foo(i32, [u8])` or `(u64, Foo)`.
+`*const T` / `*mut T` can be cast to `*const U` / `*mut U` with the following behavior:
+
+- If `T` and `U` are both sized, the pointer is returned unchanged.
+- If `T` and `U` are both unsized, the pointer is also returned unchanged. In particular,
+  the metadata is preserved exactly.
+
+    For instance, a cast from `*const [T]` to `*const [U]` preserves the number of elements.
+  Note that, as a consequence, such casts do not necessarily preserve the size of the
+  pointer's referent (e.g., casting `*const [u16]` to `*const [u8]` will result in a raw
+  pointer which refers to an object of half the size of the original). The same
+  holds for `str` and any compound type whose unsized tail is a slice type, such
+  as `struct Foo(i32, [u8])` or `(u64, Foo)`.
+- If `T` is unsized and `U` is sized, the cast discards all metadata that
+  completes the wide pointer `T` and produces a thin pointer `U` consisting
+  of the data part of the unsized pointer.
 
 ## Assignment expressions
 

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -483,18 +483,15 @@ assert_eq!(values[1], 3);
 `*const T` / `*mut T` can be cast to `*const U` / `*mut U` with the following behavior:
 
 - If `T` and `U` are both sized, the pointer is returned unchanged.
-- If `T` and `U` are both unsized, the pointer is also returned unchanged. In particular,
-  the metadata is preserved exactly.
+- If `T` and `U` are both unsized, the pointer is also returned unchanged.
+  In particular, the metadata is preserved exactly.
 
-    For instance, a cast from `*const [T]` to `*const [U]` preserves the number of elements.
-  Note that, as a consequence, such casts do not necessarily preserve the size of the
-  pointer's referent (e.g., casting `*const [u16]` to `*const [u8]` will result in a raw
-  pointer which refers to an object of half the size of the original). The same
-  holds for `str` and any compound type whose unsized tail is a slice type, such
-  as `struct Foo(i32, [u8])` or `(u64, Foo)`.
-- If `T` is unsized and `U` is sized, the cast discards all metadata that
-  completes the wide pointer `T` and produces a thin pointer `U` consisting
-  of the data part of the unsized pointer.
+  For instance, a cast from `*const [T]` to `*const [U]` preserves the number of elements.
+  Note that, as a consequence, such casts do not necessarily preserve the size of the pointer's referent
+  (e.g., casting `*const [u16]` to `*const [u8]` will result in a raw pointer which refers to an object of half the size of the original).
+  The same holds for `str` and any compound type whose unsized tail is a slice type,
+  such as `struct Foo(i32, [u8])` or `(u64, Foo)`.
+- If `T` is unsized and `U` is sized, the cast discards all metadata that completes the wide pointer `T` and produces a thin pointer `U` consisting of the data part of the unsized pointer.
 
 ## Assignment expressions
 


### PR DESCRIPTION
Relates #1448

I've tried to the best of my ability to reproduce the verbiage of the reference, some parts feel a bit wordy to me so any feedback would be appreciated.

To fully describe the semantics of unsized to sized pointer casts, I felt it was necessary to document that the reinterpreting sized to sized casts produce identical values. I couldn't immediately find this documented.

This is because unsized to sized pointer casts also permits a reintepreting cast in the same sweep (such as `*const [u8] as *const u32`).