### PR TITLE
Add rust_2024 prelude

### DIFF
--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -26,6 +26,7 @@ Edition | `no_std` not applied        | `no_std` applied
 2015    | [`std::prelude::rust_2015`] | [`core::prelude::rust_2015`]
 2018    | [`std::prelude::rust_2018`] | [`core::prelude::rust_2018`]
 2021    | [`std::prelude::rust_2021`] | [`core::prelude::rust_2021`]
+2024    | [`std::prelude::rust_2024`] | [`core::prelude::rust_2024`]
 
 
 > **Note**:


### PR DESCRIPTION
Adds links for the 2024 edition prelude (https://github.com/rust-lang/rust/issues/121042).

Draft pending 2024 stabilization.