### PR TITLE
dont use stdcall on x86_64 where it is not a valid ABI

### DIFF
--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -195,7 +195,7 @@ called from other programming languages like C:
 extern "C" fn new_i32() -> i32 { 0 }
 
 // Declares a function with the "stdcall" ABI
-# #[cfg(target_arch = "x86_64")]
+# #[cfg(any(windows, target_arch = "x86"))]
 extern "stdcall" fn new_i32_stdcall() -> i32 { 0 }
 ```
 


### PR DESCRIPTION
Unblocks https://github.com/rust-lang/rust/pull/129935