### PR TITLE
Update some "default" representation references

### DIFF
--- a/src/items/enumerations.md
+++ b/src/items/enumerations.md
@@ -133,7 +133,7 @@ Each enum instance has a _discriminant_: an integer logically associated to it
 that is used to determine which variant it holds.
 
 r[items.enum.discriminant.repr-rust]
-Under the [default representation], the discriminant is interpreted as
+Under the [`Rust` representation], the discriminant is interpreted as
 an `isize` value. However, the compiler is allowed to use a smaller type (or
 another means of distinguishing variants) in its actual memory layout.
 
@@ -378,7 +378,6 @@ enum E {
 [`C` representation]: ../type-layout.md#the-c-representation
 [call expression]: ../expressions/call-expr.md
 [constant expression]: ../const_eval.md#constant-expressions
-[default representation]: ../type-layout.md#the-default-representation
 [enumerated type]: ../types/enum.md
 [Field-less enums]: #field-less-enum
 [IDENTIFIER]: ../identifiers.md
@@ -386,6 +385,7 @@ enum E {
 [numeric cast]: ../expressions/operator-expr.md#semantics
 [path expression]: ../expressions/path-expr.md
 [primitive representation]: ../type-layout.md#primitive-representations
+[`Rust` representation]: ../type-layout.md#the-rust-representation
 [struct expression]: ../expressions/struct-expr.md
 [struct]: structs.md
 [type namespace]: ../names/namespaces.md

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -204,7 +204,7 @@ struct AlignedStruct {
 r[layout.repr.inter-field]
 The representation of a type can change the padding between fields, but does
 not change the layout of the fields themselves. For example, a struct with a
-`C` representation that contains a struct `Inner` with the default
+`C` representation that contains a struct `Inner` with the `Rust`
 representation will not change the layout of `Inner`.
 
 <a id="the-default-representation"></a>

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -207,7 +207,8 @@ not change the layout of the fields themselves. For example, a struct with a
 `C` representation that contains a struct `Inner` with the default
 representation will not change the layout of `Inner`.
 
-### <a id="the-default-representation"></a> The `Rust` Representation
+<a id="the-default-representation"></a>
+### The `Rust` Representation
 
 r[layout.repr.rust]
 


### PR DESCRIPTION
This fixes the header link for "The Rust Representation". The `<a>` tag inside the header broke mdbook's automatic header linking (which allows you to click on a header).

Additionally, this updates some of the last references of the "default" representation and instead uses the term "Rust representation" to stay consistent with the rest of the text.