### PR TITLE
 Modify mutable deref rule for `&mut T`

### DIFF
--- a/src/expressions.md
+++ b/src/expressions.md
@@ -241,7 +241,7 @@ The following expressions can be mutable place expression contexts:
 * [Temporary values].
 * [Fields][field]: this evaluates the subexpression in a mutable place expression context.
 * [Dereferences][deref] of a `*mut T` pointer.
-* Dereference of a variable, or field of a variable, with type `&mut T`.
+* Dereference of a movable place, with type `&mut T`. This includes variables and their fields, as well as temporaries.
   Note: This is an exception to the requirement of the next rule.
 * Dereferences of a type that implements `DerefMut`:
   this then requires that the value being dereferenced is evaluated in a mutable place expression context.


### PR DESCRIPTION
This indicates that any movable place expression  of type `&mut T` can be dereferenced to yield a mutable place. 
Presently the rule only lists variables and fields of variables. However, if a `&mut T` is contained within a movable `Box`, it is also valid to deref the `&mut T` and use the resulting place mutably, even if the `Box` was immutable. See the following playgrounds:
* <https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=4af671f33e513f042e1639f8170d50a6>: Demonstrates that it is possible to deref a `Box` variable 
* <https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=4af671f33e513f042e1639f8170d50a6>: Demonstrates that derefing an immutable `Box` variable (correctly) does not yield a mutable place.