### PR TITLE
Say that `pub(in path)` can't depend on `use` statements

### DIFF
--- a/src/visibility-and-privacy.md
+++ b/src/visibility-and-privacy.md
@@ -147,8 +147,9 @@ expressions, types, etc.
 In addition to public and private, Rust allows users to declare an item as
 visible only within a given scope. The rules for `pub` restrictions are as
 follows:
-- `pub(in path)` makes an item visible within the provided `path`. `path` must
-be an ancestor module of the item whose visibility is being declared.
+- `pub(in path)` makes an item visible within the provided `path`.
+  `path` must be a simple path which resolves to an ancestor module of the item whose visibility is being declared.
+  Each identifier in `path` must refer directly to a module (not to a name introduced by a `use` statement).
 - `pub(crate)` makes an item visible within the current crate.
 - `pub(super)` makes an item visible to the parent module. This is equivalent
   to `pub(in super)`.


### PR DESCRIPTION
Arbitrary path expressions aren't allowed here (in particular, the path can't rely on another `use` statement).
