### PR TITLE
Change `'_static` to `'static` as an invalid lifetime parameter name

### DIFF
--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -54,7 +54,7 @@ r[items.generics.builtin-generic-types]
 referred to with path syntax.
 
 r[items.generics.invalid-lifetimes]
-`'_` and `'_static` are not valid lifetime parameters.
+`'_` and `'static` are not valid lifetime parameter names.
 
 r[items.generics.const]
 ### Const generics


### PR DESCRIPTION
I believe that `'static` is an invalid lifetime parameter name.
I've never head that `'_static` is also invalid, thus I suspect a typo here.