### PR TITLE
Enable triagebot merge-conflict notifications

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -6,3 +6,8 @@ allow-unauthenticated = [
 [assign]
 
 [shortcut]
+
+[merge-conflicts]
+remove = []
+add = ["S-waiting-on-author"]
+unless = ["S-blocked", "S-waiting-on-team", "S-waiting-on-review"]


### PR DESCRIPTION
This adds merge conflict notifications added in https://github.com/rust-lang/triagebot/pull/1856.

(Unfortunately the next PR to merge after this will notify all existing PRs with merge conflicts, pointing to the wrong PR as the culprit. Hopefully that's not too confusing.)
