### PR TITLE
Provide a better error message for broken links in mdbook-spec

### DIFF
--- a/mdbook-spec/src/lib.rs
+++ b/mdbook-spec/src/lib.rs
@@ -10,6 +10,7 @@ use once_cell::sync::Lazy;
 use regex::{Captures, Regex};
 use semver::{Version, VersionReq};
 use std::io;
+use std::ops::Range;
 use std::path::PathBuf;
 
 mod rules;
@@ -204,4 +205,18 @@ impl Preprocessor for Spec {
 
         Ok(book)
     }
+}
+
+fn line_from_range<'a>(contents: &'a str, range: &Range<usize>) -> &'a str {
+    assert!(range.start < contents.len());
+
+    let mut start_index = 0;
+    for line in contents.lines() {
+        let end_index = start_index + line.len();
+        if range.start >= start_index && range.start <= end_index {
+            return line;
+        }
+        start_index = end_index + 1;
+    }
+    panic!("did not find line {range:?} in contents");
 }


### PR DESCRIPTION
This improves the error message when there is a broken link. I was relying on `rustdoc::broken_intra_doc_links` to generate a good message, but that doesn't seem to fire if there is a space in the link text. Thus, if you have something like `[foo bar]` which doesn't have a definition, you would get a confusing error message that just spits out a meaningless byte range.
