### PR TITLE
Use `cfg(false)` instead of `cfg(FALSE)`

### DIFF
--- a/src/items/enumerations.md
+++ b/src/items/enumerations.md
@@ -345,7 +345,7 @@ macro_rules! mac_variant {
 mac_variant! { E }
 
 // This is allowed, since it is removed before being validated.
-#[cfg(FALSE)]
+#[cfg(false)]
 enum E {
     pub U,
     pub(crate) T(u8),

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -612,7 +612,7 @@ Note that `-1i8`, for example, is analyzed as two tokens: `-` followed by `1i8`.
 Examples of integer literals which are not accepted as literal expressions:
 
 ```rust
-# #[cfg(FALSE)] {
+# #[cfg(false)] {
 0invalidSuffix;
 123AFB43;
 0b010a;
@@ -697,7 +697,7 @@ Note that `-1.0`, for example, is analyzed as two tokens: `-` followed by `1.0`.
 Examples of floating-point literals which are not accepted as literal expressions:
 
 ```rust
-# #[cfg(FALSE)] {
+# #[cfg(false)] {
 2.0f80;
 2e5f80;
 2e5e6;


### PR DESCRIPTION
Split out of https://github.com/rust-lang/reference/pull/1762 so that that PR
doesn't depend on a version of Rust that has `cfg(false)` implemented.
