### PR TITLE
`asm!`: clarify that `nomem` / `readonly` can access private memory

### DIFF
--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -505,12 +505,12 @@ r[asm.options.supported-options.pure]
   The `pure` option must be combined with either the `nomem` or `readonly` options, otherwise a compile-time error is emitted.
 
 r[asm.options.supported-options.nomem]
-- `nomem`: The `asm!` blocks does not read or write to any memory.
+- `nomem`: The `asm!` block does not read from or write to any memory accessible outside of the `asm!` block.
   This allows the compiler to cache the values of modified global variables in registers across the `asm!` block since it knows that they are not read or written to by the `asm!`.
   The compiler also assumes that this `asm!` block does not perform any kind of synchronization with other threads, e.g. via fences.
 
 r[asm.options.supported-options.readonly]
-- `readonly`: The `asm!` block does not write to any memory.
+- `readonly`: The `asm!` block does not write to any memory accessible outside of the `asm!` block.
   This allows the compiler to cache the values of unmodified global variables in registers across the `asm!` block since it knows that they are not written to by the `asm!`.
   The compiler also assumes that this `asm!` block does not perform any kind of synchronization with other threads, e.g. via fences.
 


### PR DESCRIPTION
As pointed out by @Freax13 in https://github.com/rust-lang/reference/issues/1350#issuecomment-2320193484, we already allow `asm!` blocks with `options(nomem)` or `options(readonly)` to read from or write to *private memory*, which I believe refers to memory that is allocated from within the `asm!` block and not accessible from the outside (and please correct me if I'm wrong on this):

https://github.com/rust-lang/reference/blob/c118ff6f99b2b2c9dd4fa2684715e6e06ff5bc7a/src/inline-assembly.md?plain=1#L577-L582

Since we already allow this, this PR also documents it on the `nomem` and `readonly` options directly, in addition to the documentation that can be found lower on the same page. No functional changes intended.

closes https://github.com/rust-lang/reference/issues/1350

r? @Amanieu

@rustbot label A-asm