### PR TITLE
Misc. spelling fixes

### DIFF
--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -20,7 +20,7 @@ A *block expression*, or *block*, is a control flow expression and anonymous nam
 r[expr.block.sequential-evaluation]
 As a control flow expression, a block sequentially executes its component non-item declaration statements and then its final optional expression.
 
-r[expr.block.namepsace]
+r[expr.block.namespace]
 As an anonymous namespace scope, item declarations are only in scope inside the block itself and variables declared by `let` statements are in scope from the next statement until the end of the block.
 See the [scopes] chapter for more details.
 

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -701,7 +701,7 @@ An assignment expression consists of a [mutable] [assignee expression], the *ass
 r[expr.assign.behavior-basic]
 In its most basic form, an assignee expression is a [place expression], and we discuss this case first.
 
-r[expr.assign.behavior-destructring]
+r[expr.assign.behavior-destructuring]
 The more general case of destructuring assignment is discussed below, but this case always decomposes into sequential assignments to place expressions, which may be considered the more fundamental case.
 
 r[expr.assign.basic]
@@ -711,7 +711,7 @@ r[expr.assign.evaluation-order]
 Evaluating assignment expressions begins by evaluating its operands.
 The assigned value operand is evaluated first, followed by the assignee expression.
 
-r[expr.assign.destructring-order]
+r[expr.assign.destructuring-order]
 For destructuring assignment, subexpressions of the assignee expression are evaluated left-to-right.
 
 > [!NOTE]

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -553,7 +553,7 @@ enum Enum16 {
     Variant1,
 }
 
-// The size of the C representation is platform dependant
+// The size of the C representation is platform dependent
 assert_eq!(std::mem::size_of::<EnumC>(), 8);
 // One byte for the discriminant and one byte for the value in Enum8::Variant0
 assert_eq!(std::mem::size_of::<Enum8>(), 2);


### PR DESCRIPTION
Miscellaneous spelling fixes:
- spelling fix, dependant -> dependent
- spelling fix, destructring -> destructuring
- fix spelling: namepsace -> namespace

For misspellings in references, I did a search within the repo and on github for anything using the incorrect spelling, and didn't find anything (other than forks of this repo).