### PR TITLE
Doc: add concrete decimal numbers to min/max

### DIFF
--- a/src/types/numeric.md
+++ b/src/types/numeric.md
@@ -7,24 +7,24 @@ r[type.numeric.int]
 r[type.numeric.int.unsigned]
 The unsigned integer types consist of:
 
-Type   | Minimum | Maximum
--------|---------|-------------------
-`u8`   | 0       | 2<sup>8</sup>-1
-`u16`  | 0       | 2<sup>16</sup>-1
-`u32`  | 0       | 2<sup>32</sup>-1
-`u64`  | 0       | 2<sup>64</sup>-1
-`u128` | 0       | 2<sup>128</sup>-1
+Type   | Minimum | Maximum           | Maximum (decimal)
+-------|---------|-------------------|------------------------
+`u8`   | 0       | 2<sup>8</sup>-1   | 255
+`u16`  | 0       | 2<sup>16</sup>-1  | 65535
+`u32`  | 0       | 2<sup>32</sup>-1  | 4294967295
+`u64`  | 0       | 2<sup>64</sup>-1  | 18446744073709551615
+`u128` | 0       | 2<sup>128</sup>-1 | ≈ 3.4 x 10<sup>38</sup>
 
 r[type.numeric.int.signed]
 The signed two's complement integer types consist of:
 
-Type   | Minimum            | Maximum
--------|--------------------|-------------------
-`i8`   | -(2<sup>7</sup>)   | 2<sup>7</sup>-1
-`i16`  | -(2<sup>15</sup>)  | 2<sup>15</sup>-1
-`i32`  | -(2<sup>31</sup>)  | 2<sup>31</sup>-1
-`i64`  | -(2<sup>63</sup>)  | 2<sup>63</sup>-1
-`i128` | -(2<sup>127</sup>) | 2<sup>127</sup>-1
+Type   | Minimum            | Maximum           | Decimal
+-------|--------------------|-------------------|----------------------------------------------------
+`i8`   | -(2<sup>7</sup>)   | 2<sup>7</sup>-1   | \[-128..127]
+`i16`  | -(2<sup>15</sup>)  | 2<sup>15</sup>-1  | \[-32768..32767]
+`i32`  | -(2<sup>31</sup>)  | 2<sup>31</sup>-1  | \[-2147483648..2147483647]
+`i64`  | -(2<sup>63</sup>)  | 2<sup>63</sup>-1  | \[-9223372036854775808..9223372036854775807]
+`i128` | -(2<sup>127</sup>) | 2<sup>127</sup>-1 | \[≈ -1.7 x 10<sup>38</sup>..≈1.7 x 10<sup>38</sup>]
 
 
 r[type.numeric.float]


### PR DESCRIPTION
We cannot expect people to know the exact number by heart.

Adds the concrete decimal number to improve usefulness.