### PR TITLE
Mention that code coverage can change from release to release

### DIFF
--- a/src/attributes/coverage-instrumentation.md
+++ b/src/attributes/coverage-instrumentation.md
@@ -3,6 +3,7 @@
 The following [attributes] are used for controlling coverage instrumentation.
 
 > **Note**: Coverage instrumentation is controlled in `rustc` with the [`-C instrument-coverage`] compiler flag.
+Exact specifics of how code coverage works or what code is reported in code coverage data may change from release to release.
 
 [`-C instrument-coverage`]: ../../rustc/instrument-coverage.html
 


### PR DESCRIPTION
As noted in the `-C instrument coverage` documentation itself, the exact format of instrumentation that rustc uses will vary from release to release as LLVM makes changes to it and it is also expected that code coverage data or metrics may change slightly from one release to another due to changes in how rustc generates code, how LLVM interprets coverage data and how we improve the coverage feature.