### PR TITLE
add grammar for `associated_type_bounds` in reference

### DIFF
--- a/src/paths.md
+++ b/src/paths.md
@@ -53,7 +53,7 @@ mod m {
 > &nbsp;&nbsp; | `<` ( _GenericArg_ `,` )<sup>\*</sup> _GenericArg_ `,`<sup>?</sup> `>`
 >
 > _GenericArg_ :\
-> &nbsp;&nbsp; [_Lifetime_] | [_Type_] | _GenericArgsConst_ | _GenericArgsBinding_
+> &nbsp;&nbsp; [_Lifetime_] | [_Type_] | _GenericArgsConst_ | _GenericArgsBinding_ | _GenericArgsBounds_
 >
 > _GenericArgsConst_ :\
 > &nbsp;&nbsp; &nbsp;&nbsp; [_BlockExpression_]\
@@ -62,7 +62,10 @@ mod m {
 > &nbsp;&nbsp; | [_SimplePathSegment_]
 >
 > _GenericArgsBinding_ :\
-> &nbsp;&nbsp; [IDENTIFIER] `=` [_Type_]
+> &nbsp;&nbsp; [IDENTIFIER] _GenericArgs_<sup>?</sup> `=` [_TypeParamBounds_]
+>
+> _GenericArgsBounds_ :\
+> &nbsp;&nbsp; [IDENTIFIER] _GenericArgs_<sup>?</sup> `:` [_TypeParamBounds_]
 
 Paths in expressions allow for paths with generic arguments to be specified. They are
 used in various places in [expressions] and [patterns].
@@ -396,6 +399,7 @@ mod without { // crate::without
 [_SimplePathSegment_]: #simple-paths
 [_Type_]: types.md#type-expressions
 [_TypeNoBounds_]: types.md#type-expressions
+[_TypeParamBounds_]: ../trait-bounds.md
 [literal]: expressions/literal-expr.md
 [item]: items.md
 [variable]: variables.md


### PR DESCRIPTION
This also edits the grammar to capture the fact that associated type bounds (both `:` and `=`) may have GAT parameters, i.e. `T: Trait<Foo<'a> = i32>`.

Not sure if I should also add a section on associated type bounds, and if so, where. Maybe `trait-bounds.md`?

cc rust-lang/rust#122055.