### PR TITLE
const_eval: update for const_mut_refs and const_refs_to_cell stabilization

### DIFF
--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -41,7 +41,7 @@ to be run.
 * All forms of [borrow]s, including raw borrows, with one limitation:
   mutable borrows and shared borrows to values with interior mutability
   are only allowed to refer to *transient* places. A place is *transient*
-  if it will be deallocated before the end of evaluating the current constant item.
+  if its lifetime is strictly contained inside the current [const context].
 * The [dereference operator].
 * [Grouped] expressions.
 * [Cast] expressions, except
@@ -52,6 +52,7 @@ to be run.
 * [if], [`if let`] and [match] expressions.
 
 ## Const context
+[const context]: #const-context
 
 A _const context_ is one of the following:
 

--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -38,8 +38,11 @@ to be run.
 * [Closure expressions] which don't capture variables from the environment.
 * Built-in [negation], [arithmetic], [logical], [comparison] or [lazy boolean]
   operators used on integer and floating point types, `bool`, and `char`.
-* Shared [borrow]s, except if applied to a type with [interior mutability].
-* The [dereference operator] except for raw pointers.
+* All forms of [borrow]s, including raw borrows, with one limitation:
+  mutable borrows and shared borrows to values with interior mutability
+  are only allowed to refer to *transient* places. A place is *transient*
+  if it will be deallocated before the end of evaluating the current constant item.
+* The [dereference operator].
 * [Grouped] expressions.
 * [Cast] expressions, except
   * pointer to address casts and


### PR DESCRIPTION
This is the reference PR accompanying https://github.com/rust-lang/rust/pull/129195.

Fixes https://github.com/rust-lang/rust/issues/57349
Fixes https://github.com/rust-lang/rust/issues/80384