### PR TITLE
operator expressions: add &raw

### DIFF
--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -102,7 +102,7 @@ the pointer that was dereferenced, *not* the type of the field that is being
 accessed.
 
 Note that a place based on a misaligned pointer only leads to undefined behavior
-when it is loaded from or stored to. `addr_of!`/`addr_of_mut!` on such a place
+when it is loaded from or stored to. `&raw const`/`&raw mut` on such a place
 is allowed. `&`/`&mut` on a place requires the alignment of the field type (or
 else the program would be "producing an invalid value"), which generally is a
 less restrictive requirement than being based on an aligned pointer. Taking a

--- a/src/expressions.md
+++ b/src/expressions.md
@@ -146,7 +146,7 @@ A *value expression* is an expression that represents an actual value.
 The following contexts are *place expression* contexts:
 
 * The left operand of a [compound assignment] expression.
-* The operand of a unary [borrow], [address-of][addr-of] or [dereference][deref] operator.
+* The operand of a unary [borrow], [raw borrow][raw-borrow] or [dereference][deref] operator.
 * The operand of a field expression.
 * The indexed operand of an array indexing expression.
 * The operand of any [implicit borrow].
@@ -276,7 +276,7 @@ They are never allowed before:
 
 [assign]:               expressions/operator-expr.md#assignment-expressions
 [borrow]:               expressions/operator-expr.md#borrow-operators
-[addr-of]:              expressions/operator-expr.md#raw-address-of-operators
+[raw-borrow]:           expressions/operator-expr.md#raw-borrow-operators
 [comparison]:           expressions/operator-expr.md#comparison-operators
 [compound assignment]:  expressions/operator-expr.md#compound-assignment-expressions
 [deref]:                expressions/operator-expr.md#the-dereference-operator

--- a/src/expressions.md
+++ b/src/expressions.md
@@ -146,7 +146,7 @@ A *value expression* is an expression that represents an actual value.
 The following contexts are *place expression* contexts:
 
 * The left operand of a [compound assignment] expression.
-* The operand of a unary [borrow], [raw borrow][raw-borrow] or [dereference][deref] operator.
+* The operand of a unary [borrow], [raw borrow] or [dereference][deref] operator.
 * The operand of a field expression.
 * The indexed operand of an array indexing expression.
 * The operand of any [implicit borrow].
@@ -276,7 +276,6 @@ They are never allowed before:
 
 [assign]:               expressions/operator-expr.md#assignment-expressions
 [borrow]:               expressions/operator-expr.md#borrow-operators
-[raw-borrow]:           expressions/operator-expr.md#raw-borrow-operators
 [comparison]:           expressions/operator-expr.md#comparison-operators
 [compound assignment]:  expressions/operator-expr.md#compound-assignment-expressions
 [deref]:                expressions/operator-expr.md#the-dereference-operator
@@ -294,6 +293,7 @@ They are never allowed before:
 [Mutable `static` items]: items/static-items.md#mutable-statics
 [scrutinee]:            glossary.md#scrutinee
 [promoted]:             destructors.md#constant-promotion
+[raw borrow]:           expressions/operator-expr.md#raw-borrow-operators
 [slice]:                types/slice.md
 [statement]:            statements.md
 [static variables]:     items/static-items.md

--- a/src/items/static-items.md
+++ b/src/items/static-items.md
@@ -117,7 +117,7 @@ unsafe fn bump_levels_unsafe() -> u32 {
 // must still guard against concurrent access.
 fn bump_levels_safe() -> u32 {
     unsafe {
-        return atomic_add(std::ptr::addr_of_mut!(LEVELS), 1);
+        return atomic_add(&raw mut LEVELS, 1);
     }
 }
 ```

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -575,9 +575,9 @@ was wrapped in a newtype `struct` with the same `align` modifier.
 > println!("{}", {e.f2});
 > // Or if you need a pointer, use the unaligned methods for reading and writing
 > // instead of dereferencing the pointer directly.
-> let ptr: *const u16 = std::ptr::addr_of!(e.f2);
+> let ptr: *const u16 = &raw const e.f2;
 > let value = unsafe { ptr.read_unaligned() };
-> let mut_ptr: *mut u16 = std::ptr::addr_of_mut!(e.f2);
+> let mut_ptr: *mut u16 = &raw mut e.f2;
 > unsafe { mut_ptr.write_unaligned(3) }
 > ```
 

--- a/src/types/pointer.md
+++ b/src/types/pointer.md
@@ -44,7 +44,7 @@ they exist to support interoperability with foreign code, and writing performanc
 When comparing raw pointers they are compared by their address, rather than by what they point to.
 When comparing raw pointers to [dynamically sized types] they also have their additional data compared.
 
-Raw pointers can be created directly using [`core::ptr::addr_of!`] for `*const` pointers and [`core::ptr::addr_of_mut!`] for `*mut` pointers.
+Raw pointers can be created directly using `&raw const` for `*const` pointers and `&raw mut` for `*mut` pointers.
 
 ## Smart Pointers
 


### PR DESCRIPTION
Accompanying PR for https://github.com/rust-lang/rust/pull/127679.
Fixes https://github.com/rust-lang/rust/issues/64490.

I reworded things to avoid the "address-of" terminology, since a pointer is not just an address.