### PR TITLE
Spec: Improve Definition of Type Layout

### DIFF
--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -76,6 +76,9 @@ In particular, `i128` and `u128` are often aligned to 4 or 8 bytes even though
 their size is 16, and on many 32-bit platforms, `i64`, `u64`, and `f64` are only
 aligned to 4 bytes, not 8.
 
+r[layout.primitive.align-char]
+The alignment of `char` is the same as the alignment of `u32`.
+
 ## Pointers and References Layout
 
 r[layout.pointer]


### PR DESCRIPTION
This improves the definition of Type Layout to be more formal. The following changes are made:
* The guarantees of repr(Rust) structs and unions are defined in a separate section, as they apply to all structs and unions, even when they have another representation.
* The layout of `repr(Rust)` enums is documented, with some permissions granted conservatively to implementations (like not including uninhabited variants in the size/alignment of the enum), pending approval either way. 
    * I'm not too attached to including these, but omitting them could be taken as a prohibition against them in the future.
 * Discriminant Elision (now guaranteed by https://github.com/rust-lang/rust/pull/130628) is documented. 
     * This is intended the supersede https://github.com/rust-lang/unsafe-code-guidelines/pull/538. 
 * The `repr(C)` layouts are consolidated, though the section on `struct`s is left presently. I'm not sure whether to get rid of it or replace it with a large note admonition, because it isn't needed as normative text, but the definition of `repr(C)` as applied to `struct`s can be confusing on its own. 

I think there's some more work to be done on the chapter, but I think this is a reasonable set of stuff to do in one PR, specifically targetted at the `repr` attribute. 