### PR TITLE
Fix clippy warning in procedural macro example

### DIFF
--- a/src/procedural-macros.md
+++ b/src/procedural-macros.md
@@ -234,8 +234,8 @@ shown in the comments after the function prefixed with "out:".
 
 #[proc_macro_attribute]
 pub fn show_streams(attr: TokenStream, item: TokenStream) -> TokenStream {
-    println!("attr: \"{}\"", attr.to_string());
-    println!("item: \"{}\"", item.to_string());
+    println!("attr: \"{attr}\"");
+    println!("item: \"{item}\"");
     item
 }
 ```


### PR DESCRIPTION
I copy+pasted this example into my code and the `clippy::to_string_in_format_args` lint fired.