### PR TITLE
underscore-expr: add more examples

### DIFF
--- a/src/expressions/underscore-expr.md
+++ b/src/expressions/underscore-expr.md
@@ -10,10 +10,25 @@ side of an assignment.
 
 Note that this is distinct from the [wildcard pattern](../patterns.md#wildcard-pattern).
 
-An example of an `_` expression:
+Examples of `_` expressions:
 
 ```rust
 let p = (1, 2);
 let mut a = 0;
 (_, a) = p;
+
+struct Position {
+    x: u32,
+    y: u32,
+}
+
+Position { x: a, y: _ } = Position{ x: 2, y: 3 };
+
+// unused result, assignment to `_` used to declare intent and remove a warning
+_ = 2 + 2;
+// triggers unused_must_use warning
+// 2 + 2;
+
+// equivalent technique using a wildcard pattern in a let-binding
+let _ = 2 + 2;
 ```


### PR DESCRIPTION
Add examples of `_`-expressions.
In particular, assignment to `_` is something I constantly use while prototyping.