### PR TITLE
Mention that “every address” ≠ “every pointer”

### DIFF
--- a/src/types/numeric.md
+++ b/src/types/numeric.md
@@ -63,4 +63,4 @@ r[type.numeric.validity]
 For every numeric type, `T`, the bit validity of `T` is equivalent to the bit
 validity of `[u8; size_of::<T>()]`. An uninitialized byte is not a valid `u8`.
 
-[type cast expressions]: ../expressions/operator-expr.html#type-cast-expressions
+[type cast expressions]: ../expressions/operator-expr.md#type-cast-expressions

--- a/src/types/numeric.md
+++ b/src/types/numeric.md
@@ -40,6 +40,10 @@ r[type.numeric.int.size.usize]
 The `usize` type is an unsigned integer type with the same number of bits as the
 platform's pointer type. It can represent every memory address in the process.
 
+> [!NOTE]
+> While a `usize` can represent every *address*, converting a *pointer* to a `usize` is not necessarily a reversible operation.
+> For more information, see the documentation for [type cast expressions] and [`std::ptr`].
+
 r[type.numeric.int.size.isize]
 The `isize` type is a signed integer type with the same number of bits as the
 platform's pointer type. The theoretical upper bound on object and array size
@@ -58,3 +62,5 @@ r[type.numeric.validity]
 
 For every numeric type, `T`, the bit validity of `T` is equivalent to the bit
 validity of `[u8; size_of::<T>()]`. An uninitialized byte is not a valid `u8`.
+
+[type cast expressions]: ../expressions/operator-expr.html#type-cast-expressions

--- a/src/types/numeric.md
+++ b/src/types/numeric.md
@@ -42,7 +42,7 @@ platform's pointer type. It can represent every memory address in the process.
 
 > [!NOTE]
 > While a `usize` can represent every *address*, converting a *pointer* to a `usize` is not necessarily a reversible operation.
-> For more information, see the documentation for [type cast expressions] and [`std::ptr`].
+> For more information, see the documentation for [type cast expressions], [`std::ptr`], and [provenance][std::ptr#provenance] in particular.
 
 r[type.numeric.int.size.isize]
 The `isize` type is a signed integer type with the same number of bits as the


### PR DESCRIPTION
This adds a note in case people are tempted to interpret “`usize` ... can represent every memory address” as saying that pointer→usize→pointer roundtrips are definitely okay. Since the reference does not yet discuss provenance and that’s a much larger matter, I have merely linked to relevant existing documentation inside and outside the reference.