### PR TITLE
Update closures for edition 2021 disjoint closure capturing

### DIFF
--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -62,11 +62,10 @@ r[type.closure.capture]
 r[type.closure.capture.order]
 The compiler prefers to capture a value by immutable borrow,
 followed by unique immutable borrow (see below), by mutable borrow, and finally
-by move. It will pick the first choice of these that allows the closure to
-compile. The choice is made only with regards to the contents of the closure
-expression; the compiler does not take into account surrounding code, such as
-the lifetimes of involved variables or fields.
->>>>>>> 881f305... Update closure types documentation so it includes information about RFC2229
+by move. It will pick the first choice of these that is compatible with how the
+captured value is used inside the closure body. The compiler does not take
+surrounding code into account, such as the lifetimes of involved variables or fields, or
+of the closure itself.
 
 ## Capture Precision
 

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -9,7 +9,7 @@ closure:
 
 ```rust
 #[derive(Debug)]
-struct Point { x:i32, y:i32 }
+struct Point { x: i32, y: i32 }
 struct Rectangle { left_top: Point, right_bottom: Point }
 
 fn f<F : FnOnce() -> String> (g: F) {

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -326,6 +326,139 @@ If a closure captures a field of a composite types such as structs, tuples, and 
 } // tuple.1 dropped here -----------------------------+
 ```
 
+
+## Overall Capture analysis algorithm
+
+* Input:
+    * Analyzing the closure C yields a set of `(Mode, Place)` pairs that are accessed
+    * Access mode is `ref`, `ref uniq`, `ref mut`, or `by-value` (ordered least to max)
+    * Closure mode is `ref` or `move`
+* Output:
+    * Minimal `(Mode, Place)` pairs that are actually captured
+* Cleanup and truncation
+    * Generate C' by mapping each (Mode, Place) in C:
+        * `(Mode1, Place1) = ref_opt(unsafe_check(copy_type(Mode, Place)))`
+        * if this is a ref closure:
+            * Add `ref_xform(Mode1, Place1)` to C'
+        * else:
+            * Add `move_xform(Mode1, Place1)` to C'
+* Minimization
+    * Until no rules apply:
+        * For each two places (M1, P1), (M2, P2) where P1 is a prefix of P2:
+            * Remove both places from the set
+            * Add (max(M1, M2), P1) into the set
+* Helper functions:
+    * `copy_type(Mode, Place) -> (Mode, Place)`
+        * "By-value use of a copy type is a ref"
+        * If Mode = "by-value" and type(Place) is `Copy`:
+            * Return (ref, Place)
+        * Else
+            * Return (Mode, Place)
+    * `unsafe_check(Mode, Place) -> (Mode, Place)`
+        * "Ensure unsafe accesses occur within the closure"
+        * If Place contains a deref of a raw pointer:
+            * Let Place1 = Place truncated just before the deref
+            * Return (Mode, Place1)
+        * If Mode is `ref *` and the place contains a field of a packed struct:
+            * Let Place1 = Place truncated just before the field
+            * Return (Mode, Place1)
+        * Else
+            * Return (Mode, Place1)
+    * `move_xform(Mode, Place) -> (Mode, Place)` (For move closures)
+        * "Take ownership if data being accessed is owned by the variable used to access it (or if closure attempts to move data that it doesn't own)."
+        * "When taking ownership, only capture data found on the stack."
+        * "Otherwise, reborrow the reference."
+        * If Mode is `ref mut` and the place contains a deref of an `&mut`:
+            * Return (Mode, Place)
+        * Else if Mode is `ref *` and the place contains a deref of an `&`:
+            * Return (Mode, Place)
+        * Else if place contains a deref:
+            * Let Place1 = Place truncated just before the deref
+            * Return (ByValue, Place1)
+        * Else:
+            * Return (ByValue, Place)
+    * `ref_xform(Mode, Place) -> (Mode, Place)` (for ref closures)
+        * "If taking ownership of data, only move data from enclosing stack frame."
+        * Generate C' by mapping each (Mode, Place) in C
+            * If Mode is ByValue and place contains a deref:
+                * Let Place1 = Place truncated just before the deref
+                * Return (ByValue, Place1)
+            * Else:
+                * Return (Mode, Place)
+    * `ref_opt(Mode, Place) -> (Mode, Place)` (for ref closures)
+        * "Optimization: borrow the ref, not data owned by ref."
+        * If Place contains a deref of an `&`...
+            * ...or something
+
+## Key examples
+
+### box-mut
+
+```rust
+fn box_mut() {
+    let mut s = Foo { x: 0 } ;
+    
+    let px = &mut s;
+    let bx = Box::new(px);
+    
+    
+    let c = #[rustc_capture_analysis] move || bx.x += 10;
+    // Mutable reference to this place:
+    //   (*(*bx)).x
+    //    ^ ^
+    //    | a Box
+    //    a &mut
+}
+```
+
+```
+Closure mode = move
+C = {
+    (ref mut, (*(*bx)).x)
+}
+C' = C
+```
+
+Output is the same: `C' = C`
+
+### Packed-field-ref-and-move
+
+When you have a closure that both references a packed field (which is unsafe) and moves from it (which is safe) we capture the entire struct, rather than just moving the field. This is to aid in predictability, so that removing the move doesn't make the closure become unsafe:
+
+```rust
+print(&packed.x);
+move_value(packed.x);
+```
+
+
+```rust
+struct Point { x: i32, y: i32 }
+fn f(p: &Point) -> impl Fn() {
+    let c = move || {
+      let x = p.x; 
+    }; 
+    
+    // x.x -> ByValue
+    // after rules x -> ByValue
+
+    c
+} 
+
+struct Point { x: i32, y: i32 }
+fn g(p: &mut Point) -> impl Fn() {
+    let c = move || {
+      let x = p.x; // ought to: (ref, (*p).x)
+    };
+    
+    move || {
+       p.y += 1;
+    }
+    
+    
+    // x.x -> ByValue
+   
+```
+
 # Edition 2018 and before
 
 ## Closure types difference

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -351,12 +351,12 @@ If a closure captures a field of a composite types such as structs, tuples, and 
 * Helper functions:
     * `unsafe_check(Place, Mode) -> (Place, Mode)`
         * "Ensure unsafe accesses occur within the closure"
-        * If Place contains a deref of a raw pointer:
-            * Let Place1 = Place truncated just before the deref
-            * Return (Place1, Mode)
-        * If Mode is `ref *` and the place contains a field of a packed struct:
-            * Let Place1 = Place truncated just before the field
-            * Return (Place1, Mode)
+        * If Place contains a deref (at index `i`) of a raw pointer:
+            * Let `(Place1, Mode1) = truncate_place(Place, Mode, i)`
+            * Return (Place1, Mode1)
+        * If Mode is `ref *` and the place contains a field of a packed struct at index `i`:
+            * Let `(Place1, Mode1) = truncate_place(Place, Mode, i)`
+            * Return (Place1, Mode1)
         * Else
             * Return (Place, Mode)
     * `move_xform(Place, Mode) -> (Place, Mode)` (For move closures)
@@ -367,16 +367,16 @@ If a closure captures a field of a composite types such as structs, tuples, and 
             * Return (Place, Mode)
         * Else if Mode is `ref *` and the place contains a deref of an `&`:
             * Return (Place, Mode)
-        * Else if place contains a deref:
-            * Let Place1 = Place truncated just before the deref
+        * Else if place contains a deref at index `i`:
+            * Let `(Place1, _) = truncate_place(Place, Mode, i)`
             * Return (Place1, ByValue)
         * Else:
             * Return (Place, ByValue)
     * `ref_xform(Place, Mode) -> (Place, Mode)` (for ref closures)
         * "If taking ownership of data, only move data from enclosing stack frame."
         * Generate C' by mapping each (Mode, Place) in C
-            * If Mode is ByValue and place contains a deref:
-                * Let Place1 = Place truncated just before the deref
+            * If Mode is ByValue and place contains a deref at index `i`:
+                * Let `(Place1, _) = truncate_place(Place, Mode, i)`
                 * Return (Place1, ByValue)
             * Else:
                 * Return (Place, Mode)
@@ -392,6 +392,13 @@ If a closure captures a field of a composite types such as structs, tuples, and 
               and `Place.type_before_projection(l) = ty::Ref(.., Mutability::Not)`
                 * Let Place1 = (Base, Projections[0..=l])
                 * Return (Place1, Ref)
+    * `truncate_place(Place, Mode, len) -> (Place, Mode)`
+        * "Truncate the place to length `len`, i.e. upto but not including index `len`"
+        * "If during truncation we drop Deref of a `&mut` and the place was being used by `ref mut`, the access to the truncated place must be unique"
+        * Let (Proj_before, Proj_after) = Place.split_before(len)
+            * If Mode == `ref mut` and there exists `Deref` in `Proj_after` at index `i` such that `Place.type_before_projection(len + i)` is `&mut T`
+                * Return (Place(Proj_before, ..InputPlace), `ref-uniq`)
+            * Else Return (Place(Proj_before, ..InputPlace), Mode)
 
 ## Key examples
 

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -81,14 +81,15 @@ In the case where a path and one of the ancestor’s of that path are both captu
 
 Note that this might need to be applied recursively.
 
-```rust=
-let s = String::new("S");
-let t = (s, String::new("T"));
-let mut u = (t, String::new("U"));
+```rust
+# fn move_value<T>(_: T){}
+let s = String::from("S");
+let t = (s, String::from("T"));
+let mut u = (t, String::from("U"));
 
 let c = || {
     println!("{:?}", u); // u captured by ImmBorrow
-    u.0.truncate(0); // u.0 captured by MutBorrow
+    u.1.truncate(0); // u.0 captured by MutBorrow
     move_value(u.0.0); // u.0.0 captured by ByValue
 };
 ```
@@ -111,7 +112,7 @@ let c = || match x {
 
 ### Capturing references in move contexts
 
-Rust doesn't allow moving fields out of references. As a result, in the case of move closures, when values accessed through a shared references are moved into the closure body, the compiler, instead of moving the values out of the reference, would reborrow the data.
+Moving fields out of references is not allowed. As a result, in the case of move closures, when values accessed through a shared references are moved into the closure body, the compiler, instead of moving the values out of the reference, would reborrow the data.
 
 ```rust
 struct T(String, String);
@@ -122,7 +123,7 @@ let c = move || t.0.truncate(0); // closure captures (&mut t.0)
 ```
 
 ### Raw pointer dereference
-In Rust, it's `unsafe` to dereference a raw pointer. Therefore, closures will only capture the prefix of a path that runs up to, but not including, the first dereference of a raw pointer.
+Because it is `unsafe` to dereference a raw pointer, closures will only capture the prefix of a path that runs up to, but not including, the first dereference of a raw pointer.
 
 ```rust,
 struct T(String, String);
@@ -137,7 +138,7 @@ let c = || unsafe {
 
 ### Reference into unaligned `struct`s
 
-In Rust, it's `unsafe` to hold references to unaligned fields in a structure, and therefore, closures will only capture the prefix of the path that runs up to, but not including, the first field access into an unaligned structure.
+Because it is `unsafe` to hold references to unaligned fields in a structure, closures will only capture the prefix of the path that runs up to, but not including, the first field access into an unaligned structure.
 
 ```rust
 #[repr(packed)]
@@ -152,9 +153,12 @@ let c = || unsafe {
 
 ### `Box` vs other `Deref` implementations
 
-The compiler treats the implementation of the Deref trait for `Box` differently, as it is considered a special entity.
+The implementation of the [`Deref`] trait for [`Box`] is treated differently from other `Deref` implementations, as it is considered a special entity.
 
 For example, let us look at examples involving `Rc` and `Box`. The `*rc` is desugared to a call to the trait method `deref` defined on `Rc`, but since `*box` is treated differently by the compiler, the compiler is able to do precise capture on contents of the `Box`.
+
+[`Box`]: ../special-types-and-traits.md#boxt
+[`Deref`]: ../special-types-and-traits.md#deref-and-derefmut
 
 #### Non `move` closure
 
@@ -352,7 +356,7 @@ f(Closure { rect: rect });
 ## Capture precision difference
 
 r[type.closure.capture.composite]
-Composite types such as structs, tuples, and enums are always captured in its intirety,
+Composite types such as structs, tuples, and enums are always captured in its entirety,
 not by individual fields. As a result, it may be necessary to borrow into a local variable in order to capture a single field:
 
 ```rust

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -331,7 +331,7 @@ If a closure captures a field of a composite types such as structs, tuples, and 
 * Input:
     * Analyzing the closure C yields a mapping of `Place -> Mode` that are accessed
     * Access mode is `ref`, `ref uniq`, `ref mut`, or `by-value` (ordered least to max)
-        * For a `Place` that is used in two different acess modes within the same closure, the mode reported from closure analysis is the maximum access mode.
+        * For a `Place` that is used in two different access modes within the same closure, the mode reported from closure analysis is the maximum access mode.
         * Note: `ByValue` use of a `Copy` type is seen as a `ref` access mode.
     * Closure mode is `ref` or `move`
 * Output:
@@ -397,6 +397,8 @@ If a closure captures a field of a composite types such as structs, tuples, and 
 
 ### box-mut
 
+This test shows how a `move` closure can sometimes capture values by mutable reference, if they are reached via a `&mut` reference.
+
 ```rust
 struct Foo { x: i32 }
 
@@ -419,10 +421,10 @@ fn box_mut() {
 <!-- ignore: Omit error about unterminated string literal when representing c_prime -->
 ```ignore
 Closure mode = move
-C = {
+C_in = {
     (ref mut, (*(*bx)).x)
 }
-C' = C
+C_out = C_in
 ```
 
 Output is the same: `C' = C`
@@ -453,13 +455,16 @@ fn main() {
 <!-- ignore: Omit error about unterminated string literal when representing c_prime -->
 ```ignore
 Closure mode = ref
-C = {
+C_in = {
     (ref mut, packed)
 }
-C' = C
+C_out = C_in
 ```
 
 ### Optimization-Edge-Case
+
+This test shows an interesting edge case. Normally, when we see a borrow of something behind a shared reference (`&T`), we truncate to capture the entire reference, because that is more efficient (and we can always use that reference to reach all the data it refers to). However, in the case where we are dereferencing two shared references, we have to be sure to preserve the full path, since otherwise the resulting closure could have a shorter lifetime than is necessary.
+
 ```edition2021
 struct Int(i32);
 struct B<'a>(&'a i32);
@@ -479,10 +484,10 @@ fn foo<'a, 'b>(m: &'a MyStruct<'b>) -> impl FnMut() + 'static {
 <!-- ignore: Omit error about unterminated string literal when reprenting c_prime -->
 ```ignore
 Closure mode = ref
-C = {
+C_in = {
     (ref mut, *m.a)
 }
-C' = C
+C_out = C_in
 ```
 
 # Edition 2018 and before

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -111,14 +111,14 @@ let c = || match x {
 
 ### Capturing references in move contexts
 
-Moving fields out of references is not allowed. As a result, in the case of move closures, when values accessed through a shared references are moved into the closure body, the compiler, instead of moving the values out of the reference, would reborrow the data.
+Moving fields out of references is not allowed. As a result, in the case of move closures, when values accessed through a shared references are moved into the closure body, the compiler will truncate right before a dereference.
 
 ```rust
 struct T(String, String);
 
 let mut t = T(String::from("foo"), String::from("bar"));
 let t = &mut t;
-let c = move || t.0.truncate(0); // closure captures (&mut t.0)
+let c = move || t.0.truncate(0); // closure captures `t`
 ```
 
 ### Raw pointer dereference
@@ -339,10 +339,11 @@ If a closure captures a field of a composite types such as structs, tuples, and 
 * Cleanup and truncation
     * Generate C' by mapping each (Mode, Place) in C:
         * `(Place1, Mode1) = ref_opt(unsafe_check(Place, Mode))`
-        * if this is a ref closure:
-            * Add `ref_xform(Place1, Mode1)` to C'
+        * `(Place2, Mode2)` = if this is a ref closure:
+            * `ref_xform(Place1, Mode1)`
         * else:
-            * Add `move_xform(Place1, Mode1)` to C'
+            * `move_xform(Place1, Mode1)`
+        * Add `(Place3, Mode3) = truncate_move_through_drop(Place2, Mode2)` to C'.
 * Minimization
     * Until no rules apply:
         * For each two places (P1, M1), (P2, M2) where P1 is a prefix of P2:
@@ -360,18 +361,12 @@ If a closure captures a field of a composite types such as structs, tuples, and 
         * Else
             * Return (Place, Mode)
     * `move_xform(Place, Mode) -> (Place, Mode)` (For move closures)
-        * "Take ownership if data being accessed is owned by the variable used to access it (or if closure attempts to move data that it doesn't own)."
-        * "When taking ownership, only capture data found on the stack."
-        * "Otherwise, reborrow the reference."
-        * If Mode is `ref mut` and the place contains a deref of an `&mut`:
-            * Return (Place, Mode)
-        * Else if Mode is `ref *` and the place contains a deref of an `&`:
-            * Return (Place, Mode)
-        * Else if place contains a deref at index `i`:
+        * If place contains a deref at index `i`:
             * Let `(Place1, _) = truncate_place(Place, Mode, i)`
             * Return (Place1, ByValue)
         * Else:
             * Return (Place, ByValue)
+        * Note that initially we had considered an approach where "Take ownership if data being accessed is owned by the variable used to access it (or if closure attempts to move data that it doesn't own). That is when taking ownership only capture data that is found on the stack otherwise reborrow the reference.". This cause a bug around lifetimes, check [rust-lang/rust#88431](https://github.com/rust-lang/rust/issues/88431).
     * `ref_xform(Place, Mode) -> (Place, Mode)` (for ref closures)
         * "If taking ownership of data, only move data from enclosing stack frame."
         * Generate C' by mapping each (Mode, Place) in C
@@ -392,6 +387,16 @@ If a closure captures a field of a composite types such as structs, tuples, and 
               and `Place.type_before_projection(l) = ty::Ref(.., Mutability::Not)`
                 * Let Place1 = (Base, Projections[0..=l])
                 * Return (Place1, Ref)
+    * `truncate_move_through_drop(Place1, Mode1) -> (Place, Mode)`
+        * Rust doesn't permit moving out of a type that implements drop
+        * In the case where we do a disjoint capture in a move closure, we might end up trying to move out of drop type
+        * We truncate move of not-Copy types
+        * If Mode1 != ByBalue
+            * return (Place1, Mode1)
+        * If there exists `i` such that `Place1.before_projection(i): Drop` and `Place1.ty()` doesn't impl `Copy`
+            * then return `truncate_place(Place1, Mode1, i)`
+        * Else return (Place1, Mode1)
+        * Check [rust-lang/rust#88476](https://github.com/rust-lang/rust/issues/88476) for examples.
     * `truncate_place(Place, Mode, len) -> (Place, Mode)`
         * "Truncate the place to length `len`, i.e. upto but not including index `len`"
         * "If during truncation we drop Deref of a `&mut` and the place was being used by `ref mut`, the access to the truncated place must be unique"
@@ -411,11 +416,11 @@ struct Foo { x: i32 }
 
 fn box_mut() {
     let mut s = Foo { x: 0 } ;
-    
+
     let px = &mut s;
     let bx = Box::new(px);
-    
-    
+
+
     let c = move || bx.x += 10;
     // Mutable reference to this place:
     //   (*(*bx)).x

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -2,10 +2,9 @@
 
 r[type.closure]
 
-A [closure expression] produces a closure value with a unique, anonymous type
-that cannot be written out. A closure type is approximately equivalent to a
-struct which contains the captured values. For instance, the following
-closure:
+A [closure expression] produces a closure value with a unique, anonymous type that cannot be written out.
+A closure type is approximately equivalent to a struct which contains the captured values.
+For instance, the following closure:
 
 ```rust
 #[derive(Debug)]
@@ -26,13 +25,16 @@ let c = || {
     rect.right_bottom.x += 1;
     format!("{:?}", rect.left_top)
 };
-// Prints "Point { x: 2, y: 1 }".
+f(c); // Prints "Point { x: 2, y: 1 }".
 ```
 
 generates a closure type roughly like the following:
 
 <!-- ignore: simplified -->
 ```rust,ignore
+// Note: This is not exactly how it is translated, this is only for
+// illustration.
+
 struct Closure<'a> {
     left_top : &'a mut Point,
     right_bottom_x : &'a mut i32,
@@ -40,9 +42,9 @@ struct Closure<'a> {
 
 impl<'a> FnOnce<()> for Closure<'a> {
     type Output = String;
-    fn call_once(self) -> String {
+    extern "rust-call" fn call_once(self, args: ()) -> String {
         self.left_top.x += 1;
-        self.right_bottom_x += 1;
+        *self.right_bottom_x += 1;
         format!("{:?}", self.left_top)
     }
 }
@@ -52,35 +54,84 @@ so that the call to `f` works as if it were:
 
 <!-- ignore: continuation of above -->
 ```rust,ignore
-f(Closure{ left_top: rect.left_top, right_bottom_x: rect.left_top.x });
+// Note: This is not valid Rust due to the duplicate mutable borrows.
+// This is only provided as an illustration.
+f(Closure{ left_top: &mut rect.left_top, right_bottom_x: &mut rect.left_top.x });
 ```
 
 ## Capture modes
 
 r[type.closure.capture]
 
-r[type.closure.capture.order]
-The compiler prefers to capture a value by immutable borrow,
-followed by unique immutable borrow (see below), by mutable borrow, and finally
-by move. It will pick the first choice of these that is compatible with how the
-captured value is used inside the closure body. The compiler does not take
-surrounding code into account, such as the lifetimes of involved variables or fields, or
-of the closure itself.
+r[type.closure.capture.intro]
+A *capture mode* determines how a [place expression] from the environment is borrowed or moved into the closure.
+The capture modes are:
+
+1. Immutable borrow (`ImmBorrow`) --- The place expression is captured as a [shared reference].
+2. Unique immutable borrow (`UniqueImmBorrow`) --- This is similar to an immutable borrow, but must be unique as described [below](#unique-immutable-borrows-in-captures).
+3. Mutable borrow (`MutBorrow`) --- The place expression is captured as a [mutable reference].
+4. Move (`ByValue`) --- The place expression is captured by [moving the value] into the closure.
+
+r[type.closure.capture.precedence]
+Place expressions from the environment are captured from the first mode that is compatible with how the captured value is used inside the closure body.
+The mode is not affected by the code surrounding the closure, such as the lifetimes of involved variables or fields, or of the closure itself.
+
+[moving the value]: ../expressions.md#moved-and-copied-types
+[mutable reference]: pointer.md#mutable-references-mut
+[place expression]: ../expressions.md#place-expressions-and-value-expressions
+[shared reference]: pointer.md#references--and-mut
+
+### `Copy` values
+
+Values that implement [`Copy`] that are moved into the closure are captured with the `ImmBorrow` mode.
+
+```rust
+let x = [0; 1024];
+let c = || {
+    let y = x; // x captured by ImmBorrow
+};
+```
 
 ## Capture Precision
 
-The precise path that gets captured is typically the full path that is used in the closure, but there are cases where we will only capture a prefix of the path.
+A *capture path* is a sequence starting with a variable from the environment followed by zero or more place projections that were applied to that variable.
 
+A *place projection* is a [field access], [tuple index], [dereference] (and automatic dereferences), or [array or slice index] expression applied to a variable.
+
+The closure borrows or moves the capture path, which may be truncated based on the rules described below.
+
+For example:
+
+```rust
+struct SomeStruct {
+    f1: (i32, i32),
+}
+let s = SomeStruct { f1: (1, 2) };
+
+let c = || {
+    let x = s.f1.1; // s.f1.1 captured by ImmBorrow
+};
+c();
+```
+
+Here the capture path is the local variable `s`, followed by a field access `.f1`, and then a tuple index `.1`.
+This closure captures an immutable borrow of `s.f1.1`.
+
+[field access]: ../expressions/field-expr.md
+[tuple index]: ../expressions/tuple-expr.md#tuple-indexing-expressions
+[dereference]: ../expressions/operator-expr.md#the-dereference-operator
+[array or slice index]: ../expressions/array-expr.md#array-and-slice-indexing-expressions
 
 ### Shared prefix
 
-In the case where a path and one of the ancestor’s of that path are both captured by a closure, the ancestor path is captured with the highest capture mode among the two captures,`CaptureMode = max(AncestorCaptureMode, DescendantCaptureMode)`, using the strict weak ordering
+In the case where a capture path and one of the ancestor’s of that path are both captured by a closure, the ancestor path is captured with the highest capture mode among the two captures, `CaptureMode = max(AncestorCaptureMode, DescendantCaptureMode)`, using the strict weak ordering:
 
-`ImmBorrow < UniqueImmBorrow < MutBorrow < ByValue`.
+`ImmBorrow < UniqueImmBorrow < MutBorrow < ByValue`
 
 Note that this might need to be applied recursively.
 
 ```rust
+// In this example, there are three different capture paths with a shared ancestor:
 # fn move_value<T>(_: T){}
 let s = String::from("S");
 let t = (s, String::from("T"));
@@ -91,106 +142,272 @@ let c = || {
     u.1.truncate(0); // u.0 captured by MutBorrow
     move_value(u.0.0); // u.0.0 captured by ByValue
 };
+c();
 ```
 
-Overall the closure will capture `u` by `ByValue`.
+Overall this closure will capture `u` by `ByValue`.
 
-### Wild Card Patterns
-Closures only capture data that needs to be read, which means the following closures will not capture `x`
+### Rightmost shared reference truncation
+
+The capture path is truncated at the rightmost dereference in the capture path if the dereference is applied to a shared reference.
+
+This truncation is allowed because fields that are read through a shared reference will always be read via a shared reference or a copy.
+This helps reduce the size of the capture when the extra precision does not yield any benefit from a borrow checking perspective.
+
+The reason it is the *rightmost* dereference is to help avoid a shorter lifetime than is necessary.
+Consider the following example:
 
 ```rust
-let x = 10;
-let c = || {
-    let _ = x;
-};
+struct Int(i32);
+struct B<'a>(&'a i32);
 
-let c = || match x {
+struct MyStruct<'a> {
+   a: &'static Int,
+   b: B<'a>,
+}
+
+fn foo<'a, 'b>(m: &'a MyStruct<'b>) -> impl FnMut() + 'static {
+    let c = || drop(&m.a.0);
+    c
+}
+```
+
+If this were to capture `m`, then the closure would no longer outlive `'static`, since `m` is constrained to `'a`. Instead, it captures `(*(*m).a)` by `ImmBorrow`.
+
+### Wildcard pattern bindings
+
+Closures only capture data that needs to be read.
+Binding a value with a [wildcard pattern] does not count as a read, and thus won't be captured.
+For example, the following closures will not capture `x`:
+
+```rust
+let x = String::from("hello");
+let c = || {
+    let _ = x;  // x is not captured
+};
+c();
+
+let c = || match x {  // x is not captured
     _ => println!("Hello World!")
 };
+c();
 ```
+
+This also includes destructuring of tuples, structs, and enums.
+Fields matched with the [_RestPattern_] or [_StructPatternEtCetera_] are also not considered as read, and thus those fields will not be captured.
+The following illustrates some of these:
+
+```rust
+let x = (String::from("a"), String::from("b"));
+let c = || {
+    let (first, ..) = x;  // captures `x.0` ByValue
+};
+// The first tuple field has been moved into the closure.
+// The second tuple field is still accessible.
+println!("{:?}", x.1);
+c();
+```
+
+```rust
+struct Example {
+    f1: String,
+    f2: String,
+}
+
+let e = Example {
+    f1: String::from("first"),
+    f2: String::from("second"),
+};
+let c = || {
+    let Example { f2, .. } = e; // captures `e.f2` ByValue
+};
+// Field f2 cannot be accessed since it is moved into the closure.
+// Field f1 is still accessible.
+println!("{:?}", e.f1);
+c();
+```
+
+Partial captures of arrays and slices are not supported; the entire slice or array is always captured even if used with wildcard pattern matching, indexing, or sub-slicing.
+For example:
+
+```rust,compile_fail,E0382
+#[derive(Debug)]
+struct Example;
+let x = [Example, Example];
+
+let c = || {
+    let [first, _] = x; // captures all of `x` ByValue
+};
+c();
+println!("{:?}", x[1]); // ERROR: borrow of moved value: `x`
+```
+
+Values that are matched with wildcards must still be initialized.
+
+```rust,compile_fail,E0381
+let x: i32;
+let c = || {
+    let _ = x; // ERROR: used binding `x` isn't initialized
+};
+```
+
+[_RestPattern_]: ../patterns.md#rest-patterns
+[_StructPatternEtCetera_]: ../patterns.md#struct-patterns
+[wildcard pattern]: ../patterns.md#wildcard-pattern
 
 ### Capturing references in move contexts
 
-Moving fields out of references is not allowed. As a result, in the case of move closures, when values accessed through a shared references are moved into the closure body, the compiler will truncate right before a dereference.
+Because it is not allowed to move fields out of a reference, `move` closures will only capture the prefix of a capture path that runs up to, but not including, the first dereference of a reference.
+The reference itself will be moved into the closure.
 
 ```rust
 struct T(String, String);
 
 let mut t = T(String::from("foo"), String::from("bar"));
-let t = &mut t;
-let c = move || t.0.truncate(0); // closure captures `t`
+let t_mut_ref = &mut t;
+let mut c = move || {
+    t_mut_ref.0.push_str("123"); // captures `t_mut_ref` ByValue
+};
+c();
 ```
 
 ### Raw pointer dereference
-Because it is `unsafe` to dereference a raw pointer, closures will only capture the prefix of a path that runs up to, but not including, the first dereference of a raw pointer.
 
-```rust,
+Because it is `unsafe` to dereference a raw pointer, closures will only capture the prefix of a capture path that runs up to, but not including, the first dereference of a raw pointer.
+
+```rust
 struct T(String, String);
 
 let t = T(String::from("foo"), String::from("bar"));
-let t = &t as *const T;
+let t_ptr = &t as *const T;
 
 let c = || unsafe {
-    println!("{}", (*t).0); // closure captures t
+    println!("{}", (*t_ptr).0); // captures `t_ptr` by ImmBorrow
 };
+c();
+```
+
+### Union fields
+
+Because it is `unsafe` to access a union field, closures will only capture the prefix of a capture path that runs up to the union itself.
+
+```rust
+union U {
+    a: (i32, i32),
+    b: bool,
+}
+let u = U { a: (123, 456) };
+
+let c = || {
+    let x = unsafe { u.a.0 }; // captures `u` ByValue
+};
+c();
+
+// This also includes writing to fields.
+let mut u = U { a: (123, 456) };
+
+let mut c = || {
+    u.b = true; // captures `u` with MutBorrow
+};
+c();
 ```
 
 ### Reference into unaligned `struct`s
 
-Because it is `unsafe` to hold references to unaligned fields in a structure, closures will only capture the prefix of the path that runs up to, but not including, the first field access into an unaligned structure.
+Because it is [undefined behavior] to create references to unaligned fields in a structure,
+closures will only capture the prefix of the capture path that runs up to, but not including, the first field access into a structure that uses [the `packed` representation].
+This includes all fields, even those that are aligned, to protect against compatibility concerns should any of the fields in the structure change in the future.
 
 ```rust
 #[repr(packed)]
-struct T(String, String);
+struct T(i32, i32);
 
-let t = T(String::from("foo"), String::from("bar"));
-let c = || unsafe {
-    println!("{}", t.0); // closure captures t
+let t = T(2, 5);
+let c = || {
+    let a = t.0; // captures `t` with ImmBorrow
 };
+// Copies out of `t` are ok.
+let (a, b) = (t.0, t.1);
+c();
 ```
 
+Similarly, taking the address of an unaligned field also captures the entire struct:
+
+```rust,compile_fail,E0505
+#[repr(packed)]
+struct T(String, String);
+
+let mut t = T(String::new(), String::new());
+let c = || {
+    let a = std::ptr::addr_of!(t.1); // captures `t` with ImmBorrow
+};
+let a = t.0; // ERROR: cannot move out of `t.0` because it is borrowed
+c();
+```
+
+but the above works if it is not packed since it captures the field precisely:
+
+```rust
+struct T(String, String);
+
+let mut t = T(String::new(), String::new());
+let c = || {
+    let a = std::ptr::addr_of!(t.1); // captures `t.1` with ImmBorrow
+};
+// The move here is allowed.
+let a = t.0;
+c();
+```
+
+[undefined behavior]: ../behavior-considered-undefined.md
+[the `packed` representation]: ../type-layout.md#the-alignment-modifiers
 
 ### `Box` vs other `Deref` implementations
 
 The implementation of the [`Deref`] trait for [`Box`] is treated differently from other `Deref` implementations, as it is considered a special entity.
 
-For example, let us look at examples involving `Rc` and `Box`. The `*rc` is desugared to a call to the trait method `deref` defined on `Rc`, but since `*box` is treated differently by the compiler, the compiler is able to do precise capture on contents of the `Box`.
+For example, let us look at examples involving `Rc` and `Box`. The `*rc` is desugared to a call to the trait method `deref` defined on `Rc`, but since `*box` is treated differently, it is possible to do a precise capture of the contents of the `Box`.
 
 [`Box`]: ../special-types-and-traits.md#boxt
 [`Deref`]: ../special-types-and-traits.md#deref-and-derefmut
 
-#### Non `move` closure
+#### `Box` with non-`move` closure
 
-In a non `move` closure, if the contents of the `Box` are not moved into the closure body, the contents of the `Box` are precisely captured.
+In a non-`move` closure, if the contents of the `Box` are not moved into the closure body, the contents of the `Box` are precisely captured.
 
 ```rust
-# use std::rc::Rc;
+struct S(String);
 
-struct S(i32);
-
-let b = Box::new(S(10));
+let b = Box::new(S(String::new()));
 let c_box = || {
-    println!("{}", (*b).0); // closure captures `(*b).0`
+    let x = &(*b).0; // captures `(*b).0` by ImmBorrow
 };
+c_box();
 
-let r = Rc::new(S(10));
+// Contrast `Box` with another type that implements Deref:
+let r = std::rc::Rc::new(S(String::new()));
 let c_rc = || {
-    println!("{}", (*r).0); // closure caprures `r`
+    let x = &(*r).0; // captures `r` by ImmBorrow
 };
+c_rc();
 ```
 
 However, if the contents of the `Box` are moved into the closure, then the box is entirely captured. This is done so the amount of data that needs to be moved into the closure is minimized.
 
 ```rust
-struct S(i32);
+// This is the same as the example above except the closure
+// moves the value instead of taking a reference to it.
 
-let b = Box::new(S(10));
+struct S(String);
+
+let b = Box::new(S(String::new()));
 let c_box = || {
-    let x = (*b).0; // closure captures `b`
+    let x = (*b).0; // captures `b` with ByValue
 };
+c_box();
 ```
 
-#### `move` closure
+#### `Box` with move closure
 
 Similarly to moving contents of a `Box` in a non-`move` closure, reading the contents of a `Box` in a `move` closure will capture the `Box` entirely.
 
@@ -198,41 +415,39 @@ Similarly to moving contents of a `Box` in a non-`move` closure, reading the con
 struct S(i32);
 
 let b = Box::new(S(10));
-let c_box = || {
-    println!("{}", (*b).0); // closure captures `b`
+let c_box = move || {
+    let x = (*b).0; // captures `b` with ByValue
 };
 ```
 
 ## Unique immutable borrows in captures
 
 r[type.closure.unique-immutable]
-
-Captures can occur by a special kind of borrow called a _unique immutable
-borrow_, which cannot be used anywhere else in the language and cannot be
-written out explicitly. It occurs when modifying the referent of a mutable
-reference, as in the following example:
+Captures can occur by a special kind of borrow called a _unique immutable borrow_,
+which cannot be used anywhere else in the language and cannot be written out explicitly.
+It occurs when modifying the referent of a mutable reference, as in the following example:
 
 ```rust
 let mut b = false;
 let x = &mut b;
-{
-    let mut c = || { *x = true; };
-    // The following line is an error:
-    // let y = &x;
-    c();
-}
+let mut c = || {
+    // An ImmBorrow and a MutBorrow of `x`.
+    let a = &x;
+    *x = true; // `x` captured by UniqueImmBorrow
+};
+// The following line is an error:
+// let y = &x;
+c();
+// However, the following is OK.
 let z = &x;
 ```
 
 In this case, borrowing `x` mutably is not possible, because `x` is not `mut`.
 But at the same time, borrowing `x` immutably would make the assignment illegal,
-because a `& &mut` reference might not be unique, so it cannot safely be used to
-modify a value. So a unique immutable borrow is used: it borrows `x` immutably,
-but like a mutable borrow, it must be unique. In the above example, uncommenting
-the declaration of `y` will produce an error because it would violate the
-uniqueness of the closure's borrow of `x`; the declaration of z is valid because
-the closure's lifetime has expired at the end of the block, releasing the borrow.
+because a `& &mut` reference might not be unique, so it cannot safely be used to modify a value.
+So a unique immutable borrow is used: it borrows `x` immutably, but like a mutable borrow, it must be unique.
 
+In the above example, uncommenting the declaration of `y` will produce an error because it would violate the uniqueness of the closure's borrow of `x`; the declaration of z is valid because the closure's lifetime has expired at the end of the block, releasing the borrow.
 
 ## Call traits and coercions
 
@@ -325,188 +540,11 @@ If a closure captures a field of a composite types such as structs, tuples, and 
 } // tuple.1 dropped here -----------------------------+
 ```
 
+## Edition 2018 and before
 
-## Overall Capture analysis algorithm
+### Closure types difference
 
-* Input:
-    * Analyzing the closure C yields a mapping of `Place -> Mode` that are accessed
-    * Access mode is `ref`, `ref uniq`, `ref mut`, or `by-value` (ordered least to max)
-        * For a `Place` that is used in two different access modes within the same closure, the mode reported from closure analysis is the maximum access mode.
-        * Note: `ByValue` use of a `Copy` type is seen as a `ref` access mode.
-    * Closure mode is `ref` or `move`
-* Output:
-    * Minimal `(Place, Mode)` pairs that are actually captured
-* Cleanup and truncation
-    * Generate C' by mapping each (Mode, Place) in C:
-        * `(Place1, Mode1) = ref_opt(unsafe_check(Place, Mode))`
-        * `(Place2, Mode2)` = if this is a ref closure:
-            * `ref_xform(Place1, Mode1)`
-        * else:
-            * `move_xform(Place1, Mode1)`
-        * Add `(Place3, Mode3) = truncate_move_through_drop(Place2, Mode2)` to C'.
-* Minimization
-    * Until no rules apply:
-        * For each two places (P1, M1), (P2, M2) where P1 is a prefix of P2:
-            * Remove both places from the set
-            * Add (P1, max(M1, M2)) into the set
-* Helper functions:
-    * `unsafe_check(Place, Mode) -> (Place, Mode)`
-        * "Ensure unsafe accesses occur within the closure"
-        * If Place contains a deref (at index `i`) of a raw pointer:
-            * Let `(Place1, Mode1) = truncate_place(Place, Mode, i)`
-            * Return (Place1, Mode1)
-        * If Mode is `ref *` and the place contains a field of a packed struct at index `i`:
-            * Let `(Place1, Mode1) = truncate_place(Place, Mode, i)`
-            * Return (Place1, Mode1)
-        * Else
-            * Return (Place, Mode)
-    * `move_xform(Place, Mode) -> (Place, Mode)` (For move closures)
-        * If place contains a deref at index `i`:
-            * Let `(Place1, _) = truncate_place(Place, Mode, i)`
-            * Return (Place1, ByValue)
-        * Else:
-            * Return (Place, ByValue)
-        * Note that initially we had considered an approach where "Take ownership if data being accessed is owned by the variable used to access it (or if closure attempts to move data that it doesn't own). That is when taking ownership only capture data that is found on the stack otherwise reborrow the reference.". This cause a bug around lifetimes, check [rust-lang/rust#88431](https://github.com/rust-lang/rust/issues/88431).
-    * `ref_xform(Place, Mode) -> (Place, Mode)` (for ref closures)
-        * "If taking ownership of data, only move data from enclosing stack frame."
-        * Generate C' by mapping each (Mode, Place) in C
-            * If Mode is ByValue and place contains a deref at index `i`:
-                * Let `(Place1, _) = truncate_place(Place, Mode, i)`
-                * Return (Place1, ByValue)
-            * Else:
-                * Return (Place, Mode)
-    * `ref_opt(Place, Mode) -> (Place, Mode)`
-        * "Optimization: borrow the ref, not data owned by ref."
-        * Disjoint capture over immutable reference doesn't add too much value because the fields can either be borrowed immutably or copied.
-        * Edge case: Field that is accessed via the referece lives longer than the reference.
-            * Resolution: Only consider the last Deref
-        * If Place is (Base, Projections), where Projections is a list of size N.
-            * For all `i, 0 <= i < N`, Projections[i] != Deref
-                * Return (Place, Mode)
-            * If `l, 0 <= l < N` is the last/rightmost Deref Projection i.e. for any `i, l < i < N` Projection[i] != Deref,
-              and `Place.type_before_projection(l) = ty::Ref(.., Mutability::Not)`
-                * Let Place1 = (Base, Projections[0..=l])
-                * Return (Place1, Ref)
-    * `truncate_move_through_drop(Place1, Mode1) -> (Place, Mode)`
-        * Rust doesn't permit moving out of a type that implements drop
-        * In the case where we do a disjoint capture in a move closure, we might end up trying to move out of drop type
-        * We truncate move of not-Copy types
-        * If Mode1 != ByBalue
-            * return (Place1, Mode1)
-        * If there exists `i` such that `Place1.before_projection(i): Drop` and `Place1.ty()` doesn't impl `Copy`
-            * then return `truncate_place(Place1, Mode1, i)`
-        * Else return (Place1, Mode1)
-        * Check [rust-lang/rust#88476](https://github.com/rust-lang/rust/issues/88476) for examples.
-    * `truncate_place(Place, Mode, len) -> (Place, Mode)`
-        * "Truncate the place to length `len`, i.e. upto but not including index `len`"
-        * "If during truncation we drop Deref of a `&mut` and the place was being used by `ref mut`, the access to the truncated place must be unique"
-        * Let (Proj_before, Proj_after) = Place.split_before(len)
-            * If Mode == `ref mut` and there exists `Deref` in `Proj_after` at index `i` such that `Place.type_before_projection(len + i)` is `&mut T`
-                * Return (Place(Proj_before, ..InputPlace), `ref-uniq`)
-            * Else Return (Place(Proj_before, ..InputPlace), Mode)
-
-## Key examples
-
-### box-mut
-
-This test shows how a `move` closure can sometimes capture values by mutable reference, if they are reached via a `&mut` reference.
-
-```rust
-struct Foo { x: i32 }
-
-fn box_mut() {
-    let mut s = Foo { x: 0 } ;
-
-    let px = &mut s;
-    let bx = Box::new(px);
-
-
-    let c = move || bx.x += 10;
-    // Mutable reference to this place:
-    //   (*(*bx)).x
-    //    ^ ^
-    //    | a Box
-    //    a &mut
-}
-```
-
-<!-- ignore: Omit error about unterminated string literal when representing c_prime -->
-```ignore
-Closure mode = move
-C_in = {
-    (ref mut, (*(*bx)).x)
-}
-C_out = C_in
-```
-
-Output is the same: `C' = C`
-
-### Packed-field-ref-and-move
-
-When you have a closure that both references a packed field (which is unsafe) and moves from it (which is safe) we capture the entire struct, rather than just moving the field. This is to aid in predictability, so that removing the move doesn't make the closure become unsafe:
-
-```rust
-#[repr(packed)]
-struct Packed { x: String }
-
-# fn use_ref<T>(_: &T) {}
-# fn move_value<T>(_: T) {}
-
-fn main() {
-    let packed = Packed { x: String::new() };
-
-    let c = || {
-        use_ref(&packed.x);
-        move_value(packed.x);
-    };
-
-    c();
-}
-```
-
-<!-- ignore: Omit error about unterminated string literal when representing c_prime -->
-```ignore
-Closure mode = ref
-C_in = {
-    (ref mut, packed)
-}
-C_out = C_in
-```
-
-### Optimization-Edge-Case
-
-This test shows an interesting edge case. Normally, when we see a borrow of something behind a shared reference (`&T`), we truncate to capture the entire reference, because that is more efficient (and we can always use that reference to reach all the data it refers to). However, in the case where we are dereferencing two shared references, we have to be sure to preserve the full path, since otherwise the resulting closure could have a shorter lifetime than is necessary.
-
-```edition2021
-struct Int(i32);
-struct B<'a>(&'a i32);
-
-struct MyStruct<'a> {
-   a: &'static Int,
-   b: B<'a>,
-}
-
-fn foo<'a, 'b>(m: &'a MyStruct<'b>) -> impl FnMut() + 'static {
-    let c = || drop(&m.a.0);
-    c
-}
-
-```
-
-<!-- ignore: Omit error about unterminated string literal when reprenting c_prime -->
-```ignore
-Closure mode = ref
-C_in = {
-    (ref mut, *m.a)
-}
-C_out = C_in
-```
-
-# Edition 2018 and before
-
-## Closure types difference
-
-In Edition 2018 and before, a closure would capture variables in its entirety. This means that for the example used in the [Closure types](#closure-types) section, the generated closure type would instead look something like this:
+In Edition 2018 and before, closures always capture a variable in its entirety, without its precise capture path. This means that for the example used in the [Closure types](#closure-types) section, the generated closure type would instead look something like this:
 
 <!-- ignore: simplified -->
 ```rust,ignore
@@ -516,20 +554,22 @@ struct Closure<'a> {
 
 impl<'a> FnOnce<()> for Closure<'a> {
     type Output = String;
-    fn call_once(self) -> String {
+    extern "rust-call" fn call_once(self, args: ()) -> String {
         self.rect.left_top.x += 1;
         self.rect.right_bottom.x += 1;
         format!("{:?}", self.rect.left_top)
     }
 }
 ```
+
 and the call to `f` would work as follows:
+
 <!-- ignore: continuation of above -->
 ```rust,ignore
 f(Closure { rect: rect });
 ```
 
-## Capture precision difference
+### Capture precision difference
 
 r[type.closure.capture.composite]
 Composite types such as structs, tuples, and enums are always captured in its entirety,
@@ -553,19 +593,14 @@ impl SetVec {
 }
 ```
 
-If, instead, the closure were to use `self.vec` directly, then it would attempt
-to capture `self` by mutable reference. But since `self.set` is already
-borrowed to iterate over, the code would not compile.
+If, instead, the closure were to use `self.vec` directly, then it would attempt to capture `self` by mutable reference. But since `self.set` is already borrowed to iterate over, the code would not compile.
 
 r[type.closure.capture.move]
-If the `move` keyword is used, then all captures are by move or, for `Copy`
-types, by copy, regardless of whether a borrow would work. The `move` keyword is
-usually used to allow the closure to outlive the captured values, such as if the
-closure is being returned or used to spawn a new thread.
+If the `move` keyword is used, then all captures are by move or, for `Copy` types, by copy, regardless of whether a borrow would work. The `move` keyword is usually used to allow the closure to outlive the captured values, such as if the closure is being returned or used to spawn a new thread.
 
 Regardless of if the data will be read by the closure, i.e. in case of wild card patterns, if a variable defined outside the closure is mentioned within the closure the variable will be captured in its entirety.
 
-## Drop order difference
+### Drop order difference
 
 As composite types are captured in their entirety, a closure which captures one of those composite types by value would drop the entire captured variable at the same time as the closure gets dropped.
 


### PR DESCRIPTION
This updates the closure documentation to incorporate the changes for [RFC 2229](https://github.com/rust-lang/rfcs/blob/master/text/2229-capture-disjoint-fields.md) disjoint closure captures in Edition 2021. 

This is a repost of https://github.com/rust-lang/reference/pull/1059 with some changes that I applied. I'm still not 100% confident in this, but I think it is getting close.

Closes https://github.com/rust-lang/reference/issues/1066