### PR TITLE
Remove attributes from struct field rest patterns

### DIFF
--- a/src/patterns.md
+++ b/src/patterns.md
@@ -713,7 +713,6 @@ r[patterns.struct.syntax]
 > &nbsp;&nbsp; )
 >
 > _StructPatternEtCetera_ :\
-> &nbsp;&nbsp; [_OuterAttribute_] <sup>\*</sup>\
 > &nbsp;&nbsp; `..`
 
 [_OuterAttribute_]: attributes.md


### PR DESCRIPTION
rustc never properly supported attributes in this position so this just removes them entirely.

See rustc change at: rust-lang/rust#136490

I could inline the `StructPatternEtCetera` but it felt slightly more consistent with the rest of the document to leave it separate.
I don't think there are any other changes required here as these attributes don't appear to be mentioned anywhere in the text.