### PR TITLE
Remove outdated info about impl Trait in parameters and generics in the same function

### DIFF
--- a/src/types/impl-trait.md
+++ b/src/types/impl-trait.md
@@ -48,10 +48,7 @@ That is, `impl Trait` in argument position is syntactic sugar for a generic type
 > **Note:**
 > For function parameters, generic type parameters and `impl Trait` are not exactly equivalent.
 > With a generic parameter such as `<T: Trait>`, the caller has the option to explicitly specify the generic argument for `T` at the call site using [_GenericArgs_], for example, `foo::<usize>(1)`.
-> If `impl Trait` is the type of *any* function parameter, then the caller can't ever provide any generic arguments when calling that function.
-This includes generic arguments for the return type or any const generics.
->
-> Therefore, changing the function signature from either one to the other can constitute a breaking change for the callers of a function.
+> Changing a parameter from either one to the other can constitute a breaking change for the callers of a function, since this changes the number of generic arguments.
 
 ## Abstract return types
 


### PR DESCRIPTION
When `impl Trait` in function parameters was added, it was not allowed to specify generics at all when any of the function parameters used `impl Trait`. [That is no longer the case.](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=57497ffc80ae5b1efad80567d4a02804) This restriction was lifted in [1.63.0](https://releases.rs/docs/1.63.0/) by <https://github.com/rust-lang/rust/pull/96868/>, but this instance in the reference was missed. I've removed the outdated sentences.

The original last line:

> Therefore, changing the function signature from either one to the other can constitute a breaking change for the callers of a function.

would be correct, but even in the old version, it didn't explain how converting `impl Trait` to generics could be a breaking change, and I can't think of any way it would've been. It is now, so I've added a short explanation that should be sufficient for understanding.

---

I have some more thoughts about breaking changes, but I don't think they belong in this part of the reference. I've included them as context for the change, and in case someone wants to incorporate them elsewhere.

These are the situations I know to be breaking changes:

- A function where a generic parameter is changed to `impl Trait`, and a caller is specifying generics
- A function has at least one generic of any kind, an `impl Trait` parameter is changed to a generic, and a caller is specifying generics

This assumes the trait bound is the same for the generic and its corresponding `impl Trait`. If a caller isn't specifying generics, any change can be made without causing a break. If a function had no generics and an `impl Trait` is changed to a generic, this is also fine, since an empty turbofish `::<>` seems to be equivalent to complete omission instead of "exactly zero generics". This would only realistically occur in macro expansions. However, I'm unsure if it's intended as part of the language, and I didn't see any mention of it elsewhere in the reference.