### PR TITLE
references and Box must be non-null

### DIFF
--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -214,7 +214,7 @@ r[undefined.validity.union]
   Further details are [still being debated](https://github.com/rust-lang/unsafe-code-guidelines/issues/438).
 
 r[undefined.validity.reference-box]
-* A reference or [`Box<T>`] must be aligned, it cannot be [dangling], and it must point to a valid value
+* A reference or [`Box<T>`] must be aligned and non-null, it cannot be [dangling], and it must point to a valid value
   (in case of dynamically sized types, using the actual dynamic type of the
   pointee as determined by the metadata).
   Note that the last point (about pointing to a valid value) remains a subject of some debate.


### PR DESCRIPTION
I screwed this up in https://github.com/rust-lang/reference/pull/1541... "non-null" used to be implied by "non-dangling", and then when we made the null ptr non-dangling for size 0 we forgot to update the other place where "dangling" was used. Oopsie.