### PR TITLE
Fix rule auto-linking on Windows

### DIFF
--- a/mdbook-spec/src/lib.rs
+++ b/mdbook-spec/src/lib.rs
@@ -98,7 +98,9 @@ impl Spec {
             .iter()
             .map(|(rule_id, (_, path))| {
                 let relative = pathdiff::diff_paths(path, current_path).unwrap();
-                format!("[{rule_id}]: {}#r-{rule_id}\n", relative.display())
+                // Adjust paths for Windows.
+                let relative = relative.display().to_string().replace('\\', "/");
+                format!("[{rule_id}]: {}#r-{rule_id}\n", relative)
             })
             .collect();
         format!(


### PR DESCRIPTION
This fixes an issue when linking to other rules with a syntax like `way to an [async function][items.fn.async]` on Windows. The code that is generating these link references was using native system paths, and on Windows those have backslashes instead of forward slashes, which are needed for URLs.
