### PR TITLE
Claim to follow Unicode 16 for lexing identifiers.

### DIFF
--- a/src/identifiers.md
+++ b/src/identifiers.md
@@ -19,7 +19,7 @@ r[ident.syntax]
 
 <!-- When updating the version, update the UAX links, too. -->
 r[ident.unicode]
-Identifiers follow the specification in [Unicode Standard Annex #31][UAX31] for Unicode version 15.0, with the additions described below. Some examples of identifiers:
+Identifiers follow the specification in [Unicode Standard Annex #31][UAX31] for Unicode version 16.0, with the additions described below. Some examples of identifiers:
 
 * `foo`
 * `_identifier`
@@ -89,5 +89,5 @@ It is an error to use the RESERVED_RAW_IDENTIFIER token `r#_` in order to avoid 
 [proc-macro]: procedural-macros.md
 [reserved]: keywords.md#reserved-keywords
 [strict]: keywords.md#strict-keywords
-[UAX15]: https://www.unicode.org/reports/tr15/tr15-53.html
-[UAX31]: https://www.unicode.org/reports/tr31/tr31-37.html
+[UAX15]: https://www.unicode.org/reports/tr15/tr15-56.html
+[UAX31]: https://www.unicode.org/reports/tr31/tr31-41.html


### PR DESCRIPTION
This change happened in Rust 1.83.

As I understand it, rustc's behaviour here is determined by the versions of the `unicode-xid` and `unicode-normalization` crates it's built with.

These were updated to 0.2.6 and 0.1.24 respectively in
https://github.com/rust-lang/rust/pull/129624

Both of those versions update their character databases to Unicode 16.0.0.


I've checked that rustc 1.83 accepts the following (which rustc 1.82 doesn't):

````rust
let 𐗉 = "Todhri Letter Ei";
dbg!(𐗉);
````
