### PR TITLE
Add triagebot autolabel

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -11,3 +11,14 @@ allow-unauthenticated = [
 remove = []
 add = ["S-waiting-on-author"]
 unless = ["S-blocked", "S-waiting-on-team", "S-waiting-on-review"]
+
+[autolabel."S-waiting-on-review"]
+new_pr = true
+
+[review-submitted]
+reviewed_label = "S-waiting-on-author"
+review_labels = ["S-waiting-on-review"]
+
+[review-requested]
+remove_labels = ["S-waiting-on-author"]
+add_labels = ["S-waiting-on-review"]


### PR DESCRIPTION
This adds an autolabel of S-waiting-on-review for new PRs, with similar settings used in other rust-lang repos. The intent is to help make it clearer what the status of a PR is.

