### PR TITLE
Fix paragraphs with trailing `\1`

### DIFF
--- a/src/items/modules.md
+++ b/src/items/modules.md
@@ -17,7 +17,7 @@ A module is a container for zero or more [items].
 r[items.mod.def]
 A _module item_ is a module, surrounded in braces, named, and prefixed with the
 keyword `mod`. A module item introduces a new, named module into the tree of
-modules making up a crate\1
+modules making up a crate.
 
 r[items.mod.nesting]
 Modules can nest arbitrarily.

--- a/src/types/function-item.md
+++ b/src/types/function-item.md
@@ -4,7 +4,7 @@ r[type.fn-item]
 
 r[type.fn-item.intro]
 When referred to, a function item, or the constructor of a tuple-like struct or
-enum variant, yields a zero-sized value of its _function item type_\1
+enum variant, yields a zero-sized value of its _function item type_.
 
 r[type.fn-item.unique]
 That type explicitly identifies the function - its name, its type arguments, and its

--- a/src/types/impl-trait.md
+++ b/src/types/impl-trait.md
@@ -140,7 +140,7 @@ fn capture<'a, 'b, T>(x: &'a (), y: T) -> impl Sized + use<'a, T> {
 ```
 
 r[type.impl-trait.generic-capture.precise.constraint-single]
-Currently, only one `use<..>` bound may be present in a bounds list, such bounds are not allowed in the signature of items of a trait definition, all in-scope type and const generic parameters must be included, and all lifetime parameters that appear in other bounds of the abstract type must be included\1
+Currently, only one `use<..>` bound may be present in a bounds list, such bounds are not allowed in the signature of items of a trait definition, all in-scope type and const generic parameters must be included, and all lifetime parameters that appear in other bounds of the abstract type must be included.
 
 r[type.impl-trait.generic-capture.precise.constraint-lifetime]
 Within the `use<..>` bound, any lifetime parameters present must appear before all type and const generic parameters, and the elided lifetime (`'_`) may be present if it is otherwise allowed to appear within the `impl Trait` return type.

--- a/src/types/textual.md
+++ b/src/types/textual.md
@@ -11,7 +11,7 @@ not a surrogate), represented as a 32-bit unsigned word in the 0x0000 to 0xD7FF
 or 0xE000 to 0x10FFFF range.
 
 r[type.text.char-precondition]
-It is immediate [undefined behavior] to create \1
+It is immediate [undefined behavior] to create a
 `char` that falls outside this range. A `[char]` is effectively a UCS-4 / UTF-32
 string of length 1.
 


### PR DESCRIPTION
https://github.com/rust-lang/reference/pull/1618/commits/07e0394197e11ee7b8e1c018e0fb238b3d979616 seemed to have a mistake where it introduced `\1` replacing a trailing characters (presumably a search/replace error).