### PR TITLE
Update procedural-macros.md adding context for use of `extern crate p…

### DIFF
--- a/src/procedural-macros.md
+++ b/src/procedural-macros.md
@@ -21,6 +21,11 @@ Procedural macros must be defined in a crate with the [crate type] of
 > [lib]
 > proc-macro = true
 > ```
+> 
+> This will automatically links to the compiler-provided [proc_macro](https://doc.rust-lang.org/proc_macro/index.html) crate.
+> `extern crate proc_macro;` would be needed if you want to support releases
+> older than Rust 2018, or if using another build tool that does not pass the
+> appropriate `--extern` flags to rustc.
 
 As functions, they must either return syntax, panic, or loop endlessly. Returned
 syntax either replaces or adds the syntax depending on the kind of procedural

--- a/src/procedural-macros.md
+++ b/src/procedural-macros.md
@@ -21,7 +21,7 @@ Procedural macros must be defined in a crate with the [crate type] of
 > [lib]
 > proc-macro = true
 > ```
-> 
+>
 > This will automatically links to the compiler-provided [proc_macro](https://doc.rust-lang.org/proc_macro/index.html) crate.
 > `extern crate proc_macro;` would be needed if you want to support releases
 > older than Rust 2018, or if using another build tool that does not pass the


### PR DESCRIPTION
Use of `extern crate` is generally stopped and not recommended [source](https://github.com/rust-lang/edition-guide/blob/master/src/rust-2018/path-changes.md#an-exception). Its use here was confusing for me. Based on the config provided here for the `Cargo.toml` file, use of `extern crate proc_macro;` in following examples is not required. 

The snippets were last updated 6 years ago. I would personally remove use of `extern crate` crate from following examples and add one with it to show how it can be done when using separate build system which would likely be niche case.