### PR TITLE
Spec abi chapter

### DIFF
--- a/src/abi.md
+++ b/src/abi.md
@@ -26,10 +26,13 @@ Two integer types are *abi compatible* if they have the same size and the same s
 > Two integer types with different signedness, such as `u8` and `i8` are not *abi compatible*.
 
 r[abi.compatibility.char]
-The type `char`is *abi compatible* with the type `u32`. 
+The type `char` is *abi compatible* with the type `u32`. 
 
 r[abi.compatibility.pointer]
 Two pointer types, `*mut T` and `*const U`, are *abi compatible* if the *metadata type*s of `T` and `U` are the same type. 
+
+> [!NOTE]
+> [`Sized`] types have a *metadata type* of `()`. 
 
 > [!NOTE]
 > With transitivity, this applies regardless of the mutability of either pointer type
@@ -38,14 +41,13 @@ r[abi.compatibility.reference-box]
 The types `&T`, `&mut T`, [`Box<T>`][core::boxed::Box], and [`NonNull<T>`][core::ptr::NonNull], are *abi compatible* with `*const T`
 
 > [!NOTE]
-> With transitivity,t hey are also *abi compatible** with each other, and with `*mut T`, as well as references/`Box` to different types that have the same *metadata type*.
-
+> With transitivity, they are also *abi compatible* with each other, and with `*mut T`, as well as references/`Box` to different types that have the same *metadata type*.
 
 r[abi.compatibility.core]
 The types [`MaybeUninit<T>`][core::mem::MaybeUninit], [`UnsafeCell<T>`][core::cell::UnsafeCell], and [`NonZero<T>`][core::num::NonZero], are *abi compatible* with `T`.
 
 r[abi.compatibility.transparent]
-A `struct` declared with the `transparent` representation is *abi compatible* with its field that does not have size 0 and alignment 1, if such a field exists
+A `struct` declared with the `transparent` representation is *abi compatible* with its field that does not have size 0 and alignment 1, if such a field exists.
 
 r[abi.compatibilty.zst]
 Two types, `T` and `U`, are *abi compatible* if both have size 0 and alignment 1.
@@ -68,30 +70,35 @@ Two function signatures are compatible if:
 * Each parameter of both signatures, in order, are *abi compatible*, and
 * Either both signatures have C-varargs, or neither signature does.
 
+> [!NOTE]
+> A signature is compatible with itself.
+
 r[abi.compatibility.simd-abi]
 A type has *simd abi requirements* if:
 * It is a type declared with the standard-library repr-attrbute `simd`,
 * It is a aggregate type, which has a type with *simd abi requirements* as a field.
+
+> [!NOTE]
+> The `repr(simd)` attribute cannot be used by Rust code, only by the standard library.
 
 r[abi.compatibility.simd-target-feature]
 A type with *simd abi requirements* may have one or more [*salient target features*][target_feature] . In the case of an aggregate type, the set of [*salient target features*][target_feature] is the union of the set of [*salient target features*][target_feature] of each field with *simd abi requirements*.
 
 > [!TARGET-SPECIFIC]
 > On x86 and x86-64, the [*salient target features*][target_feature] of the `simd` types are:
-> * [`__m128`], [`__m128i`], [`__m128f`], and [`__m128d`]: `sse`
-> * [`__m256`], [`__m256i`], [`__m256f`], and [`__m256d`]: `avx`
-> * [`__m512`], [`__m512i`], [`__m512f`], and [`__m512d`]: `avx512f` and `avx512vl`
+> * [`__m128`], [`__m128i`], [`__m128f`], and [`__m128d`] (128-bit vector types): `sse`
+> * [`__m256`], [`__m256i`], [`__m256f`], and [`__m256d`] (256-bit vector types): `avx`
+> * [`__m512`], [`__m512i`], [`__m512f`], and [`__m512d`] (512-bit vector types): `avx512f` and `avx512vl`
 
 r[abi.compatibility.call]
-A call to a function `f` via a function item or function pointer with a given signature `S` is valid only if the signature of `f` is *compatible* with the signature `S`, and:
-* The ABI tag of the function is `extern "Rust"`, or
-* If the type of any parameter, the return type, or the type of any argument passed via C-varargs has *simd abi requirements*, each [*salient target features*][target_feature]of that type is either set at both the definition site of the function, and at the call site, or is set at neither site.
+A call to a function `f` via a function item or function pointer with a given signature `S` is valid if and only if the signature of the definition `f` is *compatible* with the signature `S`, and:
+* The ABI tag of the signature is `extern "Rust"`, or
+* If any parameter type, the return type, or the type of any argument passed via C-varargs has *simd abi requirements*, each [*salient target features*][target_feature] of that type is either set at both the definition site of the function, and at the call site, or is set at neither site.
 
 The behaviour a call that is not valid is undefined.
 
 > [!NOTE]
 > the ABI tag `extern "Rust"` is the default when the `extern` keyword is not used (either to declare the function within an [`extern` block], or as a [function qualifier][extern functions]). Thus it is safe to call most functions that use simd types.
-
 
 [`__m128`]: https://doc.rust-lang.org/stable/core/arch/x86_64/struct.__m128.html
 [`__m128i`]: https://doc.rust-lang.org/stable/core/arch/x86_64/struct.__m128i.html
@@ -192,8 +199,6 @@ The *`no_mangle` attribute* may be specified as a built-in attribute, using the 
 r[abi.symbol-name.export_name]
 The *`export_name` attribute* may be specified as a built-in attribute, using the [_MetaNameValueStr_] syntax. The *export name* of an item with the *`no_mangle` attribute* is the content of `STRING_LITERAL`. 
 
-
-
 ## The `link_section` attribute
 
 r[abi.link_section]
@@ -234,10 +239,6 @@ pub static VAR1: u32 = 1;
 > * `.tbss`: Readable and Writable - Uninitialized and Thread-local.
 > 
 > This is not an exhaustive list, and generally extended versions of these section names such as `.text.foo`, are also defined with the same properties as the base section.
-> 
-> 
-
-
 
 [_MetaWord_]: attributes.md#meta-item-attribute-syntax
 [_MetaNameValueStr_]: attributes.md#meta-item-attribute-syntax

--- a/src/abi.md
+++ b/src/abi.md
@@ -74,16 +74,23 @@ A type has *simd abi requirements* if:
 * It is a aggregate type, which has a type with *simd abi requirements* as a field.
 
 r[abi.compatibility.simd-target-feature]
-A type with *simd abi requirements* may have one or more *salient target features* . In the case of an aggregate type, the set of *salient target features* is the union of the set of *salient target features* of each field with *simd abi requirements*.
+A type with *simd abi requirements* may have one or more [*salient target features*][target_feature] . In the case of an aggregate type, the set of [*salient target features*][target_feature] is the union of the set of [*salient target features*][target_feature] of each field with *simd abi requirements*.
 
 > [!TARGET-SPECIFIC]
-> On x86 and x86-64, the *salient target features* of the `simd` types are:
+> On x86 and x86-64, the [*salient target features*][target_feature] of the `simd` types are:
 > * [`__m128`], [`__m128i`], [`__m128f`], and [`__m128d`]: `sse`
 > * [`__m256`], [`__m256i`], [`__m256f`], and [`__m256d`]: `avx`
 > * [`__m512`], [`__m512i`], [`__m512f`], and [`__m512d`]: `avx512f` and `avx512vl`
 
 r[abi.compatibility.call]
-A call to a function `f` via a function item or function pointer with a given signature `S` is valid only if the signature of `f` is *compatible* with the signature `S`, and, if the type of any parameter, the return type, or the type of any argument passed via C-varargs has *simd abi requirements*, each *salient target feature* of that type is either set at both the definition site of the function, and at the call site, or is set at neither site. The behaviour a call that is not valid is undefined.
+A call to a function `f` via a function item or function pointer with a given signature `S` is valid only if the signature of `f` is *compatible* with the signature `S`, and:
+* The ABI tag of the function is `extern "Rust"`, or
+* If the type of any parameter, the return type, or the type of any argument passed via C-varargs has *simd abi requirements*, each [*salient target features*][target_feature]of that type is either set at both the definition site of the function, and at the call site, or is set at neither site.
+
+The behaviour a call that is not valid is undefined.
+
+> [!NOTE]
+> the ABI tag `extern "Rust"` is the default when the `extern` keyword is not used (either to declare the function within an [`extern` block], or as a [function qualifier][extern functions]). Thus it is safe to call most functions that use simd types.
 
 
 [`__m128`]: https://doc.rust-lang.org/stable/core/arch/x86_64/struct.__m128.html
@@ -100,7 +107,6 @@ A call to a function `f` via a function item or function pointer with a given si
 [`__m512d`]: https://doc.rust-lang.org/stable/core/arch/x86_64/struct.__m512d.html
 
 ## The `used` attribute
-
 
 r[abi.used]
 
@@ -231,6 +237,8 @@ pub static VAR1: u32 = 1;
 > 
 > 
 
+
+
 [_MetaWord_]: attributes.md#meta-item-attribute-syntax
 [_MetaNameValueStr_]: attributes.md#meta-item-attribute-syntax
 [`static` items]: items/static-items.md
@@ -240,3 +248,4 @@ pub static VAR1: u32 = 1;
 [function]: items/functions.md
 [item]: items.md
 [static]: items/static-items.md
+[target_feature]: attributes/codegen.md#the-target_feature-attribute

--- a/src/abi.md
+++ b/src/abi.md
@@ -59,13 +59,13 @@ r[abi.compatibility.fn-ptr]
 An `fn`-ptr type `T` is compatible with an `fn`-ptr type `U` if `T` and `U` have *abi compatible* tags.
 
 r[abi.compatibility.extern-tag]
-Two abi tags are *abi compatible* if:
+Two [abi tags][abi] are *abi compatible* if:
 * They are the same string, or
 * One tag is `"X"`, and the other is `"X-unwind"`
 
 r[abi.compatibility.signature]
 Two function signatures are compatible if:
-* The abi tags of both signatures are *abi compatible*,
+* The [abi tags][abi] of both signatures are *abi compatible*,
 * They have the same number of parameters, excluding C-varargs,
 * Each parameter of both signatures, in order, are *abi compatible*, and
 * Either both signatures have C-varargs, or neither signature does.
@@ -246,6 +246,7 @@ pub static VAR1: u32 = 1;
 [attribute]: attributes.md
 [extern functions]: items/functions.md#extern-function-qualifier
 [`extern` block]: items/external-blocks.md
+[abi]: items/external-blocks.md#abi
 [function]: items/functions.md
 [item]: items.md
 [static]: items/static-items.md

--- a/src/abi.md
+++ b/src/abi.md
@@ -19,53 +19,53 @@ Two types `T` and `U` are *abi compatible* if:
 > These properties ensure that *abi compatibility* is an equivalence relation.
 
 r[abi.compatibility.integer]
-Two integer types are *abi compatible* if they have the same size and the same signednes
+Two [integer types] are *abi compatible* if they have the same size and the same signednes
 
 > [!NOTE]
 > In particular, `usize` is *abi compatible* with `uN`, and `isize` is *abi compatible* with `iN` where `N` is the target_pointer_width. 
 > Two integer types with different signedness, such as `u8` and `i8` are not *abi compatible*.
 
 r[abi.compatibility.char]
-The type `char` is *abi compatible* with the type `u32`. 
+The type [`char`] is *abi compatible* with the type [`u32`][integer types]. 
 
 r[abi.compatibility.pointer]
-Two pointer types, `*mut T` and `*const U`, are *abi compatible* if the *metadata type*s of `T` and `U` are the same type. 
+Two [pointer types], `*mut T` and `*const U`, are *abi compatible* if the *metadata type*s of `T` and `U` are the same type. 
 
 > [!NOTE]
-> [`Sized`] types have a *metadata type* of `()`. 
+> [`core::marker::Sized`] types have a *metadata type* of `()`. 
 
 > [!NOTE]
 > With transitivity, this applies regardless of the mutability of either pointer type
 
 r[abi.compatibility.reference-box]
-The types `&T`, `&mut T`, [`Box<T>`][core::boxed::Box], and [`NonNull<T>`][core::ptr::NonNull], are *abi compatible* with `*const T`
+The types [`&T`], [`&mut T`], [`alloc::boxed::Box<T>`], and [`core::ptr::NonNull<T>`], are *abi compatible* with `*const T`
 
 > [!NOTE]
 > With transitivity, they are also *abi compatible* with each other, and with `*mut T`, as well as references/`Box` to different types that have the same *metadata type*.
 
 r[abi.compatibility.core]
-The types [`MaybeUninit<T>`][core::mem::MaybeUninit], [`UnsafeCell<T>`][core::cell::UnsafeCell], and [`NonZero<T>`][core::num::NonZero], are *abi compatible* with `T`.
+The types [`core::mem::MaybeUninit<T>`], [`core::cell::UnsafeCell<T>`], and [`core::num::NonZero<T>`], are *abi compatible* with `T`.
 
 r[abi.compatibility.transparent]
-A `struct` declared with the `transparent` representation is *abi compatible* with its field that does not have size 0 and alignment 1, if such a field exists.
+A [`struct`] declared with the `transparent` representation is *abi compatible* with its field that does not have size 0 and alignment 1, if such a field exists.
 
 r[abi.compatibilty.zst]
 Two types, `T` and `U`, are *abi compatible* if both have size 0 and alignment 1.
 
 r[abi.compatibility.option]
-If `T` is a type listed in [layout.enum.option](https://doc.rust-lang.org/stable/core/option/index.html#representation), then given `S` is a type with size 0 and alignment 1, `T` is *abi compatible* with the types [`Option<T>`], [`Result<T,S>`], and [`Result<S,T>`].
+If `T` is a type listed in [layout.enum.option](https://doc.rust-lang.org/stable/core/option/index.html#representation), then given `S` is a type with size 0 and alignment 1, `T` is *abi compatible* with the types [`core::option::Option<T>`], [`core::result::Result<T,S>`], and [`core::result::Result<S,T>`].
 
 r[abi.compatibility.fn-ptr]
-An `fn`-ptr type `T` is compatible with an `fn`-ptr type `U` if `T` and `U` have *abi compatible* tags.
+An [`fn`-ptr type] `T` is compatible with an [`fn`-ptr type] `U` if `T` and `U` have *abi compatible* tags.
 
 r[abi.compatibility.extern-tag]
-Two [abi tags][abi] are *abi compatible* if:
+Two [abi tags][abi tag] are *abi compatible* if:
 * They are the same string, or
 * One tag is `"X"`, and the other is `"X-unwind"`
 
 r[abi.compatibility.signature]
 Two function signatures are compatible if:
-* The [abi tags][abi] of both signatures are *abi compatible*,
+* The [abi tags][abi tag] of both signatures are *abi compatible*,
 * They have the same number of parameters, excluding C-varargs,
 * Each parameter of both signatures, in order, are *abi compatible*, and
 * Either both signatures have C-varargs, or neither signature does.
@@ -76,7 +76,7 @@ Two function signatures are compatible if:
 r[abi.compatibility.simd-abi]
 A type has *simd abi requirements* if:
 * It is a type declared with the standard-library repr-attrbute `simd`,
-* It is a aggregate type, which has a type with *simd abi requirements* as a field.
+* It is a aggregate type[^1], which has a type with *simd abi requirements* as a field.
 
 > [!NOTE]
 > The `repr(simd)` attribute cannot be used by Rust code, only by the standard library.
@@ -99,6 +99,8 @@ The behaviour a call that is not valid is undefined.
 
 > [!NOTE]
 > the ABI tag `extern "Rust"` is the default when the `extern` keyword is not used (either to declare the function within an [`extern` block], or as a [function qualifier][extern functions]). Thus it is safe to call most functions that use simd types.
+
+[^1]: The aggregate types, for the purposes of this clause, are [`struct`] types, [`enum`] types, [`union`] types, and [array] types.
 
 [`__m128`]: https://doc.rust-lang.org/stable/core/arch/x86_64/struct.__m128.html
 [`__m128i`]: https://doc.rust-lang.org/stable/core/arch/x86_64/struct.__m128i.html
@@ -246,8 +248,18 @@ pub static VAR1: u32 = 1;
 [attribute]: attributes.md
 [extern functions]: items/functions.md#extern-function-qualifier
 [`extern` block]: items/external-blocks.md
-[abi]: items/external-blocks.md#abi
+[abi tag]: items/external-blocks.md#abi
 [function]: items/functions.md
+[`fn`-ptr type]: types/function-pointer.md
+[integer types]: types/numeric.md#integer-types
+[`char`]: types/textual.md
+[pointer types]: types/pointer.md#raw-pointers-const-and-mut
+[`&T`]: types/pointer.md#shared-references-
+[`&mut T`]: types/pointer.md#mutable-references-mut
+[`struct`]: types/struct.md
+[`enum`]: types/enum.md
+[`union`]: types/union.md
+[array]: types/array.md
 [item]: items.md
 [static]: items/static-items.md
 [target_feature]: attributes/codegen.md#the-target_feature-attribute

--- a/src/abi.md
+++ b/src/abi.md
@@ -25,8 +25,39 @@ Two [integer types] are *abi compatible* if they have the same size and the same
 > In particular, `usize` is *abi compatible* with `uN`, and `isize` is *abi compatible* with `iN` where `N` is the target_pointer_width. 
 > Two integer types with different signedness, such as `u8` and `i8` are not *abi compatible*.
 
+```rust
+#[cfg(target_pointer_width="32")]
+fn foo(x: u32) -> u32{
+    x
+}
+#[cfg(target_pointer_width="64")]
+fn foo(x: u64) -> u64{
+    x
+}
+
+fn main(){
+    let f: fn(usize)->usize = unsafe{core::mem::transmute(foo as fn(_)->_)};
+    let x = 0usize;
+    let y = f(x);
+    assert_eq!(x,y);
+}
+```
+
 r[abi.compatibility.char]
 The type [`char`] is *abi compatible* with the type [`u32`][integer types]. 
+
+```rust
+fn foo(x: char) -> u32{
+    x as u32
+}
+
+fn main(){
+    let f: fn(u32)->char = unsafe{core::mem::transmute(foo as fn(_)->_)};
+    let x = b'A' as u32; // ascii character indecies are the same as Unicode character indecies
+    let y = f(x);
+    assert_eq!(y, 'A');
+}
+```
 
 r[abi.compatibility.pointer]
 Two [pointer types], `*mut T` and `*const U`, are *abi compatible* if the *metadata type*s of `T` and `U` are the same type. 
@@ -37,11 +68,39 @@ Two [pointer types], `*mut T` and `*const U`, are *abi compatible* if the *metad
 > [!NOTE]
 > With transitivity, this applies regardless of the mutability of either pointer type
 
+```rust
+unsafe fn foo(x: *mut i32){
+   unsafe{x.write(5);} 
+}
+
+fn main(){
+    let f: unsafe fn(*mut ()) = unsafe{core::mem::transmute(foo as unsafe fn(_))}; // Type Erase the function
+    let mut val = 0;
+    let ptr = core::ptr::addr_of_mut!(val).cast::<()>(); // Get Opaque Userdata from somewhere
+    unsafe{f(ptr);}
+    assert_eq!(val, 5);
+}
+```
+
 r[abi.compatibility.reference-box]
 The types [`&T`], [`&mut T`], [`alloc::boxed::Box<T>`], and [`core::ptr::NonNull<T>`], are *abi compatible* with `*const T`
 
 > [!NOTE]
 > With transitivity, they are also *abi compatible* with each other, and with `*mut T`, as well as references/`Box` to different types that have the same *metadata type*.
+
+```rust
+fn foo(x: &mut i32){
+   *x = 5; 
+}
+
+fn main(){
+    let f: unsafe fn(*mut ()) = unsafe{core::mem::transmute(foo as fn(_))}; // Type Erase the function
+    let mut val = 0;
+    let ptr = core::ptr::addr_of_mut!(val).cast::<()>(); // Get Opaque Userdata from somewhere
+    unsafe{f(ptr);}
+    assert_eq!(val, 5);
+}
+```
 
 r[abi.compatibility.core]
 The types [`core::mem::MaybeUninit<T>`], [`core::cell::UnsafeCell<T>`], and [`core::num::NonZero<T>`], are *abi compatible* with `T`.
@@ -54,6 +113,7 @@ Two types, `T` and `U`, are *abi compatible* if both have size 0 and alignment 1
 
 r[abi.compatibility.option]
 If `T` is a type listed in [layout.enum.option](https://doc.rust-lang.org/stable/core/option/index.html#representation), then given `S` is a type with size 0 and alignment 1, `T` is *abi compatible* with the types [`core::option::Option<T>`], [`core::result::Result<T,S>`], and [`core::result::Result<S,T>`].
+
 
 r[abi.compatibility.fn-ptr]
 An [`fn`-ptr type] `T` is compatible with an [`fn`-ptr type] `U` if `T` and `U` have *abi compatible* tags.
@@ -98,6 +158,9 @@ A call to a function `f` via a function item or function pointer with a given si
 The behaviour a call that is not valid is undefined.
 
 > [!NOTE]
+> When parameter/return types do not exactly match, they are converted as though by calling [`core::mem::transmute`]. The representation and validity requirements of the type in the definition/return site still apply, for example, passing `0` to a function pointer `fn(u32)` that points to a function declared as `fn foo(x: NonZeroU32)` is undefined behaviour.
+
+> [!NOTE]
 > the ABI tag `extern "Rust"` is the default when the `extern` keyword is not used (either to declare the function within an [`extern` block], or as a [function qualifier][extern functions]). Thus it is safe to call most functions that use simd types.
 
 [^1]: The aggregate types, for the purposes of this clause, are [`struct`] types, [`enum`] types, [`union`] types, and [array] types.
@@ -128,6 +191,11 @@ The *`used` attribute* may be specified as a built-in attribute, using the [_Met
 
 r[abi.used.restriction]
 The `used` attribute shall only be applied to a `static` item. It shall not be applied to a `static` item declared within an [`extern` block].
+
+```rust
+#[used]
+static FOO: u32 = 0;
+```
 
 r[abi.used.application]
 A `static` item with the `used` attribute is an *exported item*. 
@@ -189,8 +257,28 @@ MetaItemExportName := "export_name" "=" ([STRING_LITERAL] | [RAW_STRING_LITERAL]
 r[abi.symbol-name.names]
 The *`no_mangle` attribute* and the *`export_name` attribute* shall only be applied to a `static` or `fn` item. The *`export_name` attribute* shall not be applied to an item declared within an [`extern` block]. 
 
+```rust
+#[no_mangle]
+extern "C" fn foo(x: i32) -> i32 {
+    x + 1
+}
+
+#[export_name = "bar"]
+extern "C" fn baz(x: i32) -> i32 {
+    x + 2
+}
+```
+
+```rust,compile_fail
+extern "C" {
+    #[export_name = "foo"]
+    fn __foo(x: i32) -> i32;
+}
+```
+
 > [!NOTE]
 > They may be applied to an associated `fn` of an `impl` block.
+
 
 r[abi.symbol-name.exported]
 An item with either the *`no_mangle` attrbute* or the *`export_name` attribute* is an *exported item*.
@@ -198,8 +286,42 @@ An item with either the *`no_mangle` attrbute* or the *`export_name` attribute* 
 r[abi.symbol-name.no_mangle]
 The *`no_mangle` attribute* may be specified as a built-in attribute, using the [_MetaWord_] syntax. The *export name* of an item with the *`no_mangle` attribute* is the declaration name of the item.
 
+```rust
+extern "C" {
+    fn bar() -> i32;
+}
+mod inner{
+    #[no_mangle]
+    extern "C" fn bar() -> i32 {
+        0
+    }
+}
+
+fn main() {
+    let y = unsafe {bar()};
+    assert_eq!(y,0);
+}
+```
+
 r[abi.symbol-name.export_name]
 The *`export_name` attribute* may be specified as a built-in attribute, using the [_MetaNameValueStr_] syntax. The *export name* of an item with the *`no_mangle` attribute* is the content of `STRING_LITERAL`. 
+
+```rust
+extern "C" {
+    fn bar() -> i32;
+}
+mod inner{
+    #[export_name = "bar"]
+    extern "C" fn __some_other_item_name() -> i32 {
+        0
+    }
+}
+
+fn main(){
+    let y = unsafe {bar()};
+    assert_eq!(y,0);
+}
+```
 
 ## The `link_section` attribute
 
@@ -215,6 +337,13 @@ The *`link_section` attribute* may be specified as a built-in attribute, using t
 r[abi.link_section.restriction]
 The *`link_section` attribute* shall be aplied to a `static` or `fn` item.
 
+<!-- no_run: don't link. The format of the section name is platform-specific. -->
+```rust,no_run
+#[no_mangle]
+#[link_section = ".example_section"]
+pub static VAR1: u32 = 1;
+```
+
 r[abi.link_section.def]
 An item with the *`link_section` attribute* is placed in the specified section when linking. The section specified shall not violate the constraints on section names on the target, and shall not be invalid for the item type, no diagnostic is required.
 
@@ -224,12 +353,6 @@ An item with the *`link_section` attribute* is placed in the specified section w
 >
 > The result of using an invalid section name may be that the section is placed into the section but cannot be used as applicable, or that the section is given additional attributes that may be incompatible when linking.
 
-<!-- no_run: don't link. The format of the section name is platform-specific. -->
-```rust,no_run
-#[no_mangle]
-#[link_section = ".example_section"]
-pub static VAR1: u32 = 1;
-```
 
 > [!TARGET-SPECIFIC]
 > On ELF Platforms, the standard section names, and their attributes are:
@@ -241,6 +364,7 @@ pub static VAR1: u32 = 1;
 > * `.tbss`: Readable and Writable - Uninitialized and Thread-local.
 > 
 > This is not an exhaustive list, and generally extended versions of these section names such as `.text.foo`, are also defined with the same properties as the base section.
+
 
 [_MetaWord_]: attributes.md#meta-item-attribute-syntax
 [_MetaNameValueStr_]: attributes.md#meta-item-attribute-syntax

--- a/src/abi.md
+++ b/src/abi.md
@@ -1,21 +1,126 @@
 # Application Binary Interface (ABI)
 
-This section documents features that affect the ABI of the compiled output of
-a crate.
+r[abi]
 
-See *[extern functions]* for information on specifying the ABI for exporting
-functions. See *[external blocks]* for information on specifying the ABI for
-linking external libraries.
+## ABI Compatibility
+
+r[abi.compatibility]
+
+r[abi.compatibilty.type]
+Two types, `T` and `U`, can be *abi compatible*.
+
+r[abi.compatibility.equivalence]
+Two types `T` and `U` are *abi compatible* if:
+* They are the same type,
+* `U` is *abi compatible* with `T`, or
+* There exists a type `V`, such that `T` is *abi compatible* with `V` an `V` is *abi compatuble* with `U`,
+
+> [!NOTE]
+> These properties ensure that *abi compatibility* is an equivalence relation.
+
+r[abi.compatibility.integer]
+Two integer types are *abi compatible* if they have the same size and the same signednes
+
+> [!NOTE]
+> In particular, `usize` is *abi compatible* with `uN`, and `isize` is *abi compatible* with `iN` where `N` is the target_pointer_width. 
+> Two integer types with different signedness, such as `u8` and `i8` are not *abi compatible*.
+
+r[abi.compatibility.char]
+The type `char`is *abi compatible* with the type `u32`. 
+
+r[abi.compatibility.pointer]
+Two pointer types, `*mut T` and `*const U`, are *abi compatible* if the *metadata type*s of `T` and `U` are the same type. 
+
+> [!NOTE]
+> With transitivity, this applies regardless of the mutability of either pointer type
+
+r[abi.compatibility.reference-box]
+The types `&T`, `&mut T`, [`Box<T>`][core::boxed::Box], and [`NonNull<T>`][core::ptr::NonNull], are *abi compatible* with `*const T`
+
+> [!NOTE]
+> With transitivity,t hey are also *abi compatible** with each other, and with `*mut T`, as well as references/`Box` to different types that have the same *metadata type*.
+
+
+r[abi.compatibility.core]
+The types [`MaybeUninit<T>`][core::mem::MaybeUninit], [`UnsafeCell<T>`][core::cell::UnsafeCell], and [`NonZero<T>`][core::num::NonZero], are *abi compatible* with `T`.
+
+r[abi.compatibility.transparent]
+A `struct` declared with the `transparent` representation is *abi compatible* with its field that does not have size 0 and alignment 1, if such a field exists
+
+r[abi.compatibilty.zst]
+Two types, `T` and `U`, are *abi compatible* if both have size 0 and alignment 1.
+
+r[abi.compatibility.option]
+If `T` is a type listed in [layout.enum.option](https://doc.rust-lang.org/stable/core/option/index.html#representation), then given `S` is a type with size 0 and alignment 1, `T` is *abi compatible* with the types [`Option<T>`], [`Result<T,S>`], and [`Result<S,T>`].
+
+r[abi.compatibility.fn-ptr]
+An `fn`-ptr type `T` is compatible with an `fn`-ptr type `U` if `T` and `U` have *abi compatible* tags.
+
+r[abi.compatibility.extern-tag]
+Two abi tags are *abi compatible* if:
+* They are the same string, or
+* One tag is `"X"`, and the other is `"X-unwind"`
+
+r[abi.compatibility.signature]
+Two function signatures are compatible if:
+* The abi tags of both signatures are *abi compatible*,
+* They have the same number of parameters, excluding C-varargs,
+* Each parameter of both signatures, in order, are *abi compatible*, and
+* Either both signatures have C-varargs, or neither signature does.
+
+r[abi.compatibility.simd-abi]
+A type has *simd abi requirements* if:
+* It is a type declared with the standard-library repr-attrbute `simd`,
+* It is a aggregate type, which has a type with *simd abi requirements* as a field.
+
+r[abi.compatibility.simd-target-feature]
+A type with *simd abi requirements* may have one or more *salient target features* . In the case of an aggregate type, the set of *salient target features* is the union of the set of *salient target features* of each field with *simd abi requirements*.
+
+> [!TARGET-SPECIFIC]
+> On x86 and x86-64, the *salient target features* of the `simd` types are:
+> * [`__m128`], [`__m128i`], [`__m128f`], and [`__m128d`]: `sse`
+> * [`__m256`], [`__m256i`], [`__m256f`], and [`__m256d`]: `avx`
+> * [`__m512`], [`__m512i`], [`__m512f`], and [`__m512d`]: `avx512f` and `avx512vl`
+
+r[abi.compatibility.call]
+A call to a function `f` via a function item or function pointer with a given signature `S` is valid only if the signature of `f` is *compatible* with the signature `S`, and, if the type of any parameter, the return type, or the type of any argument passed via C-varargs has *simd abi requirements*, each *salient target feature* of that type is either set at both the definition site of the function, and at the call site, or is set at neither site. The behaviour a call that is not valid is undefined.
+
+
+[`__m128`]: https://doc.rust-lang.org/stable/core/arch/x86_64/struct.__m128.html
+[`__m128i`]: https://doc.rust-lang.org/stable/core/arch/x86_64/struct.__m128i.html
+[`__m128f`]: https://doc.rust-lang.org/stable/core/arch/x86_64/struct.__m128f.html
+[`__m128d`]: https://doc.rust-lang.org/stable/core/arch/x86_64/struct.__m128d.html
+[`__m256`]: https://doc.rust-lang.org/stable/core/arch/x86_64/struct.__m256.html
+[`__m256i`]: https://doc.rust-lang.org/stable/core/arch/x86_64/struct.__m256i.html
+[`__m256f`]: https://doc.rust-lang.org/stable/core/arch/x86_64/struct.__m256f.html
+[`__m256d`]: https://doc.rust-lang.org/stable/core/arch/x86_64/struct.__m256d.html
+[`__m512`]: https://doc.rust-lang.org/stable/core/arch/x86_64/struct.__m512.html
+[`__m512i`]: https://doc.rust-lang.org/stable/core/arch/x86_64/struct.__m512i.html
+[`__m512f`]: https://doc.rust-lang.org/stable/core/arch/x86_64/struct.__m512f.html
+[`__m512d`]: https://doc.rust-lang.org/stable/core/arch/x86_64/struct.__m512d.html
 
 ## The `used` attribute
 
-The *`used` attribute* can only be applied to [`static` items]. This [attribute] forces the
-compiler to keep the variable in the output object file (.o, .rlib, etc. excluding final binaries)
-even if the variable is not used, or referenced, by any other item in the crate.
-However, the linker is still free to remove such an item.
 
-Below is an example that shows under what conditions the compiler keeps a `static` item in the
-output object file.
+r[abi.used]
+
+```abnf
+MetaItemUsed := "used"
+```
+
+r[abi.used.syntax]
+The *`used` attribute* may be specified as a built-in attribute, using the [_MetaWord_] syntax.
+
+r[abi.used.restriction]
+The `used` attribute shall only be applied to a `static` item. It shall not be applied to a `static` item declared within an [`extern` block].
+
+r[abi.used.application]
+A `static` item with the `used` attribute is an *exported item*. 
+
+> [!NOTE]
+> *exported items* will generally appear in the output when linking a library crate, and will generally be available when linking a binary crate as a global symbol.
+> The `used` attribute does not give the `static` item a *linkage name*, and thus does not disable name mangling. It may be used to place data into a given section that is referenced by the linker via the input section, without regard to the name of the symbol.
+> Due to toolchain limitations, it is not guaranteed that a `#[used]` static will appear in the final output when linking a binary, or when linking an rlib/staticlib crate into a `dylib` or `cdylib`. 
 
 ``` rust
 // foo.rs
@@ -57,20 +162,54 @@ $ nm -C foo.o
 0000000000000000 T foo::quux
 ```
 
-## The `no_mangle` attribute
+## Symbol naming 
 
-The *`no_mangle` attribute* may be used on any [item] to disable standard
-symbol name mangling. The symbol for the item will be the identifier of the
-item's name.
+r[abi.symbol-name]
 
-Additionally, the item will be publicly exported from the produced library or
-object file, similar to the [`used` attribute](#the-used-attribute).
+```abnf
+MetaItemNoMangle := "no_mangle"
+MetaItemExportName := "export_name" "=" ([STRING_LITERAL] | [RAW_STRING_LITERAL])
+```
+
+r[abi.symbol-name.names]
+The *`no_mangle` attribute* and the *`export_name` attribute* shall only be applied to a `static` or `fn` item. The *`export_name` attribute* shall not be applied to an item declared within an [`extern` block]. 
+
+> [!NOTE]
+> They may be applied to an associated `fn` of an `impl` block.
+
+r[abi.symbol-name.exported]
+An item with either the *`no_mangle` attrbute* or the *`export_name` attribute* is an *exported item*.
+
+r[abi.symbol-name.no_mangle]
+The *`no_mangle` attribute* may be specified as a built-in attribute, using the [_MetaWord_] syntax. The *export name* of an item with the *`no_mangle` attribute* is the declaration name of the item.
+
+r[abi.symbol-name.export_name]
+The *`export_name` attribute* may be specified as a built-in attribute, using the [_MetaNameValueStr_] syntax. The *export name* of an item with the *`no_mangle` attribute* is the content of `STRING_LITERAL`. 
+
+
 
 ## The `link_section` attribute
 
-The *`link_section` attribute* specifies the section of the object file that a
-[function] or [static]'s content will be placed into. It uses the
-[_MetaNameValueStr_] syntax to specify the section name.
+r[abi.link_section]
+
+```abnf
+MetaItemLinkSection := "link_section" "=" ([STRING_LITERAL] | [RAW_STRING_LITERAL])
+```
+
+r[abi.link_section.syntax]
+The *`link_section` attribute* may be specified as a built-in attribute, using the [_MetaNameValueStr_] syntax. 
+
+r[abi.link_section.restriction]
+The *`link_section` attribute* shall be aplied to a `static` or `fn` item.
+
+r[abi.link_section.def]
+An item with the *`link_section` attribute* is placed in the specified section when linking. The section specified shall not violate the constraints on section names on the target, and shall not be invalid for the item type, no diagnostic is required.
+
+> [!NOTE]
+> A section name may be invalid if it violates the requirements for the item type, for example, an `fn` item must be placed in an executable section, and a mutable static item (`static mut` or one containing an `UnsafeCell`) must be placed in a writable section.
+> The required format and any restrictions on section names are target-specific.
+>
+> The result of using an invalid section name may be that the section is placed into the section but cannot be used as applicable, or that the section is given additional attributes that may be incompatible when linking.
 
 <!-- no_run: don't link. The format of the section name is platform-specific. -->
 ```rust,no_run
@@ -79,22 +218,25 @@ The *`link_section` attribute* specifies the section of the object file that a
 pub static VAR1: u32 = 1;
 ```
 
-## The `export_name` attribute
+> [!TARGET-SPECIFIC]
+> On ELF Platforms, the standard section names, and their attributes are:
+> * `.text`: Readable and Executable,
+> * `.rodata`: Readable,
+> * `.data`: Readable and Writable,
+> * `.bss`: Readable and Writable - Uninitialized data,
+> * `.tdata`: Readable and Writable - Thread-local,
+> * `.tbss`: Readable and Writable - Uninitialized and Thread-local.
+> 
+> This is not an exhaustive list, and generally extended versions of these section names such as `.text.foo`, are also defined with the same properties as the base section.
+> 
+> 
 
-The *`export_name` attribute* specifies the name of the symbol that will be
-exported on a [function] or [static]. It uses the [_MetaNameValueStr_] syntax
-to specify the symbol name.
-
-```rust
-#[export_name = "exported_symbol_name"]
-pub fn name_in_rust() { }
-```
-
+[_MetaWord_]: attributes.md#meta-item-attribute-syntax
 [_MetaNameValueStr_]: attributes.md#meta-item-attribute-syntax
 [`static` items]: items/static-items.md
 [attribute]: attributes.md
 [extern functions]: items/functions.md#extern-function-qualifier
-[external blocks]: items/external-blocks.md
+[`extern` block]: items/external-blocks.md
 [function]: items/functions.md
 [item]: items.md
 [static]: items/static-items.md


### PR DESCRIPTION
This rewrites the `abi` chapter, and adds [call compatibility](https://doc.rust-lang.org/core/primitive.fn.html#abi-compatibility) to the chapter. 