### PR TITLE
Fix 2 typos

### DIFF
--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -238,7 +238,7 @@ on the endianness of the target's CPU.
 
 ### `target_pointer_width`
 
-r[cfg.target_poitner_width]
+r[cfg.target_pointer_width]
 
 r[cfg.target_pointer_width.general]
 Key-value option set once with the target's pointer width in bits.

--- a/src/macro-ambiguity.md
+++ b/src/macro-ambiguity.md
@@ -11,7 +11,7 @@ of this text is copied, and expanded upon in subsequent RFCs.
 r[macro.ambiguity.convention]
 
 r[macro.ambiguity.convention.defs]
-  - `macro`: anything invokable as `foo!(...)` in source code.
+  - `macro`: anything invocable as `foo!(...)` in source code.
   - `MBE`: macro-by-example, a macro defined by `macro_rules`.
   - `matcher`: the left-hand-side of a rule in a `macro_rules` invocation, or a
     subportion thereof.


### PR DESCRIPTION
Fix 2 typos.

If you're interested I can integrate  [typos](https://github.com/crate-ci/typos) and add it to CI to prevent these kinds of typos in the future.