### PR TITLE
2024: Add reserved syntax

### DIFF
--- a/src/tokens.md
+++ b/src/tokens.md
@@ -756,9 +756,24 @@ Similarly the `r`, `b`, `br`, `c`, and `cr` prefixes used in raw string literals
 > lexes!{match"..." {}}
 > ```
 
+## Reserved guards
+
+> **<sup>Lexer 2024+</sup>**\
+> RESERVED_GUARDED_STRING_LITERAL : `#`<sup>+</sup> [STRING_LITERAL]\
+> RESERVED_POUNDS : `#`<sup>2..</sup>
+
+The reserved guards are syntax reserved for future use, and will generate a compile error if used.
+
+The *reserved guarded string literal* is a token of one or more `U+0023` (`#`) immediately followed by a [STRING_LITERAL].
+
+The *reserved pounds* is a token of two or more `U+0023` (`#`).
+
+> **Edition differences**: Before the 2024 edition, reserved guards are accepted by the lexer and interpreted as multiple tokens. For example, the `#"foo"#` form is interpreted as three tokens. `##` is interpreted as two tokens.
+
 [Inferred types]: types/inferred.md
 [Range patterns]: patterns.md#range-patterns
 [Reference patterns]: patterns.md#reference-patterns
+[STRING_LITERAL]: tokens.md#string-literals
 [Subpattern binding]: patterns.md#identifier-patterns
 [Wildcard patterns]: patterns.md#wildcard-pattern
 [arith]: expressions/operator-expr.md#arithmetic-and-logical-binary-operators


### PR DESCRIPTION
This adds the the reserved syntax in 2024 added in https://github.com/rust-lang/rust/pull/123951 (tracking https://github.com/rust-lang/rust/issues/123735).
