### PR TITLE
document guarantee about evaluation of associated consts and const blocks

### DIFF
--- a/src/expressions/path-expr.md
+++ b/src/expressions/path-expr.md
@@ -23,6 +23,8 @@ let push_integer = Vec::<i32>::push;
 let slice_reverse = <[i32]>::reverse;
 ```
 
+Evaluation of associated constants is handled the same way as [`const` blocks].
+
 [_PathInExpression_]: ../paths.md#paths-in-expressions
 [_QualifiedPathInExpression_]: ../paths.md#qualified-paths
 [place expressions]: ../expressions.md#place-expressions-and-value-expressions
@@ -30,3 +32,4 @@ let slice_reverse = <[i32]>::reverse;
 [path]: ../paths.md
 [`static mut`]: ../items/static-items.md#mutable-statics
 [`unsafe` block]: block-expr.md#unsafe-blocks
+[`const` blocks]: block-expr.md#const-blocks


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/112090

I think this has been our intention for a while (ever since https://github.com/rust-lang/rust/issues/67191 landed), but was never properly decided, so it likely needs t-lang FCP.