### PR TITLE
Add preview artifacts in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,6 +98,34 @@ jobs:
       working-directory: ./mdbook-spec
       run: cargo fmt --check
 
+  preview:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Update rustup
+      run: rustup self update
+    - name: Install Rust
+      run: |
+        rustup set profile minimal
+        rustup toolchain install nightly
+        rustup default nightly
+    - name: Install mdbook
+      run: |
+        mkdir bin
+        curl -sSL https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
+        echo "$(pwd)/bin" >> $GITHUB_PATH
+    - name: Build the book
+      env:
+          SPEC_RELATIVE: 0
+      run: mdbook build --dest-dir dist/preview-${{ github.event.pull_request.number }}
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: preview-${{ github.event.pull_request.number }}
+        overwrite: true
+        path: dist
+
   # The success job is here to consolidate the total success/failure state of
   # all other jobs. This job is then included in the GitHub branch protection
   # rule which prevents merges unless all other jobs are passing. This makes
@@ -110,6 +138,7 @@ jobs:
       - code-tests
       - style-tests
       - mdbook-spec
+      # preview is explicitly excluded here since it doesn't run on merge
     runs-on: ubuntu-latest
     steps:
       - run: jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'


### PR DESCRIPTION
This adds a CI job which will generate a preview of the reference when a PR is posted/updated.

This does not yet offer a way to view it directly. I've been looking at various options for supporting that, but that might take a while to get that ready. This particular job is a requirement of that anyways, and since it provides a benefit now, I think it would be useful to add it.

This works by uploading to a GitHub Artifact. Artifacts persist for 90 days. You can download an artifact with:

`gh run download -R rust-lang/reference -n preview-1234`

where 1234 is the PR number. And then open `preview-1234/index.html` in your browser.

GitHub may or may not make this easier in the future (https://github.com/actions/upload-artifact/issues/14).
