### PR TITLE
Update enumerations.md remove Visibility on Enum items

### DIFF
--- a/src/items/enumerations.md
+++ b/src/items/enumerations.md
@@ -12,7 +12,7 @@
 > &nbsp;&nbsp; _EnumItem_ ( `,` _EnumItem_ )<sup>\*</sup> `,`<sup>?</sup>
 >
 > _EnumItem_ :\
-> &nbsp;&nbsp; _OuterAttribute_<sup>\*</sup> [_Visibility_]<sup>?</sup>\
+> &nbsp;&nbsp; _OuterAttribute_<sup>\*</sup>\
 > &nbsp;&nbsp; [IDENTIFIER]&nbsp;( _EnumItemTuple_ | _EnumItemStruct_ )<sup>?</sup>
 >                                _EnumItemDiscriminant_<sup>?</sup>
 >


### PR DESCRIPTION
As far as I know, enums can only have a visibility as a whole, but not for single items.