### PR TITLE
Update lifetimes for pre-expansion validation

### DIFF
--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -12,7 +12,7 @@ r[items.generics.syntax]
 > &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> ( _LifetimeParam_ | _TypeParam_ | _ConstParam_ )
 >
 > _LifetimeParam_ :\
-> &nbsp;&nbsp; [LIFETIME_OR_LABEL]&nbsp;( `:` [_LifetimeBounds_] )<sup>?</sup>
+> &nbsp;&nbsp; [_Lifetime_]&nbsp;( `:` [_LifetimeBounds_] )<sup>?</sup>
 >
 > _TypeParam_ :\
 > &nbsp;&nbsp; [IDENTIFIER]&nbsp;( `:` [_TypeParamBounds_]<sup>?</sup> )<sup>?</sup> ( `=` [_Type_] )<sup>?</sup>
@@ -54,8 +54,8 @@ r[items.generics.builtin-generic-types]
 [function pointers] have lifetime or type parameters as well, but are not
 referred to with path syntax.
 
-r[items.generics.wildcard-lifetime]
-`'_` is not a valid lifetime parameter.
+r[items.generics.invalid-lifetimes]
+`'_` and `'_static` are not valid lifetime parameters.
 
 ### Const generics
 
@@ -294,7 +294,6 @@ struct Foo<#[my_flexible_clone(unbounded)] H> {
 ```
 
 [IDENTIFIER]: ../identifiers.md
-[LIFETIME_OR_LABEL]: ../tokens.md#lifetimes-and-loop-labels
 
 [_ForLifetimes_]: ../trait-bounds.md#higher-ranked-trait-bounds
 [_LifetimeParam_]: #generic-parameters

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -762,8 +762,6 @@ r[lex.token.life.syntax]
 >
 > LIFETIME_OR_LABEL :\
 > &nbsp;&nbsp; &nbsp;&nbsp; `'` [NON_KEYWORD_IDENTIFIER][identifier]
->   _(not immediately followed by `'`)_\
-> &nbsp;&nbsp; | `'_`
 >   _(not immediately followed by `'`)_
 
 r[lex.token.life.intro]

--- a/src/trait-bounds.md
+++ b/src/trait-bounds.md
@@ -21,7 +21,8 @@ r[bound.syntax]
 >
 > _Lifetime_ :\
 > &nbsp;&nbsp; &nbsp;&nbsp; [LIFETIME_OR_LABEL]\
-> &nbsp;&nbsp; | `'static`
+> &nbsp;&nbsp; | `'static`\
+> &nbsp;&nbsp; | `'_`
 >
 > _UseBound_ :\
 > &nbsp;&nbsp; `use` _UseBoundGenericArgs_


### PR DESCRIPTION
This updates the lifetime grammar to accommodate https://github.com/rust-lang/rust/pull/126762 which switched to validating lifetimes pre-expansion. It also fixes a minor oversight where `'static` was always grammatically allowed in a lifetime generic parameter (but is rejected semantically).

In summary, since this is subtle: Labels no longer parse `'_` as valid. Thus, `'_` is removed from the LIFETIME_OR_LABEL token. Since `'_` is allowed by lifetimes, it has been moved to _Lifetime_.

Example:

```rust
// This is now an error in 1.81.
#[cfg(any())]
fn f() {
    '_: {
        break '_;
    }
}
```

and the oversight that was fixed (this was always allowed, but wasn't reflected in the reference grammar):

```rust
#[cfg(any())]
fn f<'static>() {}
```

cc @compiler-errors 
