### PR TITLE
Fix improper documentation on casting non_exhaustive enums

### DIFF
--- a/src/attributes/type_system.md
+++ b/src/attributes/type_system.md
@@ -163,7 +163,7 @@ match message {
 }
 ```
 
-However, casting non-exhaustive types from foreign crates is generally disallowed, except when dealing with enums that have no non-exhaustive variants.
+It's also not allowed to use numeric casts (`as`) on enums that contain any non-exhaustive variants.
 
 For example, the following enum can be cast because it doesn't contain any non-exhaustive variants:
 ```rust, ignore

--- a/src/attributes/type_system.md
+++ b/src/attributes/type_system.md
@@ -163,7 +163,7 @@ match message {
 }
 ```
 
-In Rust, casting non-exhaustive types from foreign crates is generally disallowed, except when dealing with enums that have no non-exhaustive variants.
+However, casting non-exhaustive types from foreign crates is generally disallowed, except when dealing with enums that have no non-exhaustive variants.
 
 For example, the following enum can be cast because it doesn't contain any non-exhaustive variants:
 ```rust, ignore
@@ -186,10 +186,10 @@ pub enum Example {
 ```
 
 ```rust, ignore
-use othercrate::NonExhaustiveEnumVariants;
+use othercrate::EnumWithNonExhaustiveEnumVariants;
 
-// cannot cast an enum with a non-exhaustive variant when it's defined in another crate
-let _ = NonExhaustiveEnum::default() as u8;
+// Error: cannot cast an enum with a non-exhaustive variant when it's defined in another crate
+let _ = EnumWithNonExhaustiveEnumVariants::default() as u8;
 ```
 
 Non-exhaustive types are always considered inhabited in downstream crates.

--- a/src/attributes/type_system.md
+++ b/src/attributes/type_system.md
@@ -166,7 +166,8 @@ match message {
 It's also not allowed to use numeric casts (`as`) on enums that contain any non-exhaustive variants.
 
 For example, the following enum can be cast because it doesn't contain any non-exhaustive variants:
-```rust, ignore
+
+```rust
 #[non_exhaustive]
 pub enum Example {
     First,
@@ -176,20 +177,21 @@ pub enum Example {
 
 However, if the enum contains even a single non-exhaustive variant, casting will result in an error. Consider this modified version of the same enum:
 
-```rust, ignore
+```rust
 #[non_exhaustive]
-pub enum Example {
+pub enum EnumWithNonExhaustiveVariants {
     First,
     #[non_exhaustive]
     Second
 }
 ```
 
-```rust, ignore
-use othercrate::EnumWithNonExhaustiveEnumVariants;
+<!-- ignore: needs multiple crates -->
+```rust,ignore
+use othercrate::EnumWithNonExhaustiveVariants;
 
 // Error: cannot cast an enum with a non-exhaustive variant when it's defined in another crate
-let _ = EnumWithNonExhaustiveEnumVariants::default() as u8;
+let _ = EnumWithNonExhaustiveVariants::First as u8;
 ```
 
 Non-exhaustive types are always considered inhabited in downstream crates.

--- a/src/attributes/type_system.md
+++ b/src/attributes/type_system.md
@@ -163,11 +163,32 @@ match message {
 }
 ```
 
-It's also not allowed to cast non-exhaustive types from foreign crates.
-```rust, ignore
-use othercrate::NonExhaustiveEnum;
+In Rust, casting non-exhaustive types from foreign crates is generally disallowed, except when dealing with enums that have no non-exhaustive variants.
 
-// Cannot cast a non-exhaustive enum outside of its defining crate.
+For example, the following enum can be cast because it doesn't contain any non-exhaustive variants:
+```rust, ignore
+#[non_exhaustive]
+pub enum Example {
+    First,
+    Second
+}
+```
+
+However, if the enum contains even a single non-exhaustive variant, casting will result in an error. Consider this modified version of the same enum:
+
+```rust, ignore
+#[non_exhaustive]
+pub enum Example {
+    First,
+    #[non_exhaustive]
+    Second
+}
+```
+
+```rust, ignore
+use othercrate::NonExhaustiveEnumVariants;
+
+// cannot cast an enum with a non-exhaustive variant when it's defined in another crate
 let _ = NonExhaustiveEnum::default() as u8;
 ```
 


### PR DESCRIPTION
Added a more complete example that explains what is allowed and what's not allowed when the non_exhaustive attribute is in use.