### PR TITLE
Document `gen` keyword as reserved in Rust 2024

### DIFF
--- a/src/keywords.md
+++ b/src/keywords.md
@@ -90,6 +90,11 @@ The following keywords are reserved beginning in the 2018 edition.
 > **<sup>Lexer 2018+</sup>**\
 > KW_TRY   : `try`
 
+The following keywords are reserved beginning in the 2024 edition.
+
+> **<sup>Lexer 2024+</sup>**\
+> KW_GEN   : `gen`
+
 ## Weak keywords
 
 These keywords have special meaning only in certain contexts. For example, it


### PR DESCRIPTION
Following RFC 3513 and subsequent work, the `gen` keyword is reserved in the Rust 2024 edition.  Let's document that.

See tracking issue:

- https://github.com/rust-lang/rust/issues/123904