### PR TITLE
trait bounds grammar: make `?` and `for<>` mutually exclusive

### DIFF
--- a/src/trait-bounds.md
+++ b/src/trait-bounds.md
@@ -8,10 +8,10 @@
 > &nbsp;&nbsp; &nbsp;&nbsp; _Lifetime_ | _TraitBound_ | _UseBound_
 >
 > _TraitBound_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `?`<sup>?</sup>
-> [_ForLifetimes_](#higher-ranked-trait-bounds)<sup>?</sup> [_TypePath_]\
-> &nbsp;&nbsp; | `(` `?`<sup>?</sup>
-> [_ForLifetimes_](#higher-ranked-trait-bounds)<sup>?</sup> [_TypePath_] `)`
+> &nbsp;&nbsp; &nbsp;&nbsp; ( `?` |
+> [_ForLifetimes_](#higher-ranked-trait-bounds) )<sup>?</sup> [_TypePath_]\
+> &nbsp;&nbsp; | `(` ( `?` |
+> [_ForLifetimes_](#higher-ranked-trait-bounds) )<sup>?</sup> [_TypePath_] `)`
 >
 > _LifetimeBounds_ :\
 > &nbsp;&nbsp; ( _Lifetime_ `+` )<sup>\*</sup> _Lifetime_<sup>?</sup>


### PR DESCRIPTION
After https://github.com/rust-lang/rust/pull/127054, the `T: ?Trait` and `T: for<...> Trait` syntax is mutually exclusive, and this code no longer compiles:

```rust
fn foo<T: ?for<> Sized>() {}
```

Update the reference to reflect that.

|before|after|
|:-:|:-:|
|![](https://github.com/user-attachments/assets/1f19a572-71e5-4ff7-89e6-41bf3c5dd005)|![](https://github.com/user-attachments/assets/67689802-4904-4a6b-b3dd-42acb1cf2f5c)|

r? @compiler-errors