### PR TITLE
Places based on misaligned pointers: also mention 'static's as a possible base for place projections

### DIFF
--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -78,7 +78,7 @@ The span of bytes a pointer or reference "points to" is determined by the pointe
 A place is said to be "based on a misaligned pointer" if the last `*` projection
 during place computation was performed on a pointer that was not aligned for its
 type. (If there is no `*` projection in the place expression, then this is
-accessing the field of a local and rustc will guarantee proper alignment. If
+accessing the field of a local or `static` and rustc will guarantee proper alignment. If
 there are multiple `*` projection, then each of them incurs a load of the
 pointer-to-be-dereferenced itself from memory, and each of these loads is
 subject to the alignment constraint. Note that some `*` projections can be


### PR DESCRIPTION
In MIR, locals are the only place "roots" since statics get turned into `*PTR` where `PTR` is a constant pointer pointing to that static... but in the surface language, `STATIC.foo.bar` arguably has `STATIC` as its root and contains no `*`, so let's add that as a possible case here.