### PR TITLE
mdbook-spec: Fix Spec::new visibility

### DIFF
--- a/mdbook-spec/src/lib.rs
+++ b/mdbook-spec/src/lib.rs
@@ -57,7 +57,7 @@ pub struct Spec {
 }
 
 impl Spec {
-    fn new() -> Result<Spec> {
+    pub fn new() -> Result<Spec> {
         let deny_warnings = std::env::var("SPEC_DENY_WARNINGS").as_deref() == Ok("1");
         let rust_root = std::env::var_os("SPEC_RUST_ROOT").map(PathBuf::from);
         if deny_warnings && rust_root.is_none() {


### PR DESCRIPTION
In https://github.com/rust-lang/reference/pull/1646 I accidentally changed the visibility of `Spec::new`. It needs to be `pub` in order to work in the upstream integration.