### PR TITLE
Update link for unsafe blocks.

### DIFF
--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -180,7 +180,7 @@ if false {
 > _UnsafeBlockExpression_ :\
 > &nbsp;&nbsp; `unsafe` _BlockExpression_
 
-_See [`unsafe` block](../unsafe-blocks.md) for more information on when to use `unsafe`_
+_See [`unsafe` blocks] for more information on when to use `unsafe`_.
 
 A block of code can be prefixed with the `unsafe` keyword to permit [unsafe operations].
 Examples:
@@ -233,6 +233,7 @@ fn is_unix_platform() -> bool {
 [`loop`]: loop-expr.md#infinite-loops
 [`std::ops::Fn`]: ../../std/ops/trait.Fn.html
 [`std::future::Future`]: ../../std/future/trait.Future.html
+[`unsafe` blocks]: ../unsafe-keyword.md#unsafe-blocks-unsafe-
 [`while let`]: loop-expr.md#predicate-pattern-loops
 [`while`]: loop-expr.md#predicate-loops
 [array expressions]: array-expr.md


### PR DESCRIPTION
This link was pointing to a redirect, but the redirect isn't capable of handling linking to a specific section. This updates the link to point to the intended part of the chapter.