### PR TITLE
modules: describe both module filename styles without giving a clear preference

### DIFF
--- a/src/items/modules.md
+++ b/src/items/modules.md
@@ -79,7 +79,7 @@ Module Path               | Filesystem Path  | File Contents
 `crate::util`             | `util.rs` *or* `util/mod.rs` | `mod config;`
 `crate::util::config`     | `util/config.rs` |
 
-> **Note**: Prior to `rustc` 1.30, using `mod.rs` files was the way to load
+> **Note**: Prior to `rustc` 1.30, using `mod.rs` files was the only way to load
 > a module with nested children.
 
 ### The `path` attribute

--- a/src/items/modules.md
+++ b/src/items/modules.md
@@ -80,7 +80,7 @@ Module Path               | Filesystem Path  | File Contents
 `crate::util::config`     | `util/config.rs` |
 
 > **Note**: Prior to `rustc` 1.30, using `mod.rs` files was the only way to load
-> a module with nested children.
+> a module with nested children. Rust 2018 added the new naming convention to be more consistent with modules that don't have submodules, and to avoid having many files named `mod.rs`.
 
 ### The `path` attribute
 

--- a/src/items/modules.md
+++ b/src/items/modules.md
@@ -65,27 +65,22 @@ not have a `path` attribute, the path to the file mirrors the logical [module
 path].
 
 r[items.mod.outlined.search]
-Ancestor module path components are directories, and the module's
-contents are in a file with the name of the module plus the `.rs` extension.
+Ancestor module path components are directories, and the module's contents are in a file with the
+name of the module plus the `.rs` extension. Alternatively, the module's contents can also be in a
+file called `mod.rs` in a directory with the name of the module. It is not allowed to have both
+`$name.rs` and `$name/mod.rs`.
+
 For example, the following module structure can have this corresponding
 filesystem structure:
 
 Module Path               | Filesystem Path  | File Contents
 ------------------------- | ---------------  | -------------
 `crate`                   | `lib.rs`         | `mod util;`
-`crate::util`             | `util.rs`        | `mod config;`
+`crate::util`             | `util.rs` *or* `util/mod.rs` | `mod config;`
 `crate::util::config`     | `util/config.rs` |
 
-r[items.mod.outlined.search-mod]
-Module filenames may also be the name of the module as a directory with the
-contents in a file named `mod.rs` within that directory. The above example can
-alternately be expressed with `crate::util`'s contents in a file named
-`util/mod.rs`. It is not allowed to have both `util.rs` and `util/mod.rs`.
-
 > **Note**: Prior to `rustc` 1.30, using `mod.rs` files was the way to load
-> a module with nested children. It is encouraged to use the new naming
-> convention as it is more consistent, and avoids having many files named
-> `mod.rs` within a project.
+> a module with nested children.
 
 ### The `path` attribute
 

--- a/src/items/modules.md
+++ b/src/items/modules.md
@@ -77,7 +77,7 @@ Module Path               | Filesystem Path  | File Contents
 ------------------------- | ---------------  | -------------
 `crate`                   | `lib.rs`         | `mod util;`
 `crate::util`             | `util.rs` *or* `util/mod.rs` | `mod config;`
-`crate::util::config`     | `util/config.rs` |
+`crate::util::config`     | `util/config.rs` *or* `util/config/mod.rs` |
 
 > **Note**: Prior to `rustc` 1.30, using `mod.rs` files was the only way to load
 > a module with nested children. Rust 2018 added the new naming convention to be more consistent with modules that don't have submodules, and to avoid having many files named `mod.rs`.


### PR DESCRIPTION
There's currently no clear consensus on which filename style to use for modules, and many people have a style tha mixes both options. So let's make the reference just describe the facts, without saying which variant is preferred.

Also see the [discussion on IRLO](https://internals.rust-lang.org/t/the-module-scheme-module-rs-file-module-folder-instead-of-just-module-mod-rs-introduced-by-the-2018-edition-maybe-a-little-bit-more-confusing/21977).