### PR TITLE
Mention Variadics With No Fixed Parameter

### DIFF
--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -97,13 +97,13 @@ There are also some platform-specific ABI strings:
 ## Variadic functions
 
 Functions within external blocks may be variadic by specifying `...` as the
-last argument. There must be at least one parameter before the variadic
-parameter. The variadic parameter may optionally be specified with an
+last argument. The variadic parameter may optionally be specified with an
 identifier.
 
 ```rust
 extern "C" {
-    fn foo(x: i32, ...);
+    fn foo(...);
+    fn bar(x: i32, ...);
     fn with_name(format: *const u8, args: ...);
 }
 ```


### PR DESCRIPTION
There's an open PR rust-lang/rust#124048 to support C23's variadics without a named parameter in Rust's extern blocks. Currently, it's waiting on approval from T-lang to get merged.

This PR removes the line "There must be at least one parameter before the variadic parameter" and adds an example to highlight that Rust supports variadics without any named parameters.

Opening this now so it can get merged if and when the implementation gets approved by T-lang.