### PR TITLE
Suppress type length limit test and note that it is not enforced

### DIFF
--- a/src/attributes/limits.md
+++ b/src/attributes/limits.md
@@ -35,9 +35,7 @@ a!{}
 
 ## The `type_length_limit` attribute
 
-> [!NOTE]
-> This limit is only enforced when the nightly `-Zenforce-type-length-limit`
-> flag is active.
+> **Note**: This limit is only enforced when the nightly `-Zenforce-type-length-limit` flag is active.
 >
 > For more information, see <https://github.com/rust-lang/rust/pull/127670>.
 

--- a/src/attributes/limits.md
+++ b/src/attributes/limits.md
@@ -35,6 +35,12 @@ a!{}
 
 ## The `type_length_limit` attribute
 
+> [!NOTE]
+> This limit is only enforced when the nightly `-Zenforce-type-length-limit`
+> flag is active.
+>
+> For more information, see <https://github.com/rust-lang/rust/pull/127670>.
+
 The *`type_length_limit` attribute* limits the maximum number of type
 substitutions made when constructing a concrete type during monomorphization.
 It is applied at the [crate] level, and uses the [_MetaNameValueStr_] syntax
@@ -42,7 +48,7 @@ to set the limit based on the number of type substitutions.
 
 > Note: The default in `rustc` is 1048576.
 
-```rust,compile_fail
+```rust,ignore
 #![type_length_limit = "4"]
 
 fn f<T>(x: T) {}


### PR DESCRIPTION
Bit of a cop out, but I don't think we should actually do anything more here.

I think deprecating the limit attribute is a bit overkill, since users who add it to their code because nightly *just* started telling them it's necessary shouldn't be punished imo.

https://github.com/rust-lang/rust/pull/127670#issuecomment-2227383876