### PR TITLE
Add example of 1-ary tuple type

### DIFF
--- a/src/types/tuple.md
+++ b/src/types/tuple.md
@@ -27,7 +27,7 @@ Its one value is also called *unit* or *the unit value*.
 Some examples of tuple types:
 
 * `()` (unit)
-* `(i32, )` (1-ary tuple)
+* `(i32,)` (1-ary tuple)
 * `(f64, f64)`
 * `(String, i32)`
 * `(i32, String)` (different type from the previous example)

--- a/src/types/tuple.md
+++ b/src/types/tuple.md
@@ -27,6 +27,7 @@ Its one value is also called *unit* or *the unit value*.
 Some examples of tuple types:
 
 * `()` (unit)
+* `(i32, )` (1-ary tuple)
 * `(f64, f64)`
 * `(String, i32)`
 * `(i32, String)` (different type from the previous example)


### PR DESCRIPTION
To illustrate the existence of 1-ary tuple types with the obligatory comma, as mentioned here #1511

Fixes #1511