### PR TITLE
bytes inside implicitly const-promoted expressions are immutable

### DIFF
--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -49,7 +49,7 @@ Please read the [Rustonomicon] before writing unsafe code.
   All this also applies when values of these
   types are passed in a (nested) field of a compound type, but not behind
   pointer indirections.
-* Mutating immutable bytes. All bytes inside a [`const`] item are immutable.
+* Mutating immutable bytes. All bytes inside a [`const`] item or within an implicitly [const-promoted] expression are immutable.
   The bytes owned by an immutable binding or immutable `static` are immutable, unless those bytes are part of an [`UnsafeCell<U>`].
 
   Moreover, the bytes [pointed to] by a shared reference, including transitively through other references (both shared and mutable) and `Box`es, are immutable; transitivity includes those references stored in fields of compound types.
@@ -189,3 +189,4 @@ reading uninitialized memory is permitted are inside `union`s and in "padding"
 [project-field]: expressions/field-expr.md
 [project-tuple]: expressions/tuple-expr.md#tuple-indexing-expressions
 [project-slice]: expressions/array-expr.md#array-and-slice-indexing-expressions
+[const-promoted]: destructors.md#constant-promotion


### PR DESCRIPTION
This needs to be stated explicitly due to https://github.com/rust-lang/unsafe-code-guidelines/issues/493: with code like
```rust
let x: &'static Option<Cell<i32>> = &None;
```
it is currently UB to write to this memory, even though there is an `UnsafeCell`. This is because const-promotion notices that the *value* has no `UnsafeCell` and therefore places it in read-only global memory. However, our aliasing rules for interior mutability are likely not going to do such value-based reasoning, so we need to explicitly say that const-promotion is allowed to make things read-only here -- that's what this PR does.

Given that we have not yet said what exactly our aliasing model is, this could be considered a NOP for now. But it doesn't hurt to be explicit, and it seems likely that will eventually turn into a meaningful distinction.

Cc @rust-lang/opsem