### PR TITLE
Remove unstable vectorcall

### DIFF
--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -144,10 +144,6 @@ r[items.extern.abi.fastcall]
 * `unsafe extern "fastcall"` -- The `fastcall` ABI -- corresponds to MSVC's
   `__fastcall` and GCC and clang's `__attribute__((fastcall))`
 
-r[items.extern.abi.vectorcall]
-* `unsafe extern "vectorcall"` -- The `vectorcall` ABI -- corresponds to MSVC's
-  `__vectorcall` and clang's `__attribute__((vectorcall))`
-
 r[items.extern.abi.thiscall]
 * `unsafe extern "thiscall"` -- The default for C++ member functions on MSVC -- corresponds to MSVC's
   `__thiscall` and GCC and clang's `__attribute__((thiscall))`


### PR DESCRIPTION
This is currently unstable. cc tracking issue https://github.com/rust-lang/rust/issues/124485
Implementation: https://github.com/rust-lang/rust/blob/cd805f09ffbfa3896c8f50a619de9b67e1d9f3c3/compiler/rustc_abi/src/extern_abi/mod.rs#L214-L221