### PR TITLE
'.inst' in inline-assembly changed to '.insn'

### DIFF
--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -570,6 +570,7 @@ The following directives are guaranteed to be supported by the assembler:
 - `.global`
 - `.globl`
 - `.inst`
+- `.insn`
 - `.lcomm`
 - `.long`
 - `.octa`


### PR DESCRIPTION
The correct directive name should be `.insn`. [Here is the issue in rust repository.](https://github.com/rust-lang/rust/issues/90558)