### PR TITLE
fixup `»` insertion for rules

### DIFF
--- a/theme/reference.css
+++ b/theme/reference.css
@@ -306,7 +306,7 @@ main > .rule {
    navigate to it. This adds an indicator that the linked rule is the one that
    is "current", just like normal headers are in mdbook.
 */
-.rule:target a span::before {
+.rule:target a::before {
     display: inline-block;
     content: "»";
     padding-right: 5px;


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/35cdc69b-f216-4d42-a9c8-088faaf96576)

After:
![image](https://github.com/user-attachments/assets/8a93c1e7-ac32-499a-b143-333fc811a227)

(fixes an oversight from #1710)