### PR TITLE
Add three more WebAssembly features to the list of accepted ones

### DIFF
--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -284,6 +284,7 @@ Feature               | Implicitly Enables  | Description
 `simd128`             |                     | [WebAssembly simd proposal][simd128]
 `multivalue`          |                     | [WebAssembly multivalue proposal][multivalue]
 `reference-types`     |                     | [WebAssembly reference-types proposal][reference-types]
+`tail-call`           |                     | [WebAssembly tail-call proposal][tail-call]
 
 [bulk-memory]: https://github.com/WebAssembly/bulk-memory-operations
 [extended-const]: https://github.com/WebAssembly/extended-const
@@ -293,6 +294,7 @@ Feature               | Implicitly Enables  | Description
 [sign-ext]: https://github.com/WebAssembly/sign-extension-ops
 [simd128]: https://github.com/webassembly/simd
 [reference-types]: https://github.com/webassembly/reference-types
+[tail-call]: https://github.com/webassembly/tail-call
 [multivalue]: https://github.com/webassembly/multi-value
 
 ### Additional information

--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -282,6 +282,8 @@ Feature               | Implicitly Enables  | Description
 `relaxed-simd`        | `simd128`           | [WebAssembly relaxed simd proposal][relaxed-simd]
 `sign-ext`            |                     | [WebAssembly sign extension operators Proposal][sign-ext]
 `simd128`             |                     | [WebAssembly simd proposal][simd128]
+`multivalue`          |                     | [WebAssembly multivalue proposal][multivalue]
+`reference-types`     |                     | [WebAssembly reference-types proposal][reference-types]
 
 [bulk-memory]: https://github.com/WebAssembly/bulk-memory-operations
 [extended-const]: https://github.com/WebAssembly/extended-const
@@ -290,6 +292,8 @@ Feature               | Implicitly Enables  | Description
 [relaxed-simd]: https://github.com/WebAssembly/relaxed-simd
 [sign-ext]: https://github.com/WebAssembly/sign-extension-ops
 [simd128]: https://github.com/webassembly/simd
+[reference-types]: https://github.com/webassembly/reference-types
+[multivalue]: https://github.com/webassembly/multi-value
 
 ### Additional information
 


### PR DESCRIPTION
This is intended to be a sibling PR to rust-lang/rust#131080 to update the reference documentation for wasm supporting two more features.