### PR TITLE
Fix stdcall example broken by recent rustc change

### DIFF
--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -66,6 +66,7 @@ standard C ABI on the specific platform. Other ABIs may be specified using an
 `abi` string, as shown here:
 
 ```rust
+# #[cfg(any(windows, target_arch = "x86"))]
 // Interface to the Windows API
 unsafe extern "stdcall" { }
 ```

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -296,8 +296,8 @@ that symbol rather than having to look it up by name.
 > [!WARNING]
 > `link_ordinal` should only be used in cases where the ordinal of the symbol is known to be stable: if the ordinal of a symbol is not explicitly set when its containing binary is built then one will be automatically assigned to it, and that assigned ordinal may change between builds of the binary.
 
-<!-- ignore: Only works on x86 Windows -->
-```rust,ignore
+```rust
+# #[cfg(all(windows, target_arch = "x86"))]
 #[link(name = "exporter", kind = "raw-dylib")]
 unsafe extern "stdcall" {
     #[link_ordinal(15)]


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/129935 made `unsupported_calling_conventions` a hard-error, which in turn makes this test fail. This should fix toolstate.

Additionally, I took the opportunity to also remove an `ignore` on a test with the same issue. Note that this is subtly different in that it uses an `all` instead of `any` due to being a raw-dylib.
