### PR TITLE
`coverage` attribute

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -45,6 +45,7 @@
     - [Limits](attributes/limits.md)
     - [Type System](attributes/type_system.md)
     - [Debugger](attributes/debugger.md)
+    - [Coverage instrumentation](attributes/coverage-instrumentation.md)
 
 - [Statements and expressions](statements-and-expressions.md)
     - [Statements](statements.md)

--- a/src/attributes.md
+++ b/src/attributes.md
@@ -328,8 +328,9 @@ The following is an index of all built-in attributes.
 - Debugger
   - [`debugger_visualizer`] --- Embeds a file that specifies debugger output for a type.
   - [`collapse_debuginfo`] --- Controls how macro invocations are encoded in debuginfo.
+
 - Coverage Instrumentation
-  - [`coverage`] --- Controls how code coverage is instrumented
+  - [`coverage`] --- Controls how code coverage is instrumented.
 
 [Doc comments]: comments.md#doc-comments
 [ECMA-334]: https://www.ecma-international.org/publications-and-standards/standards/ecma-334/

--- a/src/attributes.md
+++ b/src/attributes.md
@@ -328,6 +328,8 @@ The following is an index of all built-in attributes.
 - Debugger
   - [`debugger_visualizer`] --- Embeds a file that specifies debugger output for a type.
   - [`collapse_debuginfo`] --- Controls how macro invocations are encoded in debuginfo.
+- Coverage Instrumentation
+  - [`coverage`] --- Controls how code coverage is instrumented
 
 [Doc comments]: comments.md#doc-comments
 [ECMA-334]: https://www.ecma-international.org/publications-and-standards/standards/ecma-334/
@@ -347,6 +349,7 @@ The following is an index of all built-in attributes.
 [`cfg`]: conditional-compilation.md#the-cfg-attribute
 [`cold`]: attributes/codegen.md#the-cold-attribute
 [`collapse_debuginfo`]: attributes/debugger.md#the-collapse_debuginfo-attribute
+[`coverage`]: attributes/coverage-instrumentation.md#the-coverage-attribute
 [`crate_name`]: crates-and-source-files.md#the-crate_name-attribute
 [`crate_type`]: linkage.md
 [`debugger_visualizer`]: attributes/debugger.md#the-debugger_visualizer-attribute

--- a/src/attributes/coverage-instrumentation.md
+++ b/src/attributes/coverage-instrumentation.md
@@ -4,13 +4,21 @@ The following [attributes] are used for controlling coverage instrumentation, wh
 
 ### The `coverage` attribute
 
-The *`coverage` [attribute]* indicates whether a function should instrument code coverage at all and show up in code coverage reports. It can only be controlled at the function level, but it can be applied to modules, `impl` blocks, or anything that can contain functions.
+r[attributes.coverage]
 
+r[attributes.coverage.intro]
+The *`coverage` [attribute]* indicates whether a function should instrument code coverage at all and show up in code coverage reports.
+
+r[attributes.coverage.allowed-positions]
+The `coverage` attribute can only be controlled at the function level, but it can be applied to modules, `impl` blocks, or anything that can contain functions.
+
+r[attributes.coverage.syntax]
 There are two ways to use the coverage attribute:
 
 * `#[coverage(off)]` indicates that all functions within an item, recursively, should not be instrumented, unless specified by another attribute.
 * `#[coverage(on)]` (the default) indicates that all functions within an item, recursively, *should* be instrumented, unless specified by another attribute.
 
+r[attributes.coverage.nesting]
 More-specific attributes always take priority over less-specific ones, e.g. if a crate is marked `#![coverage(off)]`, then functions inside that crate marked `#[coverage(on)]` will still have coverage.
 
 [attribute]: ../attributes.md

--- a/src/attributes/coverage-instrumentation.md
+++ b/src/attributes/coverage-instrumentation.md
@@ -1,25 +1,17 @@
 # Coverage instrumentation attributes
 
-The following [attributes] are used for controlling coverage instrumentation,
-which can be enabled with the `-C instrument-coverage` compiler flag.
+The following [attributes] are used for controlling coverage instrumentation, which can be enabled with the `-C instrument-coverage` compiler flag.
 
 ### The `coverage` attribute
 
-The *`coverage` [attribute]* indicates whether a function should instrument code
-coverage at all and show up in code coverage reports. It can only be controlled
-at the function level, but it can be applied to modules, `impl` blocks, or
-anything that can contain functions.
+The *`coverage` [attribute]* indicates whether a function should instrument code coverage at all and show up in code coverage reports. It can only be controlled at the function level, but it can be applied to modules, `impl` blocks, or anything that can contain functions.
 
 There are two ways to use the coverage attribute:
 
-* `#[coverage(off)]` indicates that all functions within an item, recursively,
-  should not be instrumented, unless specified by another attribute.
-* `#[coverage(on)]` (the default) indicates that all functions within an item,
-  recursively, *should* be instrumented, unless specified by another attribute.
+* `#[coverage(off)]` indicates that all functions within an item, recursively, should not be instrumented, unless specified by another attribute.
+* `#[coverage(on)]` (the default) indicates that all functions within an item, recursively, *should* be instrumented, unless specified by another attribute.
 
-More-specific attributes always take priority over less-specific ones, e.g.
-if a crate is marked `#![coverage(off)]`, then functions inside that crate
-marked `#[coverage(on)]` will still have coverage.
+More-specific attributes always take priority over less-specific ones, e.g. if a crate is marked `#![coverage(off)]`, then functions inside that crate marked `#[coverage(on)]` will still have coverage.
 
 [attribute]: ../attributes.md
 [attributes]: ../attributes.md

--- a/src/attributes/coverage-instrumentation.md
+++ b/src/attributes/coverage-instrumentation.md
@@ -13,14 +13,14 @@ r[attributes.coverage]
 r[attributes.coverage.intro]
 The *`coverage` [attribute]* indicates whether a function should instrument code coverage at all and show up in code coverage reports.
 
-r[attributes.coverage.allowed-positions]
-The `coverage` attribute can only be controlled at the function level, but it can be applied to modules, `impl` blocks, or anything that can contain functions.
-
 r[attributes.coverage.syntax]
 There are two ways to use the coverage attribute:
 
 * `#[coverage(off)]` indicates that all functions within an item, recursively, should not be instrumented, unless specified by another attribute.
 * `#[coverage(on)]` (the default) indicates that all functions within an item, recursively, *should* be instrumented, unless specified by another attribute.
+
+r[attributes.coverage.allowed-positions]
+The `coverage` attribute can only be controlled at the function level, but it can be applied to modules, `impl` blocks, or anything that can contain functions.
 
 r[attributes.coverage.nesting]
 More-specific attributes always take priority over less-specific ones, e.g. if a crate is marked `#![coverage(off)]`, then functions inside that crate marked `#[coverage(on)]` will still have coverage.

--- a/src/attributes/coverage-instrumentation.md
+++ b/src/attributes/coverage-instrumentation.md
@@ -11,10 +11,10 @@ The following [attributes] are used for controlling coverage instrumentation.
 r[attributes.coverage]
 
 r[attributes.coverage.intro]
-The *`coverage` [attribute]* indicates whether a function should instrument code coverage at all and show up in code coverage reports.
+The *`coverage` [attribute]* indicates whether a function should include instrumentation for code coverage and show up in code coverage reports.
 
 r[attributes.coverage.syntax]
-There are two ways to use the coverage attribute:
+The attribute uses the [_MetaListIdents_] syntax to specify its behavior:
 
 * `#[coverage(off)]` indicates that all functions within an item, recursively, should not be instrumented, unless specified by another attribute.
 * `#[coverage(on)]` (the default) indicates that all functions within an item, recursively, *should* be instrumented, unless specified by another attribute.
@@ -35,10 +35,25 @@ impl S {
 ```
 
 r[attributes.coverage.allowed-positions]
-The `coverage` attribute can only be controlled at the function level, but it can be applied to modules, `impl` blocks, or anything that can contain functions.
+The `coverage` attribute can only be controlled at the granularity of individual functions. It can be applied to [functions], [closures], [associated functions], [implementations], [modules], or [the crate root].
+
+It is an error to specify the attribute on a trait function without a body.
+
+r[attributes.coverage.trait-impl-inherit]
+When specified on a trait function, the attribute only applies to the default function body. Trait implementations do not inherit the setting from the trait definition.
+
+r[attributes.coverage.duplicates]
+It is an error to specify the `#[coverage]` attribute multiple times on the same item.
 
 r[attributes.coverage.nesting]
-More-specific attributes always take priority over less-specific ones, e.g. if a crate is marked `#![coverage(off)]`, then functions inside that crate marked `#[coverage(on)]` will still have coverage.
+Coverage attributes on more deeply nested items take priority over attributes at a higher nesting level. For example, if a crate is marked `#![coverage(off)]`, then functions inside that crate marked `#[coverage(on)]` will still have coverage.
 
+[_MetaListIdents_]: ../attributes.md#meta-item-attribute-syntax
+[associated functions]: ../items/associated-items.md#associated-functions-and-methods
 [attribute]: ../attributes.md
 [attributes]: ../attributes.md
+[closures]: ../expressions/closure-expr.md
+[functions]: ../items/functions.md
+[implementations]: ../items/implementations.md
+[modules]: ../items/modules.md
+[the crate root]: ../crates-and-source-files.md

--- a/src/attributes/coverage-instrumentation.md
+++ b/src/attributes/coverage-instrumentation.md
@@ -1,6 +1,10 @@
 # Coverage instrumentation attributes
 
-The following [attributes] are used for controlling coverage instrumentation, which can be enabled with the `-C instrument-coverage` compiler flag.
+The following [attributes] are used for controlling coverage instrumentation.
+
+> **Note**: Coverage instrumentation is controlled in `rustc` with the [`-C instrument-coverage`] compiler flag.
+
+[`-C instrument-coverage`]: ../../rustc/instrument-coverage.html
 
 ### The `coverage` attribute
 

--- a/src/attributes/coverage-instrumentation.md
+++ b/src/attributes/coverage-instrumentation.md
@@ -19,6 +19,21 @@ There are two ways to use the coverage attribute:
 * `#[coverage(off)]` indicates that all functions within an item, recursively, should not be instrumented, unless specified by another attribute.
 * `#[coverage(on)]` (the default) indicates that all functions within an item, recursively, *should* be instrumented, unless specified by another attribute.
 
+```rust
+#[coverage(off)]
+fn example() {}
+
+struct S;
+
+#[coverage(off)]
+impl S {
+    #[coverage(on)]
+    fn function_with_coverage() {}
+
+    fn function_without_coverage() {}
+}
+```
+
 r[attributes.coverage.allowed-positions]
 The `coverage` attribute can only be controlled at the function level, but it can be applied to modules, `impl` blocks, or anything that can contain functions.
 

--- a/src/attributes/coverage-instrumentation.md
+++ b/src/attributes/coverage-instrumentation.md
@@ -1,0 +1,25 @@
+# Coverage instrumentation attributes
+
+The following [attributes] are used for controlling coverage instrumentation,
+which can be enabled with the `-C instrument-coverage` compiler flag.
+
+### The `coverage` attribute
+
+The *`coverage` [attribute]* indicates whether a function should instrument code
+coverage at all and show up in code coverage reports. It can only be controlled
+at the function level, but it can be applied to modules, `impl` blocks, or
+anything that can contain functions.
+
+There are two ways to use the coverage attribute:
+
+* `#[coverage(off)]` indicates that all functions within an item, recursively,
+  should not be instrumented, unless specified by another attribute.
+* `#[coverage(on)]` (the default) indicates that all functions within an item,
+  recursively, *should* be instrumented, unless specified by another attribute.
+
+More-specific attributes always take priority over less-specific ones, e.g.
+if a crate is marked `#![coverage(off)]`, then functions inside that crate
+marked `#[coverage(on)]` will still have coverage.
+
+[attribute]: ../attributes.md
+[attributes]: ../attributes.md


### PR DESCRIPTION
Since rust-lang/rust#84605 passed FCP, this adds the `coverage` attribute to the reference. Coverage instrumentation isn't mentioned in the reference elsewhere, as most of that information lies in the `rustc` book, but it feels like it should at least go here.