### PR TITLE
Remove broken link checker.

### DIFF
--- a/style-check/src/main.rs
+++ b/style-check/src/main.rs
@@ -84,7 +84,7 @@ fn check_directory(dir: &Path, bad: &mut bool) -> Result<(), Box<dyn Error>> {
 }
 
 fn cmark_check(path: &Path, bad: &mut bool, contents: &str) -> Result<(), Box<dyn Error>> {
-    use pulldown_cmark::{BrokenLink, CodeBlockKind, Event, Options, Parser, Tag};
+    use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag};
 
     macro_rules! cmark_error {
         ($bad:expr, $path:expr, $range:expr, $($arg:tt)*) => {
@@ -96,20 +96,7 @@ fn cmark_check(path: &Path, bad: &mut bool, contents: &str) -> Result<(), Box<dy
     }
 
     let options = Options::all();
-    // Can't use `bad` because it would get captured in closure.
-    let mut link_err = false;
-    let mut cb = |link: BrokenLink<'_>| {
-        cmark_error!(
-            &mut link_err,
-            path,
-            link.span,
-            "broken {:?} link (reference `{}`)",
-            link.link_type,
-            link.reference
-        );
-        None
-    };
-    let parser = Parser::new_with_broken_link_callback(contents, options, Some(&mut cb));
+    let parser = Parser::new_ext(contents, options);
 
     for (event, range) in parser.into_offset_iter() {
         match event {
@@ -135,6 +122,5 @@ fn cmark_check(path: &Path, bad: &mut bool, contents: &str) -> Result<(), Box<dy
             _ => {}
         }
     }
-    *bad |= link_err;
     Ok(())
 }


### PR DESCRIPTION
This removes the broken-link *markdown* checker. Unfortunately it is not compatible with the mdbook-spec plugin, which adds implicit link definitions for things like rules and std links. The link checker needs to run *after* the preprocessor, but there isn't a particularly good way to do that. Eventually this should be built-in to mdbook which is capable of doing that. We'll just need to be extra careful and diligent to avoid these.

The *html* link checker still runs, which runs after content generation.
