### PR TITLE
Update macros-by-example.md

### DIFF
--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -5,9 +5,7 @@
 > &nbsp;&nbsp; `macro_rules` `!` [IDENTIFIER] _MacroRulesDef_
 >
 > _MacroRulesDef_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `(` _MacroRules_ `)` `;`\
-> &nbsp;&nbsp; | `[` _MacroRules_ `]` `;`\
-> &nbsp;&nbsp; | `{` _MacroRules_ `}`
+> &nbsp;&nbsp; `{` _MacroRules_ `}`
 >
 > _MacroRules_ :\
 > &nbsp;&nbsp; _MacroRule_ ( `;` _MacroRule_ )<sup>\*</sup> `;`<sup>?</sup>


### PR DESCRIPTION
correct syntax '_MacroRulesDef_' 
NOTE: I tried to use round and square brackets. It seems that only curly brackets are allowed.