### PR TITLE
Exclude the test summary from the search index

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -10,6 +10,9 @@ git-repository-url = "https://github.com/rust-lang/reference/"
 edit-url-template = "https://github.com/rust-lang/reference/edit/master/{path}"
 smart-punctuation = true
 
+[output.html.search.chapter]
+"test-summary.md" = { enable = false }
+
 [output.html.redirect]
 "/expressions/enum-variant-expr.html" = "struct-expr.html"
 "/unsafe-blocks.html" = "unsafe-keyword.html"


### PR DESCRIPTION
This excludes the [test summary](https://doc.rust-lang.org/nightly/reference/test-summary.html) chapter from the search index. It ends up generating a lot of noise since that single page contains every rule and more.
