### PR TITLE
Rename "object safe" to "dyn compatible"

### DIFF
--- a/src/glossary.md
+++ b/src/glossary.md
@@ -173,12 +173,14 @@ the hierarchy has its own collection of named entities.
 ### Nominal types
 
 Types that can be referred to by a path directly. Specifically [enums],
-[structs], [unions], and [trait objects].
+[structs], [unions], and [trait object types].
 
-### Object safe traits
+### Dyn-compatible traits
 
-[Traits] that can be used as [trait objects]. Only traits that follow specific
-[rules][object safety] are object safe.
+[Traits] that can be used in [trait object types] (`dyn Trait`).
+Only traits that follow specific [rules][dyn compatibility] are *dyn compatible*.
+
+These were formerly known as *object safe* traits.
 
 ### Path
 
@@ -293,6 +295,7 @@ example of an uninhabited type is the [never type] `!`, or an enum with no varia
 [attributes]: attributes.md
 [*entity*]: names.md
 [crate]: crates-and-source-files.md
+[dyn compatibility]: items/traits.md#dyn-compatibility
 [enums]: items/enumerations.md
 [fields]: expressions/field-expr.md
 [free item]: #free-item
@@ -315,12 +318,11 @@ example of an uninhabited type is the [never type] `!`, or an enum with no varia
 [*name*]: names.md
 [*namespace*]: names/namespaces.md
 [never type]: types/never.md
-[object safety]: items/traits.md#object-safety
 [*path*]: paths.md
 [Paths]: paths.md
 [*scope*]: names/scopes.md
 [structs]: items/structs.md
-[trait objects]: types/trait-object.md
+[trait object types]: types/trait-object.md
 [traits]: items/traits.md
 [turbofish test]: https://github.com/rust-lang/rust/blob/1.58.0/src/test/ui/parser/bastion-of-the-turbofish.rs
 [types of crates]: linkage.md
@@ -329,3 +331,17 @@ example of an uninhabited type is the [never type] `!`, or an enum with no varia
 [unions]: items/unions.md
 [variable bindings]: patterns.md
 [visibility rules]: visibility-and-privacy.md
+
+<script>
+(function() {
+    var fragments = {
+        "#object-safe-traits": "glossary.html#dyn-compatible-traits",
+    };
+    var target = fragments[window.location.hash];
+    if (target) {
+        var url = window.location.toString();
+        var base = url.substring(0, url.lastIndexOf('/'));
+        window.location.replace(base + "/" + target);
+    }
+})();
+</script>

--- a/src/items/traits.md
+++ b/src/items/traits.md
@@ -65,6 +65,7 @@ trait Seq<T> {
 }
 ```
 
+<a id="object-safety"></a>
 ## Dyn compatibility
 
 A dyn-compatible trait can be the base trait of a [trait object]. A trait is

--- a/src/items/traits.md
+++ b/src/items/traits.md
@@ -94,7 +94,6 @@ A dyn-compatible trait can be the base trait of a [trait object]. A trait is
         * Have a `where Self: Sized` bound (receiver type of `Self` (i.e. `self`) implies this).
 
 > **Note**: This concept was formerly known as *object safety*.
-> The original set of rules were defined in [RFC 255] and have since been extended.
 
 ```rust
 # use std::rc::Rc;
@@ -334,7 +333,6 @@ fn main() {
 [_WhereClause_]: generics.md#where-clauses
 [bounds]: ../trait-bounds.md
 [trait object]: ../types/trait-object.md
-[RFC 255]: https://github.com/rust-lang/rfcs/blob/master/text/0255-object-safety.md
 [associated items]: associated-items.md
 [method]: associated-items.md#methods
 [supertraits]: #supertraits

--- a/src/items/traits.md
+++ b/src/items/traits.md
@@ -93,8 +93,8 @@ A dyn-compatible trait can be the base trait of a [trait object]. A trait is
     * Explicitly non-dispatchable functions require:
         * Have a `where Self: Sized` bound (receiver type of `Self` (i.e. `self`) implies this).
 
-This concept was formerly known as *object safety*.
-The original set of rules was defined in [RFC 255] and has since been extended.
+> **Note**: This concept was formerly known as *object safety*.
+> The original set of rules were defined in [RFC 255] and have since been extended.
 
 ```rust
 # use std::rc::Rc;

--- a/src/type-coercions.md
+++ b/src/type-coercions.md
@@ -209,7 +209,7 @@ r[coerce.unsize.slice]
 * `[T; n]` to `[T]`.
 
 r[coerce.unsize.trait-object]
-* `T` to `dyn U`, when `T` implements `U + Sized`, and `U` is [object safe].
+* `T` to `dyn U`, when `T` implements `U + Sized`, and `U` is [dyn compatible].
 
 r[coerce.unsized.composite]
 * `Foo<..., T, ...>` to `Foo<..., U, ...>`, when:
@@ -322,7 +322,7 @@ precisely.
 [RFC 401]: https://github.com/rust-lang/rfcs/blob/master/text/0401-coercions.md
 [RFC 1558]: https://github.com/rust-lang/rfcs/blob/master/text/1558-closure-to-fn-coercion.md
 [subtype]: subtyping.md
-[object safe]: items/traits.md#object-safety
+[dyn compatible]: items/traits.md#dyn-compatibility
 [type cast operator]: expressions/operator-expr.md#type-cast-expressions
 [`Unsize`]: std::marker::Unsize
 [`CoerceUnsized`]: std::ops::CoerceUnsized

--- a/src/types/trait-object.md
+++ b/src/types/trait-object.md
@@ -12,7 +12,7 @@ r[type.trait-object.syntax]
 
 r[type.trait-object.intro]
 A *trait object* is an opaque value of another type that implements a set of
-traits. The set of traits is made up of an [object safe] *base trait* plus any
+traits. The set of traits is made up of a [dyn compatible] *base trait* plus any
 number of [auto traits].
 
 r[type.trait-object.impls]
@@ -116,6 +116,6 @@ inferred with a sensible choice.
 [_TypeParamBounds_]: ../trait-bounds.md
 [auto traits]: ../special-types-and-traits.md#auto-traits
 [defaults]: ../lifetime-elision.md#default-trait-object-lifetimes
+[dyn compatible]: ../items/traits.md#dyn-compatibility
 [dynamically sized types]: ../dynamically-sized-types.md
-[object safe]: ../items/traits.md#object-safety
 [supertraits]: ../items/traits.md#supertraits


### PR DESCRIPTION
Supersedes #1512: In line with [T-lang's latest resolution](https://github.com/rust-lang/lang-team/issues/286#issuecomment-2338905118).

Part of rust-lang/rust#130852.

r? @traviscross