### PR TITLE
Fix `pat` fragment specifier to be the "current" edition

### DIFF
--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -145,7 +145,7 @@ Valid fragment specifiers are:
   * `lifetime`: a [LIFETIME_TOKEN]
   * `literal`: matches `-`<sup>?</sup>[_LiteralExpression_]
   * `meta`: an [_Attr_], the contents of an attribute
-  * `pat`: at least any [_PatternNoTopAlt_], and possibly more depending on edition
+  * `pat`: a [_Pattern_] (see [macro.decl.meta.edition2021])
   * `pat_param`: a [_PatternNoTopAlt_]
   * `path`: a [_TypePath_] style path
   * `stmt`: a [_Statement_] without the trailing semicolon (except for item statements that require semicolons)


### PR DESCRIPTION
The main text of the reference is supposed to document the behavior of the current edition, with any edition differences relegated to the *Edition differences* section. This fixes the `pat` fragment specifier to document what the current behavior is, with a link to the edition section for readers to see that it has edition-specific behavior.