### PR TITLE
Switch from AVX to SSE in the example

### DIFF
--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -97,30 +97,30 @@ The following restrictions apply unless otherwise specified by the platform rule
 Implicitly enabled features are included in this rule. For example an `sse2` function can call ones marked with `sse`.
 
 ```rust
-# #[cfg(target_feature = "avx2")] {
-#[target_feature(enable = "avx")]
-fn foo_avx() {}
+# #[cfg(target_feature = "sse2")] {
+#[target_feature(enable = "sse")]
+fn foo_sse() {}
 
 fn bar() {
-    // Calling `foo_avx` here is unsafe, as we must ensure that AVX is
-    // available first, even if `avx` is enabled by default on the target
+    // Calling `foo_sse` here is unsafe, as we must ensure that SSE is
+    // available first, even if `sse` is enabled by default on the target
     // platform or manually enabled as compiler flags.
     unsafe {
-        foo_avx();
+        foo_sse();
     }
 }
 
-#[target_feature(enable = "avx")]
-fn bar_avx() {
-    // Calling `foo_avx` here is safe.
-    foo_avx();
-    || foo_avx();
+#[target_feature(enable = "sse")]
+fn bar_sse() {
+    // Calling `foo_sse` here is safe.
+    foo_sse();
+    || foo_sse();
 }
 
-#[target_feature(enable = "avx2")]
-fn bar_avx2() {
-    // Calling `foo_avx` here is safe because `avx2` implies `avx`.
-    foo_avx();
+#[target_feature(enable = "sse2")]
+fn bar_sse2() {
+    // Calling `foo_sse` here is safe because `sse2` implies `sse`.
+    foo_sse();
 }
 # }
 ```


### PR DESCRIPTION
I realized a few seconds too late after merging https://github.com/rust-lang/reference/pull/1720 that AVX will never get tested in CI because that is not part of the default `x86-64` CPU. SSE/SSE2 however should be.
