### PR TITLE
Tweak reference for precise capturing in traits

### DIFF
--- a/src/types/impl-trait.md
+++ b/src/types/impl-trait.md
@@ -132,13 +132,16 @@ fn capture<'a, 'b, T>(x: &'a (), y: T) -> impl Sized + use<'a, T> {
 ```
 
 r[type.impl-trait.generic-capture.precise.constraint-single]
-Currently, only one `use<..>` bound may be present in a bounds list, such bounds are not allowed in the signature of items of a trait definition, all in-scope type and const generic parameters must be included, and all lifetime parameters that appear in other bounds of the abstract type must be included.
+Currently, only one `use<..>` bound may be present in a bounds list, all in-scope type and const generic parameters must be included, and all lifetime parameters that appear in other bounds of the abstract type must be included.
 
 r[type.impl-trait.generic-capture.precise.constraint-lifetime]
 Within the `use<..>` bound, any lifetime parameters present must appear before all type and const generic parameters, and the elided lifetime (`'_`) may be present if it is otherwise allowed to appear within the `impl Trait` return type.
 
 r[type.impl-trait.generic-capture.precise.constraint-param-impl-trait]
 Because all in-scope type parameters must be included by name, a `use<..>` bound may not be used in the signature of items that use argument-position `impl Trait`, as those items have anonymous type parameters in scope.
+
+r[type.impl-trait.generic-capture.precise.constraint-in-trait]
+Any `use<..>` bound that is present in an associated function in a trait definition must include all generic parameters of the trait, including the implicit `Self` generic type parameter of the trait.
 
 ## Differences between generics and `impl Trait` in return position
 


### PR DESCRIPTION
* Remove restriction for `use<..>` in trait items
* Mention that all generics including `Self` must be captured

cc https://github.com/rust-lang/rust/pull/138128#issuecomment-2748169854