### PR TITLE
Remove stubs needed for the link checker.

### DIFF
--- a/src/crates-and-source-files.md
+++ b/src/crates-and-source-files.md
@@ -60,11 +60,6 @@ apply to the crate as a whole.
 #![warn(non_camel_case_types)]
 ```
 
-## Preludes and `no_std`
-
-This section has been moved to the [Preludes chapter](names/preludes.md).
-<!-- this is to appease the linkchecker, will remove once other books are updated -->
-
 ## Main Functions
 
 A crate that contains a `main` [function] can be compiled to an executable. If a

--- a/src/items/extern-crates.md
+++ b/src/items/extern-crates.md
@@ -52,11 +52,6 @@ Here is an example:
 extern crate hello_world; // hyphen replaced with an underscore
 ```
 
-## Extern Prelude
-
-This section has been moved to [Preludes — Extern Prelude](../names/preludes.md#extern-prelude).
-<!-- this is to appease the linkchecker, will remove once other books are updated -->
-
 ## Underscore Imports
 
 An external crate dependency can be declared without binding its name in scope


### PR DESCRIPTION
This removes some old stubs that were needed due to the way the link checker works (it doesn't handle the `<script>` redirections).
