### PR TITLE
fix typo in a "rule" name in type-coercions.md

### DIFF
--- a/src/type-coercions.md
+++ b/src/type-coercions.md
@@ -7,7 +7,7 @@ r[coerce.intro]
 They happen automatically at specific locations and are highly restricted in
 what types actually coerce.
 
-r[cerce.as]
+r[coerce.as]
 Any conversions allowed by coercion can also be explicitly performed by the
 [type cast operator], `as`.
 


### PR DESCRIPTION
`r[cerce.as]` -> `r[coerce.as]`