### PR TITLE
Add a description of rule identifiers

### DIFF
--- a/src/introduction.md
+++ b/src/introduction.md
@@ -120,6 +120,15 @@ These conventions are documented here.
 
   See [Notation] for more detail.
 
+* Rule identifiers appear before each language rule enclosed in square brackets. These identifiers provide a way to refer to a specific rule in the language. The rule identifier uses periods to separate sections from most general to most specific ([destructors.scope.nesting.function-body] for example).
+
+  The rule name can be clicked to link to that rule.
+
+r[example.rule.label]
+
+  > [!WARNING]
+  > The organization of the rules is currently in flux. For the time being, these identifier names are not stable between releases, and links to these rules may fail if they are changed. We intend to stabilize these once the organization has settled so that links to the rule names will not break between releases.
+
 ## Contributing
 
 We welcome contributions of all kinds.


### PR DESCRIPTION
This adds a description of the rule identifiers, along with a warning that these are not going to be stable in the short term. Once things have settled a bit, I think we can remove the warning.

Closes #1573
