### PR TITLE
Fix std-links for generics with commas.

### DIFF
--- a/mdbook-spec/src/std_links.rs
+++ b/mdbook-spec/src/std_links.rs
@@ -12,7 +12,7 @@ use tempfile::TempDir;
 /// the standard library using rustdoc's intra-doc notation.
 const STD_LINK: &str = r"(?: [a-z]+@ )?
                          (?: std|core|alloc|proc_macro|test )
-                         (?: ::[A-Za-z0-9_!:<>{}()\[\]]+ )?";
+                         (?: ::[A-Za-z0-9_!,:<>{}()\[\]]+ )?";
 
 /// The Regex for a markdown link that might be a link to the standard library.
 static STD_LINK_RE: Lazy<Regex> = Lazy::new(|| {


### PR DESCRIPTION
This fixes std links like `core::result::Result<T,S>` which contain commas.
