### PR TITLE
Closures: fix example of desugaring

### DIFF
--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -54,9 +54,7 @@ so that the call to `f` works as if it were:
 
 <!-- ignore: continuation of above -->
 ```rust,ignore
-// Note: This is not valid Rust due to the duplicate mutable borrows.
-// This is only provided as an illustration.
-f(Closure{ left_top: &mut rect.left_top, right_bottom_x: &mut rect.left_top.x });
+f(Closure{ left_top: &mut rect.left_top, right_bottom_x: &mut rect.right_bottom.x });
 ```
 
 r[type.closure.capture]


### PR DESCRIPTION
Passing `left_top.x` into `right_bottom_x`. This invalidates the comment being made. In fact, the closure lowering doesn't have any special borrow checking rules that would allow it to have two overlapping mutable borrows.