### PR TITLE
Fix diagnostics typo: `do_no_recommend` -> `do_not_recommend`

### DIFF
--- a/src/attributes/diagnostics.md
+++ b/src/attributes/diagnostics.md
@@ -662,7 +662,7 @@ error[E0277]: the trait bound `&str: AsExpression<Integer>` is not satisfied
    = help: for that trait implementation, expected `Text`, found `Integer`
 ```
 
-The first error message includes a somewhat confusing error message about the relationship of `&str` and `Expression`, as well as the unsatisfied trait bound in the blanket impl. After adding `#[diagnostic::do_no_recommend]`, it no longer considers the blanket impl for the recommendation. The message should be a little clearer, with an indication that a string cannot be converted to an `Integer`.
+The first error message includes a somewhat confusing error message about the relationship of `&str` and `Expression`, as well as the unsatisfied trait bound in the blanket impl. After adding `#[diagnostic::do_not_recommend]`, it no longer considers the blanket impl for the recommendation. The message should be a little clearer, with an indication that a string cannot be converted to an `Integer`.
 
 [Clippy]: https://github.com/rust-lang/rust-clippy
 [_MetaListNameValueStr_]: ../attributes.md#meta-item-attribute-syntax


### PR DESCRIPTION
Noticed this while reading the diagnostics documentation and wanted to send in a quick fix.