### PR TITLE
Add restriction for cfg_attr with crate_type and crate_name

### DIFF
--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -339,6 +339,8 @@ fn bewitched() {}
 
 The `cfg_attr` attribute is allowed anywhere attributes are allowed.
 
+The [`crate_type`] and [`crate_name`] attributes cannot be used with `cfg_attr`.
+
 ### The `cfg` macro
 
 The built-in `cfg` macro takes in a single configuration predicate and evaluates
@@ -369,6 +371,8 @@ println!("I'm running on a {} machine!", machine_kind);
 [`cfg`]: #the-cfg-attribute
 [`cfg` macro]: #the-cfg-macro
 [`cfg_attr`]: #the-cfg_attr-attribute
+[`crate_name`]: crates-and-source-files.md#the-crate_name-attribute
+[`crate_type`]: linkage.md
 [`target_feature` attribute]: attributes/codegen.md#the-target_feature-attribute
 [attribute]: attributes.md
 [attributes]: attributes.md


### PR DESCRIPTION
This was recently added in in https://github.com/rust-lang/rust/pull/129670.

I was on the fence whether this should be documented in `cfg_attr` versus no the attributes themselves. I decided to go with the slightly easier route.
