### PR TITLE
Describe all cases for which the weak `dyn` keyword is parsed as a keyword

### DIFF
--- a/src/keywords.md
+++ b/src/keywords.md
@@ -105,7 +105,8 @@ is possible to declare a variable or method with the name `union`.
   fn invalid_lifetime_parameter<'static>(s: &'static str) -> &'static str { s }
   ```
 * In the 2015 edition, [`dyn`] is a keyword when used in a type position
-  followed by a path that does not start with `::`.
+  followed by a path that does not start with `::` or `<`, a lifetime, a question mark, a `for`
+  keyword or an opening parenthesis.
 
   Beginning in the 2018 edition, `dyn` has been promoted to a strict keyword.
 


### PR DESCRIPTION
Had to figure this out for rust-analyzer and noticed that the reference is lacking here (arguably not an important detail as 2015 is rather old :)

Sourced from rustc here: https://github.com/rust-lang/rust/blob/339015920d0787ea14aee05fca2c205683c525f9/compiler/rustc_parse/src/parser/ty.rs#L722-L731 and https://github.com/rust-lang/rust/blob/339015920d0787ea14aee05fca2c205683c525f9/compiler/rustc_parse/src/parser/ty.rs#L84-L99