### PR TITLE
Reword "object safety" as "dyn compatibility"

### DIFF
--- a/src/glossary.md
+++ b/src/glossary.md
@@ -175,10 +175,13 @@ the hierarchy has its own collection of named entities.
 Types that can be referred to by a path directly. Specifically [enums],
 [structs], [unions], and [trait objects].
 
-### Object safe traits
+### Trait-object-safe traits
 
-[Traits] that can be used as [trait objects]. Only traits that follow specific
-[rules][object safety] are object safe.
+[Traits] that can be used in `dyn Trait` types, and allow creation of
+[trait objects]. Only traits that follow specific [rules][object safety] are
+trait-object safe.
+
+This is also called *object safety*.
 
 ### Path
 

--- a/src/items/traits.md
+++ b/src/items/traits.md
@@ -62,12 +62,12 @@ trait Seq<T> {
 }
 ```
 
-## Object Safety
+## Trait-Object Safety {#object-safety}
 
-Object safe traits can be the base trait of a [trait object]. A trait is
-*object safe* if it has the following qualities (defined in [RFC 255]):
+An object-safe trait can be used in a `dyn Trait` type, and be the base trait of a [trait object].
+A trait is *object safe* if it has the following qualities (defined in [RFC 255]):
 
-* All [supertraits] must also be object safe.
+* All [supertraits] must also be trait-object safe.
 * `Sized` must not be a [supertrait][supertraits]. In other words, it must not require `Self: Sized`.
 * It must not have any associated constants.
 * It must not have any associated types with generics.
@@ -93,7 +93,7 @@ Object safe traits can be the base trait of a [trait object]. A trait is
 # use std::rc::Rc;
 # use std::sync::Arc;
 # use std::pin::Pin;
-// Examples of object safe methods.
+// Examples of trait-object safe methods.
 trait TraitMethods {
     fn by_ref(self: &Self) {}
     fn by_ref_mut(self: &mut Self) {}
@@ -110,7 +110,7 @@ trait TraitMethods {
 ```
 
 ```rust,compile_fail
-// This trait is object-safe, but these methods cannot be dispatched on a trait object.
+// This trait is object-safe, but these methods cannot be dispatched on a trait object (such as `&dyn NonDispatchable`).
 trait NonDispatchable {
     // Non-methods cannot be dispatched.
     fn foo() where Self: Sized {}
@@ -135,7 +135,7 @@ obj.typed(1);  // ERROR: cannot call with generic type
 ```rust,compile_fail
 # use std::rc::Rc;
 // Examples of non-object safe traits.
-trait NotObjectSafe {
+trait NotDynCompatible {
     const CONST: i32 = 1;  // ERROR: cannot have associated const
 
     fn foo() {}  // ERROR: associated function without Sized
@@ -145,14 +145,14 @@ trait NotObjectSafe {
 }
 
 struct S;
-impl NotObjectSafe for S {
+impl NotDynCompatible for S {
     fn returns(&self) -> Self { S }
 }
-let obj: Box<dyn NotObjectSafe> = Box::new(S); // ERROR
+let obj: Box<dyn NotDynCompatible> = Box::new(S); // ERROR
 ```
 
 ```rust,compile_fail
-// Self: Sized traits are not object-safe.
+// Self: Sized traits are not trait-object-safe.
 trait TraitWithSize where Self: Sized {}
 
 struct S;
@@ -161,7 +161,7 @@ let obj: Box<dyn TraitWithSize> = Box::new(S); // ERROR
 ```
 
 ```rust,compile_fail
-// Not object safe if `Self` is a type argument.
+// Not trait-object safe if `Self` is a type argument.
 trait Super<A> {}
 trait WithSelf: Super<Self> where Self: Sized {}
 

--- a/src/items/traits.md
+++ b/src/items/traits.md
@@ -62,7 +62,7 @@ trait Seq<T> {
 }
 ```
 
-## Trait-Object Safety {#object-safety}
+## Trait-Object Safety <a id="object-safety"></a>
 
 An object-safe trait can be used in a `dyn Trait` type, and be the base trait of a [trait object].
 A trait is *object safe* if it has the following qualities (defined in [RFC 255]):

--- a/src/type-coercions.md
+++ b/src/type-coercions.md
@@ -170,7 +170,7 @@ an implementation of `Unsize<U>` for `T` will be provided:
 
 * `[T; n]` to `[T]`.
 
-* `T` to `dyn U`, when `T` implements `U + Sized`, and `U` is [object safe].
+* `T` to `dyn U`, when `T` implements `U + Sized`, and `U` is [trait-object safe].
 
 * `Foo<..., T, ...>` to `Foo<..., U, ...>`, when:
     * `Foo` is a struct.
@@ -269,7 +269,7 @@ precisely.
 [RFC 401]: https://github.com/rust-lang/rfcs/blob/master/text/0401-coercions.md
 [RFC 1558]: https://github.com/rust-lang/rfcs/blob/master/text/1558-closure-to-fn-coercion.md
 [subtype]: subtyping.md
-[object safe]: items/traits.md#object-safety
+[trait-object safe]: items/traits.md#object-safety
 [type cast operator]: expressions/operator-expr.md#type-cast-expressions
 [`Unsize`]: ../std/marker/trait.Unsize.html
 [`CoerceUnsized`]: ../std/ops/trait.CoerceUnsized.html

--- a/src/types/trait-object.md
+++ b/src/types/trait-object.md
@@ -7,8 +7,8 @@
 > _TraitObjectTypeOneBound_ :\
 > &nbsp;&nbsp; `dyn`<sup>?</sup> [_TraitBound_]
 
-A *trait object* is an opaque value of another type that implements a set of
-traits. The set of traits is made up of an [object safe] *base trait* plus any
+A *trait object* is an opaque value of a `dyn`-prefixed type that implements a set of
+traits. The set of traits is made up of a [trait-object safe] *base trait* plus any
 number of [auto traits].
 
 Trait objects implement the base trait, its auto traits, and any [supertraits]
@@ -103,5 +103,5 @@ inferred with a sensible choice.
 [auto traits]: ../special-types-and-traits.md#auto-traits
 [defaults]: ../lifetime-elision.md#default-trait-object-lifetimes
 [dynamically sized types]: ../dynamically-sized-types.md
-[object safe]: ../items/traits.md#object-safety
+[trait-object safe]: ../items/traits.md#object-safety
 [supertraits]: ../items/traits.md#supertraits


### PR DESCRIPTION
"Object safe" is not a self-explanatory term. 

The the word "object" doesn't have a clear definition in Rust's context, and to users it may not be obvious that the term refers to *trait* objects specifically.

The "safe" part is not good either, because it could be misunderstood as relating to "safe Rust" or not-`unsafe`.

However, the term "object safe" is used in a lot of places, so I propose a minimal backwards-compatible fix by calling this concept "trait-object safety". Addition of the word "trait" adds context, and clearly connects it to trait objects.

Users may only know this concept from `Box<dyn Trait>` types, so I'm also emphasising `dyn Trait` compatibility.

More in the forum thread:
https://internals.rust-lang.org/t/object-safety-is-a-terrible-term/21025