### PR TITLE
Provide an example of `target_family` being multi-valued

### DIFF
--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -142,6 +142,7 @@ Example values:
 * `"unix"`
 * `"windows"`
 * `"wasm"`
+* Both `"unix"` and `"wasm"`
 
 ### `unix` and `windows`
 


### PR DESCRIPTION
`target_family` can take multiple values, but this is not particularly clear in the documentation. To resolve this, I've changed the example to document this. I'm not entirely happy with the formatting, would like guidance if you think there's a better solution?

[A crater run](https://github.com/rust-lang/rust/pull/124355#issuecomment-2091278128) found a few instances where this value was incorrectly assumed to be a single value.

This is related to https://github.com/rust-lang/cargo/pull/14165, I'm not sure if that change would be enough?