### PR TITLE
stabilize `const_extern_fn`

### DIFF
--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -217,7 +217,7 @@ Functions qualified with the `const` keyword are [const functions], as are
 [tuple struct] and [tuple variant] constructors. _Const functions_  can be
 called from within [const contexts].
 
-Const functions may use the [`extern`] function qualifier, but only with the `"Rust"` and `"C"` ABIs.
+Const functions may use the [`extern`] function qualifier.
 
 Const functions are not allowed to be [async](#async-functions).
 


### PR DESCRIPTION
to stabilize https://github.com/rust-lang/rust/issues/64926.

This feels a little bare-bones, but I guess that is sort of what the spec is for: just factual statements.