### PR TITLE
Fix inline-assembly documentation for LoongArch

### DIFF
--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -484,7 +484,7 @@ The following ABIs can be used with `clobber_abi`:
 | AArch64 | `"C"`, `"system"`, `"efiapi"` | `x[0-17]`, `x18`\*, `x30`, `v[0-31]`, `p[0-15]`, `ffr` |
 | ARM | `"C"`, `"system"`, `"efiapi"`, `"aapcs"` | `r[0-3]`, `r12`, `r14`, `s[0-15]`, `d[0-7]`, `d[16-31]` |
 | RISC-V | `"C"`, `"system"`, `"efiapi"` | `x1`, `x[5-7]`, `x[10-17]`, `x[28-31]`, `f[0-7]`, `f[10-17]`, `f[28-31]`, `v[0-31]` |
-| LoongArch | `"C"`, `"system"`, `"efiapi"` | `$r1`, `$r[4-20]`, `$f[0-23]` |
+| LoongArch | `"C"`, `"system"` | `$r1`, `$r[4-20]`, `$f[0-23]` |
 
 > Notes:
 > - On AArch64 `x18` only included in the clobber list if it is not considered as a reserved register on the target.


### PR DESCRIPTION
Currently, clobber_abi doc lists `"efiapi"` as a supported ABI of LoongArch:

https://github.com/rust-lang/reference/blob/e61a925ee051c75c0dd71035c8e4e6b3383a0f3d/src/inline-assembly.md#L487

But only `"C"` and `"system"` are actually supported: https://github.com/rust-lang/rust/blob/267cf8d3b20e98315c8e0ddf1d7020f60f664249/compiler/rustc_target/src/asm/mod.rs#L942

r? @Amanieu