### PR TITLE
Update tools to Rust 2024

### DIFF
--- a/mdbook-spec/Cargo.toml
+++ b/mdbook-spec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mdbook-spec"
 version = "0.1.2"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "An mdBook preprocessor to help with the Rust specification."
 repository = "https://github.com/rust-lang/spec/"

--- a/mdbook-spec/src/lib.rs
+++ b/mdbook-spec/src/lib.rs
@@ -1,11 +1,11 @@
 #![deny(rust_2018_idioms, unused_lifetimes)]
 
 use crate::rules::Rules;
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
+use mdbook::BookItem;
 use mdbook::book::{Book, Chapter};
 use mdbook::errors::Error;
 use mdbook::preprocess::{CmdPreprocessor, Preprocessor, PreprocessorContext};
-use mdbook::BookItem;
 use once_cell::sync::Lazy;
 use regex::{Captures, Regex};
 use semver::{Version, VersionReq};

--- a/mdbook-spec/src/rules.rs
+++ b/mdbook-spec/src/rules.rs
@@ -1,9 +1,9 @@
 //! Handling for rule identifiers.
 
 use crate::test_links::RuleToTests;
-use crate::{warn_or_err, Diagnostics, Spec};
-use mdbook::book::Book;
+use crate::{Diagnostics, Spec, warn_or_err};
 use mdbook::BookItem;
+use mdbook::book::Book;
 use once_cell::sync::Lazy;
 use regex::{Captures, Regex};
 use std::collections::{BTreeMap, HashSet};

--- a/mdbook-spec/src/std_links.rs
+++ b/mdbook-spec/src/std_links.rs
@@ -1,9 +1,9 @@
 //! Support for translating links to the standard library.
 
-use crate::{bug, warn_or_err, Diagnostics};
-use anyhow::{bail, Result};
-use mdbook::book::{Book, Chapter};
+use crate::{Diagnostics, bug, warn_or_err};
+use anyhow::{Result, bail};
 use mdbook::BookItem;
+use mdbook::book::{Book, Chapter};
 use once_cell::sync::Lazy;
 use pulldown_cmark::{BrokenLink, CowStr, Event, LinkType, Options, Parser, Tag};
 use regex::Regex;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+style_edition = "2024"

--- a/style-check/Cargo.toml
+++ b/style-check/Cargo.toml
@@ -2,7 +2,7 @@
 name = "style-check"
 version = "0.1.0"
 authors = ["steveklabnik <steve@steveklabnik.com>"]
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 pulldown-cmark = "0.10.0"


### PR DESCRIPTION
This updates the internal tools to use the 2024 edition.