### PR TITLE
Fix unclosed `<sup>` elements

### DIFF
--- a/src/identifiers.md
+++ b/src/identifiers.md
@@ -3,7 +3,7 @@
 r[ident]
 
 r[ident.syntax]
-> **<sup>Lexer:<sup>**\
+> **<sup>Lexer:</sup>**\
 > IDENTIFIER_OR_KEYWORD :\
 > &nbsp;&nbsp; &nbsp;&nbsp; XID_Start XID_Continue<sup>\*</sup>\
 > &nbsp;&nbsp; | `_` XID_Continue<sup>+</sup>

--- a/src/items.md
+++ b/src/items.md
@@ -3,7 +3,7 @@
 r[items]
 
 r[items.syntax]
-> **<sup>Syntax:<sup>**\
+> **<sup>Syntax:</sup>**\
 > _Item_:\
 > &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup>\
 > &nbsp;&nbsp; &nbsp;&nbsp; _VisItem_\

--- a/src/items/extern-crates.md
+++ b/src/items/extern-crates.md
@@ -3,7 +3,7 @@
 r[items.extern-crate]
 
 r[items.extern-crate.syntax]
-> **<sup>Syntax:<sup>**\
+> **<sup>Syntax:</sup>**\
 > _ExternCrate_ :\
 > &nbsp;&nbsp; `extern` `crate` _CrateRef_ _AsClause_<sup>?</sup> `;`
 >

--- a/src/visibility-and-privacy.md
+++ b/src/visibility-and-privacy.md
@@ -3,7 +3,7 @@
 r[vis]
 
 r[vis.syntax]
-> **<sup>Syntax<sup>**\
+> **<sup>Syntax</sup>**\
 > _Visibility_ :\
 > &nbsp;&nbsp; &nbsp;&nbsp; `pub`\
 > &nbsp;&nbsp; | `pub` `(` `crate` `)`\


### PR DESCRIPTION
Changes several instances of `<sup><sup>` (two unclosed `<sup>` elements) to `<sup></sup>` (one, properly closed `<sup>` element), matching the rest of the instances in the source e.g.: https://github.com/rust-lang/reference/blob/acd6794e712d5e2ef6f5c84fb95688d32a69b816/src/attributes.md?plain=1#L5