### PR TITLE
2024: Add updates for unsafe extern blocks

### DIFF
--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -33,10 +33,11 @@ Calling functions or accessing statics that are declared in external blocks is o
 r[items.extern.namespace]
 The external block defines its functions and statics in the [value namespace] of the module or block where it is located.
 
-**Edition differences**: Starting in the 2024 edition, the `unsafe` keyword is
-required to appear before the `extern` keyword on external blocks. In previous
-editions, it is accepted but not required. The `safe` and `unsafe` item qualifiers
-are only allowed if the external block itself is marked as `unsafe`.
+r[items.extern.unsafe-required]
+The `unsafe` keyword is semantically required to appear before the `extern` keyword on external blocks.
+
+r[items.extern.edition2024]
+> **Edition differences**: Prior to the 2024 edition, the `unsafe` keyword is optional. The `safe` and `unsafe` item qualifiers are only allowed if the external block itself is marked as `unsafe`.
 
 ## Functions
 

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -5,7 +5,7 @@ r[items.extern]
 r[items.extern.syntax]
 > **<sup>Syntax</sup>**\
 > _ExternBlock_ :\
-> &nbsp;&nbsp; `unsafe`<sup>?</sup> `extern` [_Abi_]<sup>?</sup> `{`\
+> &nbsp;&nbsp; `unsafe`<sup>?</sup>[^unsafe-2024] `extern` [_Abi_]<sup>?</sup> `{`\
 > &nbsp;&nbsp; &nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>\
 > &nbsp;&nbsp; &nbsp;&nbsp; _ExternalItem_<sup>\*</sup>\
 > &nbsp;&nbsp; `}`
@@ -15,6 +15,8 @@ r[items.extern.syntax]
 > &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; [_MacroInvocationSemi_]\
 > &nbsp;&nbsp; &nbsp;&nbsp; | ( [_Visibility_]<sup>?</sup> ( [_StaticItem_] | [_Function_] ) )\
 > &nbsp;&nbsp; )
+>
+> [^unsafe-2024]: Starting with the 2024 Edition, the `unsafe` keyword is required semantically.
 
 r[items.extern.intro]
 External blocks provide _declarations_ of items that are not _defined_ in the
@@ -30,6 +32,11 @@ Calling functions or accessing statics that are declared in external blocks is o
 
 r[items.extern.namespace]
 The external block defines its functions and statics in the [value namespace] of the module or block where it is located.
+
+**Edition differences**: Starting in the 2024 edition, the `unsafe` keyword is
+required to appear before the `extern` keyword on external blocks. In previous
+editions, it is accepted but not required. The `safe` and `unsafe` item qualifiers
+are only allowed if the external block itself is marked as `unsafe`.
 
 ## Functions
 

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -11,7 +11,7 @@ r[items.fn.syntax]
 > &nbsp;&nbsp; &nbsp;&nbsp; ( [_BlockExpression_] | `;` )
 >
 > _FunctionQualifiers_ :\
-> &nbsp;&nbsp; `const`<sup>?</sup> `async`[^async-edition]<sup>?</sup> _ItemSafety_<sup>?</sup> (`extern` _Abi_<sup>?</sup>)<sup>?</sup>
+> &nbsp;&nbsp; `const`<sup>?</sup> `async`[^async-edition]<sup>?</sup> _ItemSafety_<sup>?</sup>[^extern-qualifiers] (`extern` _Abi_<sup>?</sup>)<sup>?</sup>
 >
 > _ItemSafety_ :\
 > &nbsp;&nbsp; `safe`[^extern-safe] | `unsafe`
@@ -47,6 +47,10 @@ r[items.fn.syntax]
 >
 > [^extern-safe]: The `safe` function qualifier is only allowed semantically within
 >   `extern` blocks.
+>
+> [^extern-qualifiers]: *Relevant to editions earlier than Rust 2024*: Within
+>   `extern` blocks, the `safe` or `unsafe` function qualifier is only allowed
+>   when the `extern` is qualified as `unsafe`.
 >
 > [^fn-param-2015]: Function parameters with only a type are only allowed
 >   in an associated function of a [trait item] in the 2015 edition.

--- a/src/unsafe-keyword.md
+++ b/src/unsafe-keyword.md
@@ -81,6 +81,8 @@ r[unsafe.extern]
 
 The programmer who declares an [external block] must assure that the signatures of the items contained within are correct. Failing to do so may lead to undefined behavior.  That this obligation has been met is indicated by writing `unsafe extern`.
 
+**Edition differences**: Prior to edition 2024, `extern` blocks were allowed without being qualified as `unsafe`.
+
 [external block]: items/external-blocks.md
 
 ## Unsafe attributes (`#[unsafe(attr)]`)

--- a/src/unsafe-keyword.md
+++ b/src/unsafe-keyword.md
@@ -81,7 +81,8 @@ r[unsafe.extern]
 
 The programmer who declares an [external block] must assure that the signatures of the items contained within are correct. Failing to do so may lead to undefined behavior.  That this obligation has been met is indicated by writing `unsafe extern`.
 
-**Edition differences**: Prior to edition 2024, `extern` blocks were allowed without being qualified as `unsafe`.
+r[unsafe.extern.edition2024]
+> **Edition differences**: Prior to edition 2024, `extern` blocks were allowed without being qualified as `unsafe`.
 
 [external block]: items/external-blocks.md
 

--- a/src/unsafety.md
+++ b/src/unsafety.md
@@ -26,10 +26,12 @@ r[safety.unsafe-impl]
 - Implementing an [unsafe trait].
 
 r[safety.unsafe-extern]
-- Declaring an [`extern`] block.
+- Declaring an [`extern`] block[^extern-2024].
 
 r[safety.unsafe-attribute]
 - Applying an [unsafe attribute] to an item.
+
+[^extern-2024]: Prior to the 2024 edition, extern blocks were allowed to be declared without `unsafe`.
 
 [`extern`]: items/external-blocks.md
 [`union`]: items/unions.md


### PR DESCRIPTION
This adds documentation for the edition differences for unsafe extern blocks in the 2024 edition. The main documentation was added in #1536, and this just adds what is now different in 2024.

Draft pending stabilization of the 2024 edition.
