### PR TITLE
Fix std::ops links in range-expr

### DIFF
--- a/src/expressions/range-expr.md
+++ b/src/expressions/range-expr.md
@@ -72,10 +72,3 @@ for i in 1..11 {
 ```
 
 [_Expression_]: ../expressions.md
-
-[std::ops::Range]: https://doc.rust-lang.org/std/ops/struct.Range.html
-[std::ops::RangeFrom]: https://doc.rust-lang.org/std/ops/struct.RangeFrom.html
-[std::ops::RangeTo]: https://doc.rust-lang.org/std/ops/struct.RangeTo.html
-[std::ops::RangeFull]: https://doc.rust-lang.org/std/ops/struct.RangeFull.html
-[std::ops::RangeInclusive]: https://doc.rust-lang.org/std/ops/struct.RangeInclusive.html
-[std::ops::RangeToInclusive]: https://doc.rust-lang.org/std/ops/struct.RangeToInclusive.html


### PR DESCRIPTION
Somehow I missed these in https://github.com/rust-lang/reference/pull/1578. They should be using the automatic std-linking support so that they can be relative when necessary.