### PR TITLE
const_eval: update for const-fn float stabilization

### DIFF
--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -63,7 +63,9 @@ A _const context_ is one of the following:
 
 Const contexts that are used as parts of types (array type and repeat length
 expressions as well as const generic arguments) can only make restricted use of
-surrounding generic type and lifetime parameters.
+surrounding generic parameters: such an expression must either be a single bare
+const generic parameter, or an arbitrary expression not making use of any
+generics.
 
 ## Const Functions
 

--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -61,39 +61,21 @@ A _const context_ is one of the following:
 * A [const generic argument]
 * A [const block]
 
+Const contexts that are used as parts of types (array type and repeat length
+expressions as well as const generic arguments) can only make restricted use of
+surrounding generic type and lifetime parameters.
+
 ## Const Functions
 
 A _const fn_ is a function that one is permitted to call from a const context. Declaring a function
 `const` has no effect on any existing uses, it only restricts the types that arguments and the
-return type may use, as well as prevent various expressions from being used within it. You can freely
-do anything with a const function that you can do with a regular function.
+return type may use, and restricts the function body to constant expressions.
 
 When called from a const context, the function is interpreted by the
 compiler at compile time. The interpretation happens in the
 environment of the compilation target and not the host. So `usize` is
 `32` bits if you are compiling against a `32` bit system, irrelevant
 of whether you are building on a `64` bit or a `32` bit system.
-
-Const functions have various restrictions to make sure that they can be
-evaluated at compile-time. It is, for example, not possible to write a random
-number generator as a const function. Calling a const function at compile-time
-will always yield the same result as calling it at runtime, even when called
-multiple times. There's one exception to this rule: if you are doing complex
-floating point operations in extreme situations, then you might get (very
-slightly) different results. It is advisable to not make array lengths and enum
-discriminants depend on floating point computations.
-
-
-Notable features that are allowed in const contexts but not in const functions include:
-
-* floating point operations
-  * floating point values are treated just like generic parameters without trait bounds beyond
-  `Copy`. So you cannot do anything with them but copy/move them around.
-
-Conversely, the following are possible in a const function, but not in a const context:
-
-* Use of generic type and lifetime parameters.
-  * Const contexts do allow limited use of [const generic parameters].
 
 [arithmetic]:           expressions/operator-expr.md#arithmetic-and-logical-binary-operators
 [array expressions]:    expressions/array-expr.md


### PR DESCRIPTION
Accompanying reference update for https://github.com/rust-lang/rust/pull/128596.

The float semantics RFC decided that this is *not* a guarantee we actually provide (and I am surprised to see that this was ever documented here, since we have [other plans](https://github.com/rust-lang/rust/issues/124625) that will make this even less true):

> Calling a const function at compile-time
will always yield the same result as calling it at runtime, even when called
multiple times.

Therefore, I removed this paragraph. I am not sure what its purpose was.

Also fixes https://github.com/rust-lang/reference/issues/1581.