### PR TITLE
Add `target_env = "macabi"` and `target_env = "sim"`

### DIFF
--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -196,17 +196,19 @@ Example values:
 * `"msvc"`
 * `"musl"`
 * `"sgx"`
+* `"sim"`
+* `"macabi"`
 
 r[cfg.target_abi]
 ### `target_abi`
 
 r[cfg.target_abi.general]
-Key-value option set to further disambiguate the `target_env` with information
-about the target ABI.
+Key-value option set to further disambiguate the `target_env` or `target_arch`
+with information about the target ABI.
 
 r[cfg.target_abi.disambiguation]
 For historical reasons, this value is only defined as not the empty-string when actually
- needed for disambiguation. Thus, for example, on many GNU platforms, this value will be
+needed for disambiguation. Thus, for example, on many GNU platforms, this value will be
 empty.
 
 r[cfg.target_abi.values]
@@ -216,8 +218,6 @@ Example values:
 * `"llvm"`
 * `"eabihf"`
 * `"abi64"`
-* `"sim"`
-* `"macabi"`
 
 r[cfg.target_endian]
 ### `target_endian`

--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -203,8 +203,8 @@ r[cfg.target_abi]
 ### `target_abi`
 
 r[cfg.target_abi.general]
-Key-value option set to further disambiguate the `target_env` or `target_arch`
-with information about the target ABI.
+Key-value option set to further disambiguate the target with information about
+the target ABI.
 
 r[cfg.target_abi.disambiguation]
 For historical reasons, this value is only defined as not the empty-string when actually


### PR DESCRIPTION
Replaces `target_abi` variants. The old variants are still available, but may be deprecated in the future, so I've removed them as examples from the reference.

Depends on https://github.com/rust-lang/rust/pull/139451.