### PR TITLE
trait object constraint correction

### DIFF
--- a/src/types/trait-object.md
+++ b/src/types/trait-object.md
@@ -24,7 +24,7 @@ Trait objects are written as the keyword `dyn` followed by a set of trait
 bounds, but with the following restrictions on the trait bounds.
 
 r[type.trait-object.constraint]
-All traits except one trait must be auto traits, there may not be more than one
+There may not be more than one non-auto trait, no more than one
 lifetime, and opt-out bounds (e.g. `?Sized`) are not allowed. Furthermore,
 paths to traits may be parenthesized.
 

--- a/src/types/trait-object.md
+++ b/src/types/trait-object.md
@@ -24,7 +24,7 @@ Trait objects are written as the keyword `dyn` followed by a set of trait
 bounds, but with the following restrictions on the trait bounds.
 
 r[type.trait-object.constraint]
-All traits except the first trait must be auto traits, there may not be more than one
+All traits except one trait must be auto traits, there may not be more than one
 lifetime, and opt-out bounds (e.g. `?Sized`) are not allowed. Furthermore,
 paths to traits may be parenthesized.
 


### PR DESCRIPTION
The non-auto trait does not have to be in the first position in a trait object, also mentioned [here](https://github.com/rust-lang/reference/pull/255#discussion_r170752509) and [here](https://github.com/rust-lang/reference/issues/392#issuecomment-614408780), 