### PR TITLE
fix: no equivalence between never type and zero-variant enum.

### DIFF
--- a/src/items/enumerations.md
+++ b/src/items/enumerations.md
@@ -320,8 +320,8 @@ enum ZeroVariants {}
 ```
 
 r[items.enum.empty.uninhabited]
-Zero-variant enums are equivalent to the [never type], but they cannot be
-coerced into other types.
+Only the [never type] can be coerced into zero-variant enums. Conversely, 
+zero-variant enums cannot be coerced into any other type.
 
 ```rust,compile_fail
 # enum ZeroVariants {}

--- a/src/items/enumerations.md
+++ b/src/items/enumerations.md
@@ -320,7 +320,7 @@ enum ZeroVariants {}
 ```
 
 r[items.enum.empty.uninhabited]
-Only the [never type] can be coerced into zero-variant enums. Conversely, 
+Only the [never type] can be coerced into zero-variant enums. Conversely,
 zero-variant enums cannot be coerced into any other type.
 
 ```rust,compile_fail


### PR DESCRIPTION
Zero-variant enums and the never type are not equivalent. 

None of them can be instantiated since they have no possible values, but:
  1. Only the !  type can be coerced into any other type. (this by itself already invalidate any claims of equivalence)
  2. The ! type has a very well defined use case and semantical meaning in the language itself: represent the result of computations that never complete. At best, Zero-variant enums can have user-defined semantical meaning inside a program when implemented by the developer which, if it's a sound implementation, will be closely related to it's defining property: "a type that has no possible values".