### PR TITLE
Add '_ to LIFETIME_OR_LABEL

### DIFF
--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -209,6 +209,8 @@ Labels follow the hygiene and shadowing rules of local variables. For example, t
 }
 ```
 
+`'_` is not a valid loop label.
+
 ## `break` expressions
 
 > **<sup>Syntax</sup>**\

--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -44,6 +44,8 @@ See [generic parameter scopes] for more details.
 [function pointers] have lifetime or type parameters as well, but are not
 referred to with path syntax.
 
+`'_` is not a valid lifetime parameter.
+
 ### Const generics
 
 *Const generic parameters* allow items to be generic over constant values. The

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -645,6 +645,8 @@ Examples of reserved forms:
 >
 > LIFETIME_OR_LABEL :\
 > &nbsp;&nbsp; &nbsp;&nbsp; `'` [NON_KEYWORD_IDENTIFIER][identifier]
+>   _(not immediately followed by `'`)_\
+> &nbsp;&nbsp; | `'_`
 >   _(not immediately followed by `'`)_
 
 Lifetime parameters and [loop labels] use LIFETIME_OR_LABEL tokens. Any

--- a/src/trait-bounds.md
+++ b/src/trait-bounds.md
@@ -18,8 +18,7 @@
 >
 > _Lifetime_ :\
 > &nbsp;&nbsp; &nbsp;&nbsp; [LIFETIME_OR_LABEL]\
-> &nbsp;&nbsp; | `'static`\
-> &nbsp;&nbsp; | `'_`
+> &nbsp;&nbsp; | `'static`
 
 [Trait] and lifetime bounds provide a way for [generic items][generic] to
 restrict which types and lifetimes are used as their parameters. Bounds can be


### PR DESCRIPTION
This adds `'_` to the LIFETIME_OR_LABEL. It has been supported syntactically since before 1.0. 