### PR TITLE
Add a new grammar renderer

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -12,6 +12,7 @@ smart-punctuation = true
 
 [output.html.search.chapter]
 "test-summary.md" = { enable = false }
+"grammar.md" = { enable = false }
 
 [output.html.redirect]
 "/expressions/enum-variant-expr.html" = "struct-expr.html"

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -214,3 +214,7 @@ r[foo.bar.edition2021]
 > [!EDITION-2021]
 > Describe what changed in 2021.
 ```
+
+## Grammar
+
+See [Grammar](grammar.md) for details on how to write grammar rules.

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -16,6 +16,8 @@ The category is used to group similar productions on the grammar summary page in
 
 The syntax for the grammar itself is pretty close to what is described in the [Notation chapter](../src/notation.md), though there are some rendering differences.
 
+A "root" production, marked with `@root`, is one that is not used in any other production.
+
 The syntax for the grammar itself (written in itself, hopefully that's not too confusing) is:
 
 ```
@@ -25,7 +27,7 @@ BACKTICK -> U+0060
 
 LF -> U+000A
 
-Production -> Name ` ->` Expression
+Production -> `@root`? Name ` ->` Expression
 
 Name -> <Alphanumeric or `_`>+
 

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -1,0 +1,120 @@
+# Grammar
+
+The Reference grammar is written in markdown code blocks using a modified BNF-like syntax (with a blend of regex and other arbitrary things). The `mdbook-spec` extension parses these rules and converts them to a renderable format, including railroad diagrams.
+
+The code block should have a lang string with the word "grammar", a comma, and the category of the grammar, like this:
+
+~~~
+```grammar,items
+ProductionName -> SomeExpression
+```
+~~~
+
+The category is used to group similar productions on the grammar summary page in the appendix.
+
+## Grammar syntax
+
+The syntax for the grammar itself is pretty close to what is described in the [Notation chapter](../src/notation.md), though there are some rendering differences.
+
+The syntax for the grammar itself (written in itself, hopefully that's not too confusing) is:
+
+```
+Grammar -> Production+
+
+BACKTICK -> U+0060
+
+LF -> U+000A
+
+Production -> Name ` ->` Expression
+
+Name -> <Alphanumeric or `_`>+
+
+Expression -> Sequence (` `* `|` ` `* Sequence)*
+
+Sequence -> (` `* AdornedExpr)+
+
+AdornedExpr -> ExprRepeat Suffix? Footnote?
+
+Suffix -> ` _` <not underscore, unless in backtick>* `_`
+
+Footnote -> `[^` ~[`]` LF]+ `]`
+
+ExprRepeat ->
+      Expr1 `?`
+    | Expr1 `*?`
+    | Expr1 `*`
+    | Expr1 `+?`
+    | Expr1 `+`
+    | Expr1 `{` Range? `..` Range? `}`
+
+Range -> [0-9]+
+
+Expr1 ->
+      Unicode
+    | NonTerminal
+    | Break
+    | Terminal
+    | Charset
+    | Prose
+    | Group
+    | NegativeExpression
+
+Unicode -> `U+` [`A`-`Z` `0`-`9`]4..4
+
+NonTerminal -> Name
+
+Break -> LF ` `+
+
+Terminal -> BACKTICK ~[LF]+ BACKTICK
+
+Charset -> `[` (` `* Characters)+ ` `* `]`
+
+Characters ->
+      CharacterRange
+    | CharacterTerminal
+    | CharacterName
+
+CharacterRange -> BACKTICK <any char> BACKTICK `-` BACKTICK <any char> BACKTICK
+
+CharacterTerminal -> Terminal
+
+CharacterName -> Name
+
+Prose -> `<` ~[`>` LF]+ `>`
+
+Group -> `(` ` `* Expression ` `* `)`
+
+NegativeExpression -> `~` ( Charset | Terminal | NonTerminal )
+```
+
+The general format is a series of productions separated by blank lines. The expressions are:
+
+| Expression | Example | Description |
+|------------|---------|-------------|
+| Unicode | U+0060 | A single unicode character. |
+| NonTerminal | FunctionParameters | A reference to another production by name. |
+| Break | | This is used internally by the renderer to detect line breaks and indentation. |
+| Terminal | \`example\` | This is a sequence of exact characters, surrounded by backticks |
+| Charset | [ \`A\`-\`Z\` \`0\`-\`9\` \`_\` ] | A choice from a set of characters, space separated. There are three different forms. |
+| CharacterRange | [ \`A\`-\`Z\` ] | A range of characters, each character should be in backticks.
+| CharacterTerminal | [ \`x\` ] | A single character, surrounded by backticks. |
+| CharacterName | [ LF ] | A nonterminal, referring to another production. |
+| Prose | \<any ASCII character except CR\> | This is an English description of what should be matched, surrounded in angle brackets. |
+| Group | (\`,\` Parameter)+ | This groups an expression for the purpose of precedence, such as applying a repetition operator to a sequence of other expressions.
+| NegativeExpression | ~[\` \` LF] | Matches anything except the given Charset, Terminal, or Nonterminal. |
+| Sequence | \`fn\` Name Parameters | A sequence of expressions, where they must match in order. |
+| Alternation | Expr1 \| Expr2 | Matches only one of the given expressions, separated by the vertical pipe character. |
+| Suffix | \_except \[LazyBooleanExpression\]\_  | This adds a suffix to the previous expression to provide an additional English description to it, rendered in subscript. This can have limited markdown, but try to avoid anything except basics like links. |
+| Footnote | \[^extern-safe\] | This adds a footnote, which can supply some extra information that may be helpful to the user. The footnote itself should be defined outside of the code block like a normal markdown footnote. |
+| Optional | Expr? | The preceding expression is optional. |
+| Repeat | Expr* | The preceding expression is repeated 0 or more times. |
+| Repeat (non-greedy) | Expr*? | The preceding expression is repeated 0 or more times without being greedy. |
+| RepeatPlus | Expr+ | The preceding expression is repeated 1 or more times. |
+| RepeatPlus (non-greedy) | Expr+? | The preceding expression is repeated 1 or more times without being greedy. |
+| RepeatRange | Expr{2..4} | The preceding expression is repeated between the range of times specified. Either bounds can be excluded, which works just like Rust ranges. |
+
+## Automatic linking
+
+The plugin automatically adds markdown link definitions for all the production names on every page. If you want to link directly to a production name, all you need to do is surround it in square brackets, like `[ArrayExpression]`.
+
+In some cases there might be name collisions with the automatic linking of rule names. In that case, disambiguate with the `grammar-` prefix, such as `[Type][grammar-Type]`. You can also do that if you just feel like being more explicit.

--- a/mdbook-spec/Cargo.lock
+++ b/mdbook-spec/Cargo.lock
@@ -412,6 +412,7 @@ dependencies = [
  "once_cell",
  "pathdiff",
  "pulldown-cmark",
+ "railroad",
  "regex",
  "semver",
  "serde_json",
@@ -567,6 +568,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "railroad"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ecedffc46c1b2cb04f4b80e094eae6b3f3f470a9635f1f396dd5206428f6b58"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -779,6 +789,12 @@ name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "utf8parse"

--- a/mdbook-spec/Cargo.toml
+++ b/mdbook-spec/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "An mdBook preprocessor to help with the Rust specification."
 repository = "https://github.com/rust-lang/spec/"
+default-run = "mdbook-spec"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -15,6 +16,7 @@ once_cell = "1.19.0"
 pathdiff = "0.2.1"
 # Try to keep in sync with mdbook.
 pulldown-cmark = { version = "0.10.3", default-features = false }
+railroad = { version = "0.3.2", default-features = false }
 regex = "1.9.4"
 semver = "1.0.21"
 serde_json = "1.0.113"

--- a/mdbook-spec/src/grammar.rs
+++ b/mdbook-spec/src/grammar.rs
@@ -309,7 +309,18 @@ fn render_names(
     };
 
     let markdown_link_map = updated_link_map(render_markdown::markdown_id);
-    if let Err(e) = grammar.render_markdown(&names, &markdown_link_map, &mut output, for_summary) {
+    // Modify the link map so that it contains the exact destination needed to
+    // link to the railroad productions, and to accommodate the summary
+    // chapter.
+    let railroad_link_map = updated_link_map(render_railroad::railroad_id);
+
+    if let Err(e) = grammar.render_markdown(
+        &names,
+        &markdown_link_map,
+        &railroad_link_map,
+        &mut output,
+        for_summary,
+    ) {
         warn_or_err!(
             diag,
             "grammar failed in chapter {:?}: {e}",
@@ -319,9 +330,9 @@ fn render_names(
 
     output.push_str(
         "\n\
-         <button class=\"grammar-toggle\" type=\"button\" \
-            title=\"Toggle grammar display\" \
-            onclick=\"toggle_grammar()\">\
+         <button class=\"grammar-toggle-railroad\" type=\"button\" \
+            title=\"Toggle railroad display\" \
+            onclick=\"toggle_railroad()\">\
             Show Railroad\
          </button>\n\
          </div>\n\
@@ -329,11 +340,13 @@ fn render_names(
          \n",
     );
 
-    // Modify the link map so that it contains the exact destination needed to
-    // link to the railroad productions, and to accommodate the summary
-    // chapter.
-    let railroad_link_map = updated_link_map(render_railroad::railroad_id);
-    if let Err(e) = grammar.render_railroad(&names, &railroad_link_map, &mut output, for_summary) {
+    if let Err(e) = grammar.render_railroad(
+        &names,
+        &railroad_link_map,
+        &markdown_link_map,
+        &mut output,
+        for_summary,
+    ) {
         warn_or_err!(
             diag,
             "grammar failed in chapter {:?}: {e}",

--- a/mdbook-spec/src/grammar.rs
+++ b/mdbook-spec/src/grammar.rs
@@ -200,8 +200,8 @@ fn check_unexpected_roots(grammar: &Grammar, diag: &mut Diagnostics) {
     .into_iter()
     .collect();
     if set != expected {
-        let new: Vec<_> = set.symmetric_difference(&expected).collect();
-        let removed: Vec<_> = expected.symmetric_difference(&set).collect();
+        let new: Vec<_> = set.difference(&expected).collect();
+        let removed: Vec<_> = expected.difference(&set).collect();
         if !new.is_empty() {
             warn_or_err!(
                 diag,

--- a/mdbook-spec/src/grammar.rs
+++ b/mdbook-spec/src/grammar.rs
@@ -31,7 +31,7 @@ pub struct Production {
     is_root: bool,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct Expression {
     kind: ExpressionKind,
     /// Suffix is the `_foo_` part that is shown as a subscript.
@@ -40,7 +40,7 @@ struct Expression {
     footnote: Option<String>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 enum ExpressionKind {
     /// `( A B C )`
     Grouped(Box<Expression>),
@@ -78,7 +78,7 @@ enum ExpressionKind {
     Unicode(String),
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 enum Characters {
     /// `LF`
     Named(String),
@@ -97,6 +97,14 @@ impl Grammar {
 }
 
 impl Expression {
+    fn new_kind(kind: ExpressionKind) -> Self {
+        Self {
+            kind,
+            suffix: None,
+            footnote: None,
+        }
+    }
+
     fn visit_nt(&self, callback: &mut dyn FnMut(&str)) {
         match &self.kind {
             ExpressionKind::Grouped(e)

--- a/mdbook-spec/src/grammar.rs
+++ b/mdbook-spec/src/grammar.rs
@@ -1,0 +1,388 @@
+//! Support for rendering the grammar.
+
+use crate::{Diagnostics, warn_or_err};
+use mdbook::book::{Book, BookItem, Chapter};
+use regex::{Captures, Regex};
+use std::collections::{HashMap, HashSet};
+use std::fmt::Write;
+use std::path::PathBuf;
+use std::sync::LazyLock;
+
+mod parser;
+mod render_markdown;
+mod render_railroad;
+
+#[derive(Debug, Default)]
+pub struct Grammar {
+    pub productions: HashMap<String, Production>,
+    /// The order that the production names were discovered.
+    pub name_order: Vec<String>,
+}
+
+#[derive(Debug)]
+pub struct Production {
+    name: String,
+    /// Category is from the markdown lang string, and defines how it is
+    /// grouped and organized on the summary page.
+    category: String,
+    expression: Expression,
+    /// The path to the chapter where this is defined.
+    path: PathBuf,
+}
+
+#[derive(Debug)]
+struct Expression {
+    kind: ExpressionKind,
+    /// Suffix is the `_foo_` part that is shown as a subscript.
+    suffix: Option<String>,
+    /// A footnote is a markdown footnote link.
+    footnote: Option<String>,
+}
+
+#[derive(Debug)]
+enum ExpressionKind {
+    /// `( A B C )`
+    Grouped(Box<Expression>),
+    /// `A | B | C`
+    Alt(Vec<Expression>),
+    /// `A B C`
+    Sequence(Vec<Expression>),
+    /// `A?`
+    Optional(Box<Expression>),
+    /// `A*`
+    Repeat(Box<Expression>),
+    /// `A*?`
+    RepeatNonGreedy(Box<Expression>),
+    /// `A+`
+    RepeatPlus(Box<Expression>),
+    /// `A+?`
+    RepeatPlusNonGreedy(Box<Expression>),
+    /// `A{2..4}`
+    RepeatRange(Box<Expression>, Option<u32>, Option<u32>),
+    /// `NonTerminal`
+    Nt(String),
+    /// `` `string` ``
+    Terminal(String),
+    /// `<english description>`
+    Prose(String),
+    /// An LF followed by the given number of spaces.
+    ///
+    /// Used by the renderer to help format and structure the grammar.
+    Break(usize),
+    /// ``[`A`-`Z` `_` LF]``
+    Charset(Vec<Characters>),
+    /// ``~[` ` LF]``
+    NegExpression(Box<Expression>),
+    /// `U+0060`
+    Unicode(String),
+}
+
+#[derive(Debug)]
+enum Characters {
+    /// `LF`
+    Named(String),
+    /// `` `_` ``
+    Terminal(String),
+    /// `` `A`-`Z` ``
+    Range(char, char),
+}
+
+impl Grammar {
+    fn visit_nt(&self, callback: &mut dyn FnMut(&str)) {
+        for p in self.productions.values() {
+            p.expression.visit_nt(callback);
+        }
+    }
+}
+
+impl Expression {
+    fn visit_nt(&self, callback: &mut dyn FnMut(&str)) {
+        match &self.kind {
+            ExpressionKind::Grouped(e)
+            | ExpressionKind::Optional(e)
+            | ExpressionKind::Repeat(e)
+            | ExpressionKind::RepeatNonGreedy(e)
+            | ExpressionKind::RepeatPlus(e)
+            | ExpressionKind::RepeatPlusNonGreedy(e)
+            | ExpressionKind::RepeatRange(e, _, _)
+            | ExpressionKind::NegExpression(e) => {
+                e.visit_nt(callback);
+            }
+            ExpressionKind::Alt(es) | ExpressionKind::Sequence(es) => {
+                for e in es {
+                    e.visit_nt(callback);
+                }
+            }
+            ExpressionKind::Nt(nt) => {
+                callback(&nt);
+            }
+            ExpressionKind::Terminal(_)
+            | ExpressionKind::Prose(_)
+            | ExpressionKind::Break(_)
+            | ExpressionKind::Unicode(_) => {}
+            ExpressionKind::Charset(set) => {
+                for ch in set {
+                    match ch {
+                        Characters::Named(s) => callback(s),
+                        Characters::Terminal(_) | Characters::Range(_, _) => {}
+                    }
+                }
+            }
+        }
+    }
+
+    fn is_break(&self) -> bool {
+        matches!(self.kind, ExpressionKind::Break(_))
+    }
+}
+
+static GRAMMAR_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?ms)^```grammar,([^\n]+)\n(.*?)^```").unwrap());
+static NAMES_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?m)^([A-Za-z0-9_]+)(?: \([^)]+\))? ->").unwrap());
+
+/// Loads the [`Grammar`] from the book.
+pub fn load_grammar(book: &Book, diag: &mut Diagnostics) -> Grammar {
+    let mut grammar = Grammar::default();
+    for item in book.iter() {
+        let BookItem::Chapter(ch) = item else {
+            continue;
+        };
+        if ch.is_draft_chapter() {
+            continue;
+        }
+        let path = ch.path.as_ref().unwrap().to_owned();
+        for cap in GRAMMAR_RE.captures_iter(&ch.content) {
+            let category = &cap[1];
+            let input = &cap[2];
+            if let Err(e) = parser::parse_grammar(input, &mut grammar, category, &path) {
+                warn_or_err!(diag, "failed to parse grammar in {path:?}: {e}");
+            }
+        }
+    }
+    check_undefined_nt(&grammar, diag);
+    check_unexpected_roots(&grammar, diag);
+    grammar
+}
+
+/// Checks for nonterminals that are used but not defined.
+fn check_undefined_nt(grammar: &Grammar, diag: &mut Diagnostics) {
+    grammar.visit_nt(&mut |nt| {
+        if !grammar.productions.contains_key(nt) {
+            warn_or_err!(diag, "non-terminal `{nt}` is used but not defined");
+        }
+    });
+}
+
+/// This checks that all the grammar roots are what we expect.
+///
+/// This is intended to help catch any unexpected misspellings, orphaned
+/// productions, or general mistakes.
+fn check_unexpected_roots(grammar: &Grammar, diag: &mut Diagnostics) {
+    let mut set: HashSet<_> = grammar.name_order.iter().map(|s| s.as_str()).collect();
+    grammar.visit_nt(&mut |nt| {
+        set.remove(nt);
+    });
+    // TODO: We may want to rethink how some of these are structured.
+    let expected: HashSet<_> = [
+        "CfgAttrAttribute",
+        "CfgAttribute",
+        "Crate",
+        "INNER_LINE_DOC",
+        "LINE_COMMENT",
+        "MetaListIdents",
+        "MetaListNameValueStr",
+        "MetaListPaths",
+        "MetaWord",
+        "OUTER_LINE_DOC",
+    ]
+    .into_iter()
+    .collect();
+    if set != expected {
+        let new: Vec<_> = set.symmetric_difference(&expected).collect();
+        let removed: Vec<_> = expected.symmetric_difference(&set).collect();
+        if !new.is_empty() {
+            warn_or_err!(
+                diag,
+                "New grammar production detected that is not used in any other production.\n\
+                 If this is expected, add it to the `check_unexpected_roots` function.\n\
+                 If not, make sure it is spelled correctly and used in another production.\n\
+                 The new names are: {new:?}\n"
+            );
+        } else if !removed.is_empty() {
+            warn_or_err!(
+                diag,
+                "Old grammar production root seems to have been removed.\n\
+                 If this is expected, remove it from the `check_unexpected_roots` function.\n\
+                 The removed names are: {removed:?}\n"
+            );
+        } else {
+            unreachable!("unexpected");
+        }
+    }
+}
+
+/// Replaces the text grammar in the given chapter with the rendered version.
+pub fn insert_grammar(grammar: &Grammar, chapter: &Chapter, diag: &mut Diagnostics) -> String {
+    let link_map = make_relative_link_map(grammar, chapter);
+
+    let mut content = GRAMMAR_RE
+        .replace_all(&chapter.content, |cap: &Captures<'_>| {
+            let names: Vec<_> = NAMES_RE
+                .captures_iter(&cap[2])
+                .map(|cap| cap.get(1).unwrap().as_str())
+                .collect();
+            let for_lexer = &cap[1] == "lexer";
+            render_names(grammar, &names, &link_map, for_lexer, chapter, diag)
+        })
+        .to_string();
+
+    // Make all production names easily linkable.
+    let is_summary = is_summary(chapter);
+    for (name, path) in &link_map {
+        let id = render_markdown::markdown_id(name, is_summary);
+        if is_summary {
+            // On the summary page, link to the production on the summary page.
+            writeln!(content, "[{name}]: #{id}").unwrap();
+        } else {
+            // This includes two variants, one for convenience (like
+            // `[ArrayExpression]`), and one with the `grammar-` prefix to
+            // disambiguate links that have the same name as a rule (rules
+            // take precedence).
+            writeln!(
+                content,
+                "[{name}]: {path}#{id}\n\
+                 [grammar-{name}]: {path}#{id}"
+            )
+            .unwrap();
+        }
+    }
+    content
+}
+
+/// Creates a map of production name -> relative link path.
+fn make_relative_link_map(grammar: &Grammar, chapter: &Chapter) -> HashMap<String, String> {
+    let current_path = chapter.path.as_ref().unwrap().parent().unwrap();
+    grammar
+        .productions
+        .values()
+        .map(|p| {
+            let relative = pathdiff::diff_paths(&p.path, current_path).unwrap();
+            // Adjust paths for Windows.
+            let relative = relative.display().to_string().replace('\\', "/");
+            (p.name.clone(), relative)
+        })
+        .collect()
+}
+
+/// Helper to take a list of production names and to render all of those to a
+/// mixture of markdown and HTML.
+fn render_names(
+    grammar: &Grammar,
+    names: &[&str],
+    link_map: &HashMap<String, String>,
+    for_lexer: bool,
+    chapter: &Chapter,
+    diag: &mut Diagnostics,
+) -> String {
+    let for_summary = is_summary(chapter);
+    let mut output = String::new();
+    output.push_str(
+        "<div class=\"grammar-container\">\n\
+         \n",
+    );
+    if for_lexer {
+        output.push_str("**<sup>Lexer</sup>**\n");
+    } else {
+        output.push_str("**<sup>Syntax</sup>**\n");
+    }
+    output.push_str("<br>\n");
+
+    // Convert the link map to add the id.
+    let updated_link_map = |get_id: fn(&str, bool) -> String| -> HashMap<String, String> {
+        link_map
+            .iter()
+            .map(|(name, path)| {
+                let id = get_id(name, for_summary);
+                let path = if for_summary {
+                    format!("#{id}")
+                } else {
+                    format!("{path}#{id}")
+                };
+                (name.clone(), path)
+            })
+            .collect()
+    };
+
+    let markdown_link_map = updated_link_map(render_markdown::markdown_id);
+    if let Err(e) = grammar.render_markdown(&names, &markdown_link_map, &mut output, for_summary) {
+        warn_or_err!(
+            diag,
+            "grammar failed in chapter {:?}: {e}",
+            chapter.source_path.as_ref().unwrap()
+        );
+    }
+
+    output.push_str(
+        "\n\
+         <button class=\"grammar-toggle\" type=\"button\" \
+            title=\"Toggle grammar display\" \
+            onclick=\"toggle_grammar()\">\
+            Show Railroad\
+         </button>\n\
+         </div>\n\
+         <div class=\"grammar-railroad grammar-hidden\">\n\
+         \n",
+    );
+
+    // Modify the link map so that it contains the exact destination needed to
+    // link to the railroad productions, and to accommodate the summary
+    // chapter.
+    let railroad_link_map = updated_link_map(render_railroad::railroad_id);
+    if let Err(e) = grammar.render_railroad(&names, &railroad_link_map, &mut output, for_summary) {
+        warn_or_err!(
+            diag,
+            "grammar failed in chapter {:?}: {e}",
+            chapter.source_path.as_ref().unwrap()
+        );
+    }
+
+    output.push_str("</div>\n");
+
+    output
+}
+
+pub fn is_summary(chapter: &Chapter) -> bool {
+    chapter.name == "Grammar summary"
+}
+
+/// Inserts the summary of all grammar rules into the grammar summary chapter.
+pub fn insert_summary(grammar: &Grammar, chapter: &Chapter, diag: &mut Diagnostics) -> String {
+    let link_map = make_relative_link_map(grammar, chapter);
+    let mut seen = HashSet::new();
+    let categories: Vec<_> = grammar
+        .name_order
+        .iter()
+        .map(|name| &grammar.productions[name].category)
+        .filter(|cat| seen.insert(*cat))
+        .collect();
+    let mut grammar_summary = String::new();
+    for category in categories {
+        let mut chars = category.chars();
+        let cap = chars.next().unwrap().to_uppercase().collect::<String>() + chars.as_str();
+        write!(grammar_summary, "\n## {cap} summary\n\n").unwrap();
+        let names: Vec<_> = grammar
+            .name_order
+            .iter()
+            .filter(|name| grammar.productions[*name].category == *category)
+            .map(|s| s.as_str())
+            .collect();
+        let for_lexer = category == "lexer";
+        let s = render_names(grammar, &names, &link_map, for_lexer, chapter, diag);
+        grammar_summary.push_str(&s);
+    }
+
+    chapter
+        .content
+        .replace("{{ grammar-summary }}", &grammar_summary)
+}

--- a/mdbook-spec/src/grammar.rs
+++ b/mdbook-spec/src/grammar.rs
@@ -187,6 +187,7 @@ fn check_unexpected_roots(grammar: &Grammar, diag: &mut Diagnostics) {
     let expected: HashSet<_> = [
         "CfgAttrAttribute",
         "CfgAttribute",
+        "CHAR",
         "Crate",
         "INNER_LINE_DOC",
         "LINE_COMMENT",

--- a/mdbook-spec/src/grammar/parser.rs
+++ b/mdbook-spec/src/grammar/parser.rs
@@ -1,0 +1,442 @@
+//! A parser of the ENBF-like grammar.
+
+use super::{Characters, Expression, ExpressionKind, Grammar, Production};
+use regex::{Captures, Regex};
+use std::fmt;
+use std::fmt::Display;
+use std::path::Path;
+use std::sync::LazyLock;
+
+struct Parser<'a> {
+    input: &'a str,
+    index: usize,
+}
+
+pub struct Error {
+    message: String,
+    line: String,
+    lineno: usize,
+    col: usize,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        let lineno = format!("{}", self.lineno);
+        let space = " ".repeat(lineno.len() + 1);
+        let col = " ".repeat(self.col);
+        let line = &self.line;
+        let message = &self.message;
+        write!(f, "\n{space}|\n{lineno} | {line}\n{space}|{col}^ {message}")
+    }
+}
+
+macro_rules! bail {
+    ($parser:expr, $($arg:tt)*) => {{
+        let mut msg = String::new();
+        fmt::write(&mut msg, format_args!($($arg)*)).unwrap();
+        return Err($parser.error(msg));
+    }};
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+pub fn parse_grammar(
+    input: &str,
+    grammar: &mut Grammar,
+    category: &str,
+    path: &Path,
+) -> Result<()> {
+    let mut parser = Parser { input, index: 0 };
+    loop {
+        let p = parser.parse_production(category, path)?;
+        grammar.name_order.push(p.name.clone());
+        if let Some(dupe) = grammar.productions.insert(p.name.clone(), p) {
+            bail!(parser, "duplicate production {} in grammar", dupe.name);
+        }
+        parser.take_while(&|ch| ch == '\n');
+        if parser.eof() {
+            break;
+        }
+    }
+    Ok(())
+}
+
+impl Parser<'_> {
+    fn take_while(&mut self, f: &dyn Fn(char) -> bool) -> &str {
+        let mut upper = 0;
+        let i = self.index;
+        let mut ci = self.input[i..].chars();
+        while let Some(ch) = ci.next() {
+            if !f(ch) {
+                break;
+            }
+            upper += ch.len_utf8();
+        }
+        self.index += upper;
+        &self.input[i..i + upper]
+    }
+
+    /// If the input matches the given regex, it is returned and the head is moved forward.
+    ///
+    /// Note that regexes must start with `^`.
+    fn take_re(&mut self, re: &Regex) -> Option<Captures<'_>> {
+        if let Some(cap) = re.captures(&self.input[self.index..]) {
+            self.index += cap[0].len();
+            Some(cap)
+        } else {
+            None
+        }
+    }
+
+    /// Returns whether or not the given string is next, and advances the head if it is.
+    fn take_str(&mut self, s: &str) -> bool {
+        if self.input[self.index..].starts_with(s) {
+            self.index += s.len();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns the next byte, or None if eof.
+    fn peek(&mut self) -> Option<u8> {
+        if self.index >= self.input.len() {
+            None
+        } else {
+            Some(self.input.as_bytes()[self.index])
+        }
+    }
+
+    fn eof(&mut self) -> bool {
+        self.index >= self.input.len()
+    }
+
+    /// Expects the next input to be the given string, and advances the head.
+    fn expect(&mut self, s: &str, err: &str) -> Result<()> {
+        if !self.input[self.index..].starts_with(s) {
+            bail!(self, "{err}");
+        };
+        self.index += s.len();
+        Ok(())
+    }
+
+    fn error(&mut self, message: String) -> Error {
+        let (line, lineno, col) = translate_position(self.input, self.index);
+        Error {
+            message,
+            line: line.to_string(),
+            lineno,
+            col,
+        }
+    }
+
+    /// Advances zero or more spaces.
+    fn space0(&mut self) -> &str {
+        self.take_while(&|ch| ch == ' ')
+    }
+
+    fn parse_production(&mut self, category: &str, path: &Path) -> Result<Production> {
+        let name = self
+            .parse_name()
+            .ok_or_else(|| self.error("expected production name".to_string()))?;
+        self.expect(" ->", "expected -> arrow")?;
+        let Some(expression) = self.parse_expression()? else {
+            bail!(self, "expected an expression");
+        };
+        Ok(Production {
+            name,
+            category: category.to_string(),
+            expression,
+            path: path.to_owned(),
+        })
+    }
+
+    fn parse_name(&mut self) -> Option<String> {
+        let name = self.take_while(&|c: char| c.is_alphanumeric() || c == '_');
+        if name.is_empty() {
+            None
+        } else {
+            Some(name.to_string())
+        }
+    }
+
+    fn parse_expression(&mut self) -> Result<Option<Expression>> {
+        static ALT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^ *\| *").unwrap());
+
+        let mut es = Vec::new();
+        loop {
+            let Some(e) = self.parse_seq()? else { break };
+            es.push(e);
+            if self.take_re(&ALT_RE).is_none() {
+                break;
+            }
+        }
+        match es.len() {
+            0 => Ok(None),
+            1 => Ok(Some(es.pop().unwrap())),
+            _ => Ok(Some(Expression {
+                kind: ExpressionKind::Alt(es),
+                suffix: None,
+                footnote: None,
+            })),
+        }
+    }
+
+    fn parse_seq(&mut self) -> Result<Option<Expression>> {
+        let mut es = Vec::new();
+        loop {
+            self.space0();
+            let Some(e) = self.parse_expr1()? else {
+                break;
+            };
+            es.push(e);
+        }
+        match es.len() {
+            0 => Ok(None),
+            1 => Ok(Some(es.pop().unwrap())),
+            _ => Ok(Some(Expression {
+                kind: ExpressionKind::Sequence(es),
+                suffix: None,
+                footnote: None,
+            })),
+        }
+    }
+
+    fn parse_expr1(&mut self) -> Result<Option<Expression>> {
+        let Some(next) = self.peek() else {
+            return Ok(None);
+        };
+
+        let mut kind = if self.take_str("U+") {
+            self.parse_unicode()?
+        } else if self.input[self.index..]
+            .chars()
+            .next()
+            .map(|ch| ch.is_alphanumeric())
+            .unwrap_or(false)
+        {
+            self.parse_nonterminal()
+                .expect("first char already checked")
+        } else if self.take_str("\n") {
+            if self.eof() || self.take_str("\n") {
+                return Ok(None);
+            }
+            let space = self.take_while(&|ch| ch == ' ');
+            if space.len() == 0 {
+                bail!(self, "expected indentation on next line");
+            }
+            ExpressionKind::Break(space.len())
+        } else if next == b'`' {
+            self.parse_terminal()?
+        } else if next == b'[' {
+            self.parse_charset()?
+        } else if next == b'<' {
+            self.parse_prose()?
+        } else if next == b'(' {
+            self.parse_grouped()?
+        } else if next == b'~' {
+            self.parse_neg_expression()?
+        } else {
+            return Ok(None);
+        };
+
+        static REPEAT_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^ ?(\*\?|\+\?|\?|\*|\+)").unwrap());
+        static RANGE_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^\{([0-9]+)?\.\.([0-9]+)?\}").unwrap());
+        if let Some(cap) = self.take_re(&REPEAT_RE) {
+            kind = match &cap[1] {
+                "?" => ExpressionKind::Optional(box_kind(kind)),
+                "*" => ExpressionKind::Repeat(box_kind(kind)),
+                "*?" => ExpressionKind::RepeatNonGreedy(box_kind(kind)),
+                "+" => ExpressionKind::RepeatPlus(box_kind(kind)),
+                "+?" => ExpressionKind::RepeatPlusNonGreedy(box_kind(kind)),
+                s => panic!("unexpected `{s}`"),
+            };
+        } else if let Some(cap) = self.take_re(&RANGE_RE) {
+            let a = cap.get(1).map(|m| m.as_str().parse::<u32>().unwrap());
+            let b = cap.get(2).map(|m| m.as_str().parse::<u32>().unwrap());
+            kind = ExpressionKind::RepeatRange(box_kind(kind), a, b);
+        }
+
+        let suffix = self.parse_suffix()?;
+        let footnote = self.parse_footnote()?;
+
+        Ok(Some(Expression {
+            kind,
+            suffix,
+            footnote,
+        }))
+    }
+
+    fn parse_nonterminal(&mut self) -> Option<ExpressionKind> {
+        let nt = self.parse_name()?;
+        Some(ExpressionKind::Nt(nt))
+    }
+
+    fn parse_terminal(&mut self) -> Result<ExpressionKind> {
+        static TERMINAL_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^`([^`\n]+)`").unwrap());
+        match self.take_re(&TERMINAL_RE) {
+            Some(cap) => Ok(ExpressionKind::Terminal(cap[1].to_string())),
+            None => bail!(self, "unterminated terminal, expected closing backtick"),
+        }
+    }
+
+    fn parse_charset(&mut self) -> Result<ExpressionKind> {
+        self.expect("[", "expected opening [")?;
+        let mut characters = Vec::new();
+        loop {
+            self.space0();
+            let Some(ch) = self.parse_characters() else {
+                break;
+            };
+            characters.push(ch);
+        }
+        if characters.is_empty() {
+            bail!(self, "expected at least one character in character group");
+        }
+        self.space0();
+        self.expect("]", "expected closing ]")?;
+        Ok(ExpressionKind::Charset(characters))
+    }
+
+    fn parse_characters(&mut self) -> Option<Characters> {
+        static RANGE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^`(.)`-`(.)`").unwrap());
+        static TERMINAL_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new("^`([^`\n]+)`").unwrap());
+        if let Some(cap) = self.take_re(&RANGE_RE) {
+            let a = cap[1].chars().next().unwrap();
+            let b = cap[2].chars().next().unwrap();
+            Some(Characters::Range(a, b))
+        } else if let Some(cap) = self.take_re(&TERMINAL_RE) {
+            Some(Characters::Terminal(cap[1].to_string()))
+        } else {
+            let name = self.parse_name()?;
+            Some(Characters::Named(name))
+        }
+    }
+
+    fn parse_prose(&mut self) -> Result<ExpressionKind> {
+        static PROSE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^<([^>\n]+)>").unwrap());
+        match self.take_re(&PROSE_RE) {
+            Some(cap) => Ok(ExpressionKind::Prose(cap[1].to_string())),
+            None => bail!(self, "unterminated prose, expected closing `>`"),
+        }
+    }
+
+    fn parse_grouped(&mut self) -> Result<ExpressionKind> {
+        self.expect("(", "expected opening `(`")?;
+        self.space0();
+        let Some(e) = self.parse_expression()? else {
+            bail!(self, "expected expression in parenthesized group");
+        };
+        self.space0();
+        self.expect(")", "expected closing `)`")?;
+        Ok(ExpressionKind::Grouped(Box::new(e)))
+    }
+
+    fn parse_neg_expression(&mut self) -> Result<ExpressionKind> {
+        self.expect("~", "expected ~")?;
+        let Some(next) = self.peek() else {
+            bail!(self, "expected expression after ~");
+        };
+        let kind = match next {
+            b'[' => self.parse_charset()?,
+            b'`' => self.parse_terminal()?,
+            _ => self.parse_nonterminal().ok_or_else(|| {
+                self.error("expected a charset, terminal, or name after ~ negation".to_string())
+            })?,
+        };
+        Ok(ExpressionKind::NegExpression(box_kind(kind)))
+    }
+
+    fn parse_unicode(&mut self) -> Result<ExpressionKind> {
+        static UNICODE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[A-Z0-9]{4}").unwrap());
+
+        match self.take_re(&UNICODE_RE) {
+            Some(s) => Ok(ExpressionKind::Unicode(s[0].to_string())),
+            None => bail!(self, "expected 4 hexadecimal uppercase digits after U+"),
+        }
+    }
+
+    fn parse_suffix(&mut self) -> Result<Option<String>> {
+        if !self.take_str(" _") {
+            return Ok(None);
+        }
+        let mut in_backtick = false;
+        let start = self.index;
+        loop {
+            let Some(next) = self.peek() else {
+                bail!(self, "failed to find end of _ suffixed text");
+            };
+            self.index += 1;
+            match next {
+                b'\n' => bail!(self, "failed to find end of _ suffixed text"),
+                b'`' => in_backtick = !in_backtick,
+                b'_' if !in_backtick => {
+                    if self
+                        .peek()
+                        .map(|b| matches!(b, b'\n' | b' '))
+                        .unwrap_or(true)
+                    {
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(Some(self.input[start..self.index - 1].to_string()))
+    }
+
+    fn parse_footnote(&mut self) -> Result<Option<String>> {
+        static FOOTNOTE_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^([^\]\n]+)]").unwrap());
+        if !self.take_str("[^") {
+            return Ok(None);
+        }
+        match self.take_re(&FOOTNOTE_RE) {
+            Some(cap) => Ok(Some(cap[1].to_string())),
+            None => bail!(self, "unterminated footnote, expected closing `]`"),
+        }
+    }
+}
+
+fn box_kind(kind: ExpressionKind) -> Box<Expression> {
+    Box::new(Expression {
+        kind,
+        suffix: None,
+        footnote: None,
+    })
+}
+
+/// Helper to translate a byte index to a `(line, line_no, col_no)` (1-based).
+fn translate_position(input: &str, index: usize) -> (&str, usize, usize) {
+    if input.is_empty() {
+        return ("", 0, 0);
+    }
+    let index = index.min(input.len());
+
+    let mut line_start = 0;
+    let mut line_number = 0;
+    for line in input.lines() {
+        let line_end = line_start + line.len();
+        if index >= line_start && index <= line_end {
+            let column_number = index - line_start + 1;
+            return (line, line_number + 1, column_number);
+        }
+        line_start = line_end + 1;
+        line_number += 1;
+    }
+    ("", line_number + 1, 0)
+}
+
+#[test]
+fn translate_tests() {
+    assert_eq!(translate_position("", 0), ("", 0, 0));
+    assert_eq!(translate_position("test", 0), ("test", 1, 1));
+    assert_eq!(translate_position("test", 3), ("test", 1, 4));
+    assert_eq!(translate_position("test", 4), ("test", 1, 5));
+    assert_eq!(translate_position("test\ntest2", 4), ("test", 1, 5));
+    assert_eq!(translate_position("test\ntest2", 5), ("test2", 2, 1));
+    assert_eq!(translate_position("test\ntest2\n", 11), ("", 3, 0));
+}

--- a/mdbook-spec/src/grammar/parser.rs
+++ b/mdbook-spec/src/grammar/parser.rs
@@ -136,6 +136,8 @@ impl Parser<'_> {
     }
 
     fn parse_production(&mut self, category: &str, path: &Path) -> Result<Production> {
+        let is_root = self.parse_is_root();
+        self.space0();
         let name = self
             .parse_name()
             .ok_or_else(|| self.error("expected production name".to_string()))?;
@@ -148,7 +150,12 @@ impl Parser<'_> {
             category: category.to_string(),
             expression,
             path: path.to_owned(),
+            is_root,
         })
+    }
+
+    fn parse_is_root(&mut self) -> bool {
+        self.take_str("@root")
     }
 
     fn parse_name(&mut self) -> Option<String> {

--- a/mdbook-spec/src/grammar/parser.rs
+++ b/mdbook-spec/src/grammar/parser.rs
@@ -263,6 +263,10 @@ impl Parser<'_> {
         } else if let Some(cap) = self.take_re(&RANGE_RE) {
             let a = cap.get(1).map(|m| m.as_str().parse::<u32>().unwrap());
             let b = cap.get(2).map(|m| m.as_str().parse::<u32>().unwrap());
+            match (a, b) {
+                (Some(a), Some(b)) if b < a => bail!(self, "range {a}..{b} is malformed"),
+                _ => {}
+            }
             kind = ExpressionKind::RepeatRange(box_kind(kind), a, b);
         }
 

--- a/mdbook-spec/src/grammar/render_markdown.rs
+++ b/mdbook-spec/src/grammar/render_markdown.rs
@@ -1,0 +1,228 @@
+//! Renders the grammar to markdown.
+
+use super::{Characters, Expression, ExpressionKind, Production};
+use crate::grammar::Grammar;
+use anyhow::bail;
+use regex::Regex;
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::fmt::Write;
+use std::sync::LazyLock;
+
+impl Grammar {
+    pub fn render_markdown(
+        &self,
+        names: &[&str],
+        link_map: &HashMap<String, String>,
+        output: &mut String,
+        for_summary: bool,
+    ) -> anyhow::Result<()> {
+        let mut iter = names.into_iter().peekable();
+        while let Some(name) = iter.next() {
+            let prod = match self.productions.get(*name) {
+                Some(p) => p,
+                None => bail!("could not find grammar production named `{name}`"),
+            };
+            prod.render_markdown(link_map, output, for_summary);
+            if iter.peek().is_some() {
+                output.push_str("\n");
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The HTML id for the production.
+pub fn markdown_id(name: &str, for_summary: bool) -> String {
+    if for_summary {
+        format!("grammar-summary-{}", name)
+    } else {
+        format!("grammar-{}", name)
+    }
+}
+
+impl Production {
+    fn render_markdown(
+        &self,
+        link_map: &HashMap<String, String>,
+        output: &mut String,
+        for_summary: bool,
+    ) {
+        write!(
+            output,
+            "<span class=\"grammar-text grammar-production\" id=\"{id}\">{name}</span> → ",
+            id = markdown_id(&self.name, for_summary),
+            name = self.name
+        )
+        .unwrap();
+        self.expression.render_markdown(link_map, output);
+        output.push('\n');
+    }
+}
+
+impl Expression {
+    /// Returns the last [`ExpressionKind`] of this expression.
+    fn last(&self) -> &ExpressionKind {
+        match &self.kind {
+            ExpressionKind::Alt(es) | ExpressionKind::Sequence(es) => es.last().unwrap().last(),
+            ExpressionKind::Grouped(_)
+            | ExpressionKind::Optional(_)
+            | ExpressionKind::Repeat(_)
+            | ExpressionKind::RepeatNonGreedy(_)
+            | ExpressionKind::RepeatPlus(_)
+            | ExpressionKind::RepeatPlusNonGreedy(_)
+            | ExpressionKind::RepeatRange(_, _, _)
+            | ExpressionKind::Nt(_)
+            | ExpressionKind::Terminal(_)
+            | ExpressionKind::Prose(_)
+            | ExpressionKind::Break(_)
+            | ExpressionKind::Charset(_)
+            | ExpressionKind::NegExpression(_)
+            | ExpressionKind::Unicode(_) => &self.kind,
+        }
+    }
+
+    fn render_markdown(&self, link_map: &HashMap<String, String>, output: &mut String) {
+        match &self.kind {
+            ExpressionKind::Grouped(e) => {
+                output.push_str("( ");
+                e.render_markdown(link_map, output);
+                if !matches!(e.last(), ExpressionKind::Break(_)) {
+                    output.push(' ');
+                }
+                output.push(')');
+            }
+            ExpressionKind::Alt(es) => {
+                let mut iter = es.iter().peekable();
+                while let Some(e) = iter.next() {
+                    e.render_markdown(link_map, output);
+                    if iter.peek().is_some() {
+                        if !matches!(e.last(), ExpressionKind::Break(_)) {
+                            output.push(' ');
+                        }
+                        output.push_str("| ");
+                    }
+                }
+            }
+            ExpressionKind::Sequence(es) => {
+                let mut iter = es.iter().peekable();
+                while let Some(e) = iter.next() {
+                    e.render_markdown(link_map, output);
+                    if iter.peek().is_some() && !matches!(e.last(), ExpressionKind::Break(_)) {
+                        output.push(' ');
+                    }
+                }
+            }
+            ExpressionKind::Optional(e) => {
+                e.render_markdown(link_map, output);
+                output.push_str("<sup>?</sup>");
+            }
+            ExpressionKind::Repeat(e) => {
+                e.render_markdown(link_map, output);
+                output.push_str("<sup>\\*</sup>");
+            }
+            ExpressionKind::RepeatNonGreedy(e) => {
+                e.render_markdown(link_map, output);
+                output.push_str("<sup>\\* (non-greedy)</sup>");
+            }
+            ExpressionKind::RepeatPlus(e) => {
+                e.render_markdown(link_map, output);
+                output.push_str("<sup>+</sup>");
+            }
+            ExpressionKind::RepeatPlusNonGreedy(e) => {
+                e.render_markdown(link_map, output);
+                output.push_str("<sup>+ (non-greedy)</sup>");
+            }
+            ExpressionKind::RepeatRange(e, a, b) => {
+                e.render_markdown(link_map, output);
+                write!(
+                    output,
+                    "<sup>{}..{}</sup>",
+                    a.map(|v| v.to_string()).unwrap_or_default(),
+                    b.map(|v| v.to_string()).unwrap_or_default(),
+                )
+                .unwrap();
+            }
+            ExpressionKind::Nt(nt) => {
+                let dest = link_map.get(nt).map_or("missing", |d| d.as_str());
+                write!(output, "<span class=\"grammar-text\">[{nt}]({dest})</span>").unwrap();
+            }
+            ExpressionKind::Terminal(t) => {
+                write!(
+                    output,
+                    "<span class=\"grammar-literal\">{}</span>",
+                    markdown_escape(t)
+                )
+                .unwrap();
+            }
+            ExpressionKind::Prose(s) => {
+                write!(output, "<span class=\"grammar-text\">\\<{s}\\></span>").unwrap();
+            }
+            ExpressionKind::Break(indent) => {
+                output.push_str("\\\n");
+                output.push_str(&"&nbsp;".repeat(*indent));
+            }
+            ExpressionKind::Charset(set) => charset_render_markdown(set, link_map, output),
+            ExpressionKind::NegExpression(e) => {
+                output.push('~');
+                e.render_markdown(link_map, output);
+            }
+            ExpressionKind::Unicode(s) => {
+                output.push_str("U+");
+                output.push_str(s);
+            }
+        }
+        if let Some(suffix) = &self.suffix {
+            write!(output, "<sub class=\"grammar-text\">{suffix}</sub>").unwrap();
+        }
+        if let Some(footnote) = &self.footnote {
+            // The ZeroWidthSpace is to avoid conflicts with markdown link references.
+            write!(output, "&ZeroWidthSpace;[^{footnote}]").unwrap();
+        }
+    }
+}
+
+fn charset_render_markdown(
+    set: &[Characters],
+    link_map: &HashMap<String, String>,
+    output: &mut String,
+) {
+    output.push_str("\\[");
+    let mut iter = set.iter().peekable();
+    while let Some(chars) = iter.next() {
+        chars.render_markdown(link_map, output);
+        if iter.peek().is_some() {
+            output.push(' ');
+        }
+    }
+    output.push(']');
+}
+
+impl Characters {
+    fn render_markdown(&self, link_map: &HashMap<String, String>, output: &mut String) {
+        match self {
+            Characters::Named(s) => {
+                let dest = link_map.get(s).map_or("missing", |d| d.as_str());
+                write!(output, "[{s}]({dest})").unwrap();
+            }
+            Characters::Terminal(s) => write!(
+                output,
+                "<span class=\"grammar-literal\">{}</span>",
+                markdown_escape(s)
+            )
+            .unwrap(),
+            Characters::Range(a, b) => write!(
+                output,
+                "<span class=\"grammar-literal\">{a}\
+                 </span>-<span class=\"grammar-literal\">{b}</span>"
+            )
+            .unwrap(),
+        }
+    }
+}
+
+/// Escapes characters that markdown would otherwise interpret.
+fn markdown_escape(s: &str) -> Cow<'_, str> {
+    static ESC_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"[\\`_*\[\](){}'"]"#).unwrap());
+    ESC_RE.replace_all(s, r"\$0")
+}

--- a/mdbook-spec/src/grammar/render_markdown.rs
+++ b/mdbook-spec/src/grammar/render_markdown.rs
@@ -14,6 +14,7 @@ impl Grammar {
         &self,
         names: &[&str],
         link_map: &HashMap<String, String>,
+        rr_link_map: &HashMap<String, String>,
         output: &mut String,
         for_summary: bool,
     ) -> anyhow::Result<()> {
@@ -23,7 +24,7 @@ impl Grammar {
                 Some(p) => p,
                 None => bail!("could not find grammar production named `{name}`"),
             };
-            prod.render_markdown(link_map, output, for_summary);
+            prod.render_markdown(link_map, rr_link_map, output, for_summary);
             if iter.peek().is_some() {
                 output.push_str("\n");
             }
@@ -45,14 +46,23 @@ impl Production {
     fn render_markdown(
         &self,
         link_map: &HashMap<String, String>,
+        rr_link_map: &HashMap<String, String>,
         output: &mut String,
         for_summary: bool,
     ) {
+        let dest = rr_link_map
+            .get(&self.name)
+            .map(|path| path.to_string())
+            .unwrap_or_else(|| format!("missing"));
         write!(
             output,
-            "<span class=\"grammar-text grammar-production\" id=\"{id}\">{name}</span> → ",
+            "<span class=\"grammar-text grammar-production\" id=\"{id}\" \
+               onclick=\"show_railroad()\"\
+             >\
+               [{name}]({dest})\
+             </span> → ",
             id = markdown_id(&self.name, for_summary),
-            name = self.name
+            name = self.name,
         )
         .unwrap();
         self.expression.render_markdown(link_map, output);

--- a/mdbook-spec/src/grammar/render_markdown.rs
+++ b/mdbook-spec/src/grammar/render_markdown.rs
@@ -20,9 +20,8 @@ impl Grammar {
     ) -> anyhow::Result<()> {
         let mut iter = names.into_iter().peekable();
         while let Some(name) = iter.next() {
-            let prod = match self.productions.get(*name) {
-                Some(p) => p,
-                None => bail!("could not find grammar production named `{name}`"),
+            let Some(prod) = self.productions.get(*name) else {
+                bail!("could not find grammar production named `{name}`");
             };
             prod.render_markdown(link_map, rr_link_map, output, for_summary);
             if iter.peek().is_some() {

--- a/mdbook-spec/src/grammar/render_railroad.rs
+++ b/mdbook-spec/src/grammar/render_railroad.rs
@@ -163,15 +163,12 @@ impl Expression {
                 Box::new(Optional::new(n))
             }
             ExpressionKind::Repeat(e) => {
-                // Railroad renders everything in the opposite order. However,
-                // our grammar is not written that way, so we need to undo the
-                // reversal.
-                let n = e.render_railroad(stack, link_map, !reverse)?;
-                Box::new(Repeat::new(railroad::Empty, n))
+                let n = e.render_railroad(stack, link_map, reverse)?;
+                Box::new(Optional::new(Repeat::new(n, railroad::Empty)))
             }
             ExpressionKind::RepeatNonGreedy(e) => {
-                let n = e.render_railroad(stack, link_map, !reverse)?;
-                let r = Box::new(Repeat::new(railroad::Empty, n));
+                let n = e.render_railroad(stack, link_map, reverse)?;
+                let r = Box::new(Optional::new(Repeat::new(n, railroad::Empty)));
                 let lbox = LabeledBox::new(r, Comment::new("non-greedy".to_string()));
                 Box::new(lbox)
             }

--- a/mdbook-spec/src/grammar/render_railroad.rs
+++ b/mdbook-spec/src/grammar/render_railroad.rs
@@ -1,0 +1,235 @@
+//! Converts a [`Grammar`] to an SVG railroad diagram.
+
+use super::{Characters, Expression, ExpressionKind, Production};
+use crate::grammar::Grammar;
+use anyhow::bail;
+use railroad::*;
+use regex::Regex;
+use std::collections::HashMap;
+use std::fmt::Write;
+use std::sync::LazyLock;
+
+impl Grammar {
+    pub fn render_railroad(
+        &self,
+        names: &[&str],
+        link_map: &HashMap<String, String>,
+        output: &mut String,
+        for_summary: bool,
+    ) -> anyhow::Result<()> {
+        for name in names {
+            let prod = match self.productions.get(*name) {
+                Some(p) => p,
+                None => bail!("could not find grammar production named `{name}`"),
+            };
+            prod.render_railroad(link_map, output, for_summary);
+        }
+        Ok(())
+    }
+}
+
+/// The HTML id for the production.
+pub fn railroad_id(name: &str, for_summary: bool) -> String {
+    if for_summary {
+        format!("railroad-summary-{}", name)
+    } else {
+        format!("railroad-{}", name)
+    }
+}
+
+impl Production {
+    fn render_railroad(
+        &self,
+        link_map: &HashMap<String, String>,
+        output: &mut String,
+        for_summary: bool,
+    ) {
+        let mut dia = self.make_diagram(false, link_map);
+        // If the diagram is very wide, try stacking it to reduce the width.
+        // This 900 is somewhat arbitrary based on looking at productions that
+        // looked too squished. If your diagram is still too squished,
+        // consider adding more rules to shorten it.
+        if dia.width() > 900 {
+            dia = self.make_diagram(true, link_map);
+        }
+        writeln!(
+            output,
+            "<div style=\"width: {width}px; height: auto; max-width: 100%; max-height: 100%\" \
+                class=\"railroad-production\" \
+                id=\"{id}\">{dia}</div>",
+            width = dia.width(),
+            id = railroad_id(&self.name, for_summary),
+        )
+        .unwrap();
+    }
+
+    fn make_diagram(
+        &self,
+        stack: bool,
+        link_map: &HashMap<String, String>,
+    ) -> Diagram<Box<dyn Node>> {
+        let n = self.expression.render_railroad(stack, link_map);
+        let seq: Sequence<Box<dyn Node>> =
+            Sequence::new(vec![Box::new(SimpleStart), n.unwrap(), Box::new(SimpleEnd)]);
+        let vert = VerticalGrid::<Box<dyn Node>>::new(vec![
+            Box::new(Comment::new(self.name.clone())),
+            Box::new(seq),
+        ]);
+
+        Diagram::new(Box::new(vert))
+    }
+}
+
+impl Expression {
+    fn render_railroad(
+        &self,
+        stack: bool,
+        link_map: &HashMap<String, String>,
+    ) -> Option<Box<dyn Node>> {
+        let n: Box<dyn Node> = match &self.kind {
+            ExpressionKind::Grouped(e) => {
+                // I don't think this needs anything special. The grouped
+                // expression is usually an Alt or Optional or something like
+                // that which ends up as a distinct railroad node. But I'm not
+                // sure.
+                e.render_railroad(stack, link_map)?
+            }
+            ExpressionKind::Alt(es) => {
+                let choices: Vec<_> = es
+                    .iter()
+                    .map(|e| e.render_railroad(stack, link_map))
+                    .filter_map(|n| n)
+                    .collect();
+                Box::new(Choice::<Box<dyn Node>>::new(choices))
+            }
+            ExpressionKind::Sequence(es) => {
+                let make_seq = |es: &[Expression]| {
+                    let seq: Vec<_> = es
+                        .iter()
+                        .map(|e| e.render_railroad(stack, link_map))
+                        .filter_map(|n| n)
+                        .collect();
+                    let seq: Sequence<Box<dyn Node>> = Sequence::new(seq);
+                    Box::new(seq)
+                };
+
+                // If `stack` is true, split the sequence on Breaks and stack them vertically.
+                if stack {
+                    // First, trim a Break from the front and back.
+                    let es = if matches!(
+                        es.first(),
+                        Some(e) if e.is_break()
+                    ) {
+                        &es[1..]
+                    } else {
+                        &es[..]
+                    };
+                    let es = if matches!(
+                        es.last(),
+                        Some(e) if e.is_break()
+                    ) {
+                        &es[..es.len() - 1]
+                    } else {
+                        &es[..]
+                    };
+
+                    let mut breaks: Vec<_> =
+                        es.split(|e| e.is_break()).map(|es| make_seq(es)).collect();
+                    // If there aren't any breaks, don't bother stacking.
+                    if breaks.len() == 1 {
+                        breaks.pop().unwrap()
+                    } else {
+                        Box::new(Stack::new(breaks))
+                    }
+                } else {
+                    make_seq(es)
+                }
+            }
+            ExpressionKind::Optional(e) => {
+                let n = e.render_railroad(stack, link_map)?;
+                Box::new(Optional::new(n))
+            }
+            ExpressionKind::Repeat(e) => {
+                let n = e.render_railroad(stack, link_map)?;
+                Box::new(Repeat::new(railroad::Empty, n))
+            }
+            ExpressionKind::RepeatNonGreedy(e) => {
+                let n = e.render_railroad(stack, link_map)?;
+                let r = Box::new(Repeat::new(railroad::Empty, n));
+                let lbox = LabeledBox::new(r, Comment::new("non-greedy".to_string()));
+                Box::new(lbox)
+            }
+            ExpressionKind::RepeatPlus(e) => {
+                let n = e.render_railroad(stack, link_map)?;
+                Box::new(Repeat::new(n, railroad::Empty))
+            }
+            ExpressionKind::RepeatPlusNonGreedy(e) => {
+                let n = e.render_railroad(stack, link_map)?;
+                let r = Repeat::new(n, railroad::Empty);
+                let lbox = LabeledBox::new(r, Comment::new("non-greedy".to_string()));
+                Box::new(lbox)
+            }
+            ExpressionKind::RepeatRange(e, a, b) => {
+                let n = e.render_railroad(stack, link_map)?;
+                let cmt = match (a, b) {
+                    (Some(a), Some(b)) => format!("repeat between {a} and {b} times"),
+                    (None, Some(b)) => format!("repeat at most {b} times"),
+                    (Some(a), None) => format!("repeat at least {a} times"),
+                    (None, None) => panic!("infinite repeat should use *"),
+                };
+                let r = Repeat::new(n, Comment::new(cmt));
+                Box::new(r)
+            }
+            ExpressionKind::Nt(nt) => node_for_nt(link_map, nt),
+            ExpressionKind::Terminal(t) => Box::new(Terminal::new(t.clone())),
+            ExpressionKind::Prose(s) => Box::new(Terminal::new(s.clone())),
+            ExpressionKind::Break(_) => return None,
+            ExpressionKind::Charset(set) => {
+                let ns: Vec<_> = set.iter().map(|c| c.render_railroad(link_map)).collect();
+                Box::new(Choice::<Box<dyn Node>>::new(ns))
+            }
+            ExpressionKind::NegExpression(e) => {
+                let n = e.render_railroad(stack, link_map)?;
+                let lbox = LabeledBox::new(n, Comment::new("any character except".to_string()));
+                Box::new(lbox)
+            }
+            ExpressionKind::Unicode(s) => Box::new(Terminal::new(format!("U+{}", s))),
+        };
+        if let Some(suffix) = &self.suffix {
+            let suffix = strip_markdown(suffix);
+            let lbox = LabeledBox::new(n, Comment::new(suffix));
+            return Some(Box::new(lbox));
+        }
+        // Note: Footnotes aren't supported. They could be added as a comment
+        // on a vertical stack or a LabeledBox or something like that, but I
+        // don't feel like bothering.
+        Some(n)
+    }
+}
+
+impl Characters {
+    fn render_railroad(&self, link_map: &HashMap<String, String>) -> Box<dyn Node> {
+        match self {
+            Characters::Named(s) => node_for_nt(link_map, s),
+            Characters::Terminal(s) => Box::new(Terminal::new(s.clone())),
+            Characters::Range(a, b) => Box::new(Terminal::new(format!("{a}-{b}"))),
+        }
+    }
+}
+
+fn node_for_nt(link_map: &HashMap<String, String>, name: &str) -> Box<dyn Node> {
+    let dest = link_map
+        .get(name)
+        .map(|path| path.to_string())
+        .unwrap_or_else(|| format!("missing"));
+    let n = NonTerminal::new(name.to_string());
+    Box::new(Link::new(n, dest))
+}
+
+/// Removes some markdown so it can be rendered as text.
+fn strip_markdown(s: &str) -> String {
+    // Right now this just removes markdown linkifiers, but more can be added if needed.
+    static LINK_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?s)\[([^\]]+)\](?:\[[^\]]*\]|\([^)]*\))?").unwrap());
+    LINK_RE.replace_all(s, "$1").to_string()
+}

--- a/mdbook-spec/src/lib.rs
+++ b/mdbook-spec/src/lib.rs
@@ -27,7 +27,7 @@ static ADMONITION_RE: Lazy<Regex> = Lazy::new(|| {
 
 /// A primitive regex to find link reference definitions.
 static MD_LINK_REFERENCE_DEFINITION: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?m)^\[(?<label>[^]]+)]: (?<dest>.*)").unwrap());
+    Lazy::new(|| Regex::new(r"(?m)^\[(?<label>[^]]+)]: +(?<dest>.*)").unwrap());
 
 pub fn handle_preprocessing() -> Result<(), Error> {
     let pre = Spec::new(None)?;

--- a/mdbook-spec/src/lib.rs
+++ b/mdbook-spec/src/lib.rs
@@ -14,6 +14,7 @@ use std::io;
 use std::ops::Range;
 use std::path::PathBuf;
 
+pub mod grammar;
 mod rules;
 mod std_links;
 mod test_links;
@@ -268,6 +269,7 @@ impl Preprocessor for Spec {
         if diag.deny_warnings && self.rust_root.is_none() {
             bail!("error: SPEC_RUST_ROOT environment variable must be set");
         }
+        let grammar = grammar::load_grammar(&book, &mut diag);
         let rules = self.collect_rules(&book, &mut diag);
         let tests = self.collect_tests(&rules);
         let summary_table = test_links::make_summary_table(&book, &tests, &rules);
@@ -293,6 +295,10 @@ impl Preprocessor for Spec {
             if ch.name == "Test summary" {
                 ch.content = ch.content.replace("{{summary-table}}", &summary_table);
             }
+            if grammar::is_summary(ch) {
+                ch.content = grammar::insert_summary(&grammar, &ch, &mut diag);
+            }
+            ch.content = grammar::insert_grammar(&grammar, &ch, &mut diag);
         });
 
         // Final pass will resolve everything as a std link (or error if the

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -132,6 +132,7 @@
 - [The Rust runtime](runtime.md)
 
 - [Appendices](appendices.md)
+    - [Grammar summary](grammar.md)
     - [Macro Follow-Set Ambiguity Formal Specification](macro-ambiguity.md)
     - [Influences](influences.md)
     - [Test summary](test-summary.md)

--- a/src/abi.md
+++ b/src/abi.md
@@ -81,7 +81,7 @@ extern "C" fn foo() {}
 
 The *`link_section` attribute* specifies the section of the object file that a
 [function] or [static]'s content will be placed into. It uses the
-[_MetaNameValueStr_] syntax to specify the section name.
+[MetaNameValueStr] syntax to specify the section name.
 
 This attribute is unsafe as it allows users to place data and code into sections
 of memory not expecting them, such as mutable data into read-only areas.
@@ -99,7 +99,7 @@ pub static VAR1: u32 = 1;
 ## The `export_name` attribute
 
 The *`export_name` attribute* specifies the name of the symbol that will be
-exported on a [function] or [static]. It uses the [_MetaNameValueStr_] syntax
+exported on a [function] or [static]. It uses the [MetaNameValueStr] syntax
 to specify the symbol name.
 
 This attribute is unsafe as a symbol with a custom name may collide with another
@@ -114,7 +114,6 @@ pub fn name_in_rust() { }
 > [!EDITION-2024]
 > Before the 2024 edition it is allowed to use the `export_name` attribute without the `unsafe` qualification.
 
-[_MetaNameValueStr_]: attributes.md#meta-item-attribute-syntax
 [`static` items]: items/static-items.md
 [attribute]: attributes.md
 [extern functions]: items/functions.md#extern-function-qualifier

--- a/src/attributes.md
+++ b/src/attributes.md
@@ -164,19 +164,19 @@ forms:
 
 r[attributes.meta.builtin.syntax]
 ```grammar,attributes
-MetaWord ->
+@root MetaWord ->
     IDENTIFIER
 
 MetaNameValueStr ->
     IDENTIFIER `=` (STRING_LITERAL | RAW_STRING_LITERAL)
 
-MetaListPaths ->
+@root MetaListPaths ->
     IDENTIFIER `(` ( SimplePath (`,` SimplePath)* `,`? )? `)`
 
-MetaListIdents ->
+@root MetaListIdents ->
     IDENTIFIER `(` ( IDENTIFIER (`,` IDENTIFIER)* `,`? )? `)`
 
-MetaListNameValueStr ->
+@root MetaListNameValueStr ->
     IDENTIFIER `(` ( MetaNameValueStr (`,` MetaNameValueStr)* `,`? )? `)`
 ```
 

--- a/src/attributes.md
+++ b/src/attributes.md
@@ -161,6 +161,7 @@ Various built-in attributes use different subsets of the meta item syntax to
 specify their inputs. The following grammar rules show some commonly used
 forms:
 
+r[attributes.meta.builtin.syntax]
 > **<sup>Syntax</sup>**\
 > _MetaWord_:\
 > &nbsp;&nbsp; [IDENTIFIER]

--- a/src/attributes.md
+++ b/src/attributes.md
@@ -1,4 +1,5 @@
 {{#include attributes-redirect.html}}
+r[attributes]
 # Attributes
 
 r[attributes.syntax]

--- a/src/attributes.md
+++ b/src/attributes.md
@@ -3,20 +3,19 @@ r[attributes]
 # Attributes
 
 r[attributes.syntax]
-> **<sup>Syntax</sup>**\
-> _InnerAttribute_ :\
-> &nbsp;&nbsp; `#` `!` `[` _Attr_ `]`
->
-> _OuterAttribute_ :\
-> &nbsp;&nbsp; `#` `[` _Attr_ `]`
->
-> _Attr_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_SimplePath_] _AttrInput_<sup>?</sup>\
-> &nbsp;&nbsp; | `unsafe` `(` [_SimplePath_] _AttrInput_<sup>?</sup> `)`
->
-> _AttrInput_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_DelimTokenTree_]\
-> &nbsp;&nbsp; | `=` [_Expression_]
+```grammar,attributes
+InnerAttribute -> `#` `!` `[` Attr `]`
+
+OuterAttribute -> `#` `[` Attr `]`
+
+Attr ->
+      SimplePath AttrInput?
+    | `unsafe` `(` SimplePath AttrInput? `)`
+
+AttrInput ->
+      DelimTokenTree
+    | `=` Expression
+```
 
 r[attributes.intro]
 An _attribute_ is a general, free-form metadatum that is interpreted according
@@ -114,18 +113,19 @@ A "meta item" is the syntax used for the _Attr_ rule by most [built-in
 attributes]. It has the following grammar:
 
 r[attributes.meta.syntax]
-> **<sup>Syntax</sup>**\
-> _MetaItem_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_SimplePath_]\
-> &nbsp;&nbsp; | [_SimplePath_] `=` [_Expression_]\
-> &nbsp;&nbsp; | [_SimplePath_] `(` _MetaSeq_<sup>?</sup> `)`
->
-> _MetaSeq_ :\
-> &nbsp;&nbsp; _MetaItemInner_ ( `,` MetaItemInner )<sup>\*</sup> `,`<sup>?</sup>
->
-> _MetaItemInner_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; _MetaItem_\
-> &nbsp;&nbsp; | [_Expression_]
+```grammar,attributes
+MetaItem ->
+      SimplePath
+    | SimplePath `=` Expression
+    | SimplePath `(` MetaSeq? `)`
+
+MetaSeq ->
+    MetaItemInner ( `,` MetaItemInner )* `,`?
+
+MetaItemInner ->
+      MetaItem
+    | Expression
+```
 
 r[attributes.meta.literal-expr]
 Expressions in meta items must macro-expand to literal expressions, which must not
@@ -163,21 +163,22 @@ specify their inputs. The following grammar rules show some commonly used
 forms:
 
 r[attributes.meta.builtin.syntax]
-> **<sup>Syntax</sup>**\
-> _MetaWord_:\
-> &nbsp;&nbsp; [IDENTIFIER]
->
-> _MetaNameValueStr_:\
-> &nbsp;&nbsp; [IDENTIFIER] `=` ([STRING_LITERAL] | [RAW_STRING_LITERAL])
->
-> _MetaListPaths_:\
-> &nbsp;&nbsp; [IDENTIFIER] `(` ( [_SimplePath_] (`,` [_SimplePath_])* `,`<sup>?</sup> )<sup>?</sup> `)`
->
-> _MetaListIdents_:\
-> &nbsp;&nbsp; [IDENTIFIER] `(` ( [IDENTIFIER] (`,` [IDENTIFIER])* `,`<sup>?</sup> )<sup>?</sup> `)`
->
-> _MetaListNameValueStr_:\
-> &nbsp;&nbsp; [IDENTIFIER] `(` ( _MetaNameValueStr_ (`,` _MetaNameValueStr_)* `,`<sup>?</sup> )<sup>?</sup> `)`
+```grammar,attributes
+MetaWord ->
+    IDENTIFIER
+
+MetaNameValueStr ->
+    IDENTIFIER `=` (STRING_LITERAL | RAW_STRING_LITERAL)
+
+MetaListPaths ->
+    IDENTIFIER `(` ( SimplePath (`,` SimplePath)* `,`? )? `)`
+
+MetaListIdents ->
+    IDENTIFIER `(` ( IDENTIFIER (`,` IDENTIFIER)* `,`? )? `)`
+
+MetaListNameValueStr ->
+    IDENTIFIER `(` ( MetaNameValueStr (`,` MetaNameValueStr)* `,`? )? `)`
+```
 
 Some examples of meta items are:
 
@@ -331,14 +332,8 @@ The following is an index of all built-in attributes.
 [ECMA-334]: https://www.ecma-international.org/publications-and-standards/standards/ecma-334/
 [ECMA-335]: https://www.ecma-international.org/publications-and-standards/standards/ecma-335/
 [Expression Attributes]: expressions.md#expression-attributes
-[IDENTIFIER]: identifiers.md
-[RAW_STRING_LITERAL]: tokens.md#raw-string-literals
-[STRING_LITERAL]: tokens.md#string-literals
 [The Rustdoc Book]: ../rustdoc/the-doc-attribute.html
 [The Unstable Book]: ../unstable-book/index.html
-[_DelimTokenTree_]: macros.md
-[_Expression_]: expressions.md
-[_SimplePath_]: paths.md#simple-paths
 [`allow`]: attributes/diagnostics.md#lint-check-attributes
 [`automatically_derived`]: attributes/derive.md#the-automatically_derived-attribute
 [`cfg_attr`]: conditional-compilation.md#the-cfg_attr-attribute

--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -59,7 +59,7 @@ r[attributes.codegen.target_feature]
 r[attributes.codegen.target_feature.intro]
 The *`target_feature` [attribute]* may be applied to a function to
 enable code generation of that function for specific platform architecture
-features. It uses the [_MetaListNameValueStr_] syntax with a single key of
+features. It uses the [MetaListNameValueStr] syntax with a single key of
 `enable` whose value is a string of comma-separated feature names to enable.
 
 ```rust
@@ -495,7 +495,6 @@ trait object whose methods are attributed.
 > [!NOTE]
 > The aforementioned shim for function pointers is necessary because `rustc` implements `track_caller` in a codegen context by appending an implicit parameter to the function ABI, but this would be unsound for an indirect call because the parameter is not a part of the function's type and a given function pointer type may or may not refer to a function with the attribute. The creation of a shim hides the implicit parameter from callers of the function pointer, preserving soundness.
 
-[_MetaListNameValueStr_]: ../attributes.md#meta-item-attribute-syntax
 [`-C target-cpu`]: ../../rustc/codegen-options/index.html#target-cpu
 [`-C target-feature`]: ../../rustc/codegen-options/index.html#target-feature
 [`is_x86_feature_detected`]: ../../std/arch/macro.is_x86_feature_detected.html

--- a/src/attributes/debugger.md
+++ b/src/attributes/debugger.md
@@ -11,7 +11,7 @@ The *`debugger_visualizer` attribute* can be used to embed a debugger visualizer
 This enables an improved debugger experience for displaying values in the debugger.
 
 r[attributes.debugger.debugger_visualizer.syntax]
-It uses the [_MetaListNameValueStr_] syntax to specify its inputs, and must be specified as a crate attribute.
+It uses the [MetaListNameValueStr] syntax to specify its inputs, and must be specified as a crate attribute.
 
 r[attributes.debugger.debugger_visualizer.natvis]
 ### Using `debugger_visualizer` with Natvis
@@ -150,7 +150,6 @@ When the crate's debug executable is passed into GDB[^rust-gdb], `print bob` wil
 [attributes]: ../attributes.md
 [Natvis documentation]: https://docs.microsoft.com/en-us/visualstudio/debugger/create-custom-views-of-native-objects
 [pretty printing documentation]: https://sourceware.org/gdb/onlinedocs/gdb/Pretty-Printing.html
-[_MetaListNameValueStr_]: ../attributes.md#meta-item-attribute-syntax
 
 r[attributes.debugger.collapse_debuginfo]
 ## The `collapse_debuginfo` attribute
@@ -160,7 +159,7 @@ The *`collapse_debuginfo` [attribute]* controls whether code locations from a ma
 when generating debuginfo for code calling this macro.
 
 r[attributes.debugger.collapse_debuginfo.syntax]
-The attribute uses the [_MetaListIdents_] syntax to specify its inputs, and can only be applied to macro definitions.
+The attribute uses the [MetaListIdents] syntax to specify its inputs, and can only be applied to macro definitions.
 
 r[attributes.debugger.collapse_debuginfo.options]
 Accepted options:
@@ -185,4 +184,3 @@ macro_rules! example {
 ```
 
 [attribute]: ../attributes.md
-[_MetaListIdents_]: ../attributes.md#meta-item-attribute-syntax

--- a/src/attributes/derive.md
+++ b/src/attributes/derive.md
@@ -6,7 +6,7 @@ The *`derive` attribute* allows new [items] to be automatically generated for
 data structures.
 
 r[attributes.derive.syntax]
-It uses the [_MetaListPaths_] syntax to specify a list of
+It uses the [MetaListPaths] syntax to specify a list of
 traits to implement or paths to [derive macros] to process.
 
 For example, the following will create an [`impl` item] for the
@@ -43,7 +43,6 @@ The *`automatically_derived` attribute* is automatically added to
 has no direct effect, but it may be used by tools and diagnostic lints to
 detect these automatically generated implementations.
 
-[_MetaListPaths_]: ../attributes.md#meta-item-attribute-syntax
 [`impl` item]: ../items/implementations.md
 [items]: ../items.md
 [derive macros]: ../procedural-macros.md#derive-macros

--- a/src/attributes/diagnostics.md
+++ b/src/attributes/diagnostics.md
@@ -12,7 +12,7 @@ unreachable code or omitted documentation.
 
 r[attributes.diagnostics.lint.level]
 The lint attributes `allow`,
-`expect`, `warn`, `deny`, and `forbid` use the [_MetaListPaths_] syntax
+`expect`, `warn`, `deny`, and `forbid` use the [MetaListPaths] syntax
 to specify a list of lint names to change the lint level for the entity
 to which the attribute applies.
 
@@ -313,7 +313,7 @@ The `deprecated` attribute has several forms:
 - `deprecated` --- Issues a generic message.
 - `deprecated = "message"` --- Includes the given string in the deprecation
   message.
-- [_MetaListNameValueStr_] syntax with two optional fields:
+- [MetaListNameValueStr] syntax with two optional fields:
   - `since` --- Specifies a version number when the item was deprecated. `rustc`
     does not currently interpret the string, but external tools like [Clippy]
     may check the validity of the value.
@@ -359,7 +359,7 @@ and [traits].
 
 r[attributes.diagnostics.must_use.message]
 The `must_use` attribute may include a message by using the
-[_MetaNameValueStr_] syntax such as `#[must_use = "example message"]`. The
+[MetaNameValueStr] syntax such as `#[must_use = "example message"]`. The
 message will be given alongside the warning.
 
 r[attributes.diagnostics.must_use.type]
@@ -483,7 +483,7 @@ r[attributes.diagnostic.on_unimplemented.allowed-positions]
 The attribute should be placed on a [trait declaration], though it is not an error to be located in other positions.
 
 r[attributes.diagnostic.on_unimplemented.syntax]
-The attribute uses the [_MetaListNameValueStr_] syntax to specify its inputs, though any malformed input to the attribute is not considered as an error to provide both forwards and backwards compatibility.
+The attribute uses the [MetaListNameValueStr] syntax to specify its inputs, though any malformed input to the attribute is not considered as an error to provide both forwards and backwards compatibility.
 
 r[attributes.diagnostic.on_unimplemented.keys]
 The following keys have the given meaning:
@@ -663,9 +663,6 @@ error[E0277]: the trait bound `&str: AsExpression<Integer>` is not satisfied
 The first error message includes a somewhat confusing error message about the relationship of `&str` and `Expression`, as well as the unsatisfied trait bound in the blanket impl. After adding `#[diagnostic::do_not_recommend]`, it no longer considers the blanket impl for the recommendation. The message should be a little clearer, with an indication that a string cannot be converted to an `Integer`.
 
 [Clippy]: https://github.com/rust-lang/rust-clippy
-[_MetaListNameValueStr_]: ../attributes.md#meta-item-attribute-syntax
-[_MetaListPaths_]: ../attributes.md#meta-item-attribute-syntax
-[_MetaNameValueStr_]: ../attributes.md#meta-item-attribute-syntax
 [`Drop`]: ../special-types-and-traits.md#drop
 [attributes]: ../attributes.md
 [block expression]: ../expressions/block-expr.md

--- a/src/attributes/limits.md
+++ b/src/attributes/limits.md
@@ -12,7 +12,7 @@ maximum depth for potentially infinitely-recursive compile-time operations
 like macro expansion or auto-dereference.
 
 r[attributes.limits.recursion_limit.syntax]
-It uses the [_MetaNameValueStr_]
+It uses the [MetaNameValueStr]
 syntax to specify the recursion depth.
 
 > [!NOTE]
@@ -53,7 +53,7 @@ The *`type_length_limit` attribute* limits the maximum number of type
 substitutions made when constructing a concrete type during monomorphization.
 
 r[attributes.limits.type_length_limit.syntax]
-It is applied at the [crate] level, and uses the [_MetaNameValueStr_] syntax
+It is applied at the [crate] level, and uses the [MetaNameValueStr] syntax
 to set the limit based on the number of type substitutions.
 
 > [!NOTE]
@@ -69,6 +69,5 @@ fn f<T>(x: T) {}
 f(((((1,), 2), 3), 4));
 ```
 
-[_MetaNameValueStr_]: ../attributes.md#meta-item-attribute-syntax
 [attributes]: ../attributes.md
 [crate]: ../crates-and-source-files.md

--- a/src/attributes/testing.md
+++ b/src/attributes/testing.md
@@ -57,7 +57,7 @@ A function annotated with the `test` attribute can also be annotated with the
 execute that function as a test. It will still be compiled when in test mode.
 
 r[attributes.testing.ignore.syntax]
-The `ignore` attribute may optionally be written with the [_MetaNameValueStr_]
+The `ignore` attribute may optionally be written with the [MetaNameValueStr]
 syntax to specify a reason why the test is ignored.
 
 ```rust
@@ -86,7 +86,7 @@ r[attributes.testing.should_panic.syntax]
 The `should_panic` attribute may optionally take an input string that must
 appear within the panic message. If the string is not found in the message,
 then the test will fail. The string may be passed using the
-[_MetaNameValueStr_] syntax or the [_MetaListNameValueStr_] syntax with an
+[MetaNameValueStr] syntax or the [MetaListNameValueStr] syntax with an
 `expected` field.
 
 ```rust
@@ -97,8 +97,6 @@ fn mytest() {
 }
 ```
 
-[_MetaListNameValueStr_]: ../attributes.md#meta-item-attribute-syntax
-[_MetaNameValueStr_]: ../attributes.md#meta-item-attribute-syntax
 [`Termination`]: std::process::Termination
 [`report`]: std::process::Termination::report
 [`test` conditional compilation option]: ../conditional-compilation.md#test

--- a/src/attributes/type_system.md
+++ b/src/attributes/type_system.md
@@ -14,7 +14,7 @@ r[attributes.type-system.non_exhaustive.allowed-positions]
 It can be applied to [`struct`s][struct], [`enum`s][enum], and `enum` variants.
 
 r[attributes.type-system.non_exhaustive.syntax]
-The `non_exhaustive` attribute uses the [_MetaWord_] syntax and thus does not
+The `non_exhaustive` attribute uses the [MetaWord] syntax and thus does not
 take any inputs.
 
 r[attributes.type-system.non_exhaustive.same-crate]
@@ -80,7 +80,7 @@ r[attributes.type-system.non_exhaustive.construction]
 Non-exhaustive types cannot be constructed outside of the defining crate:
 
 - Non-exhaustive variants ([`struct`][struct] or [`enum` variant][enum]) cannot be constructed
-  with a [_StructExpression_] \(including with [functional update syntax]).
+  with a [StructExpression] \(including with [functional update syntax]).
 - The implicitly defined same-named constant of a [unit-like struct][struct],
   or the same-named constructor function of a [tuple struct][struct],
   has a [visibility] no greater than `pub(crate)`.
@@ -132,7 +132,7 @@ r[attributes.type-system.non_exhaustive.match]
 There are limitations when matching on non-exhaustive types outside of the defining crate:
 
 - When pattern matching on a non-exhaustive variant ([`struct`][struct] or [`enum` variant][enum]),
-  a [_StructPattern_] must be used which must include a `..`. A tuple variant's constructor's
+  a [StructPattern] must be used which must include a `..`. A tuple variant's constructor's
   [visibility] is reduced to be no greater than `pub(crate)`.
 - When pattern matching on a non-exhaustive [`enum`][enum], matching on a variant does not
   contribute towards the exhaustiveness of the arms.
@@ -206,10 +206,6 @@ let _ = EnumWithNonExhaustiveVariants::First as u8;
 
 Non-exhaustive types are always considered inhabited in downstream crates.
 
-[_MetaWord_]: ../attributes.md#meta-item-attribute-syntax
-[_StructExpression_]: ../expressions/struct-expr.md
-[_StructPattern_]: ../patterns.md#struct-patterns
-[_TupleStructPattern_]: ../patterns.md#tuple-struct-patterns
 [`if let`]: ../expressions/if-expr.md#if-let-expressions
 [`match`]: ../expressions/match-expr.md
 [attributes]: ../attributes.md

--- a/src/comments.md
+++ b/src/comments.md
@@ -4,7 +4,7 @@ r[comments]
 r[comments.syntax]
 > **<sup>Lexer</sup>**\
 > LINE_COMMENT :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `//` (~\[`/` `!` `\n`] | `//`) ~`\n`<sup>\*</sup>\
+> &nbsp;&nbsp; &nbsp;&nbsp; `//` (~\[`/` `!` LF] | `//`) ~LF<sup>\*</sup>\
 > &nbsp;&nbsp; | `//`
 >
 > BLOCK_COMMENT :\
@@ -14,13 +14,13 @@ r[comments.syntax]
 > &nbsp;&nbsp; | `/***/`
 >
 > INNER_LINE_DOC :\
-> &nbsp;&nbsp; `//!` ~\[`\n` CR]<sup>\*</sup>
+> &nbsp;&nbsp; `//!` ~\[LF CR]<sup>\*</sup>
 >
 > INNER_BLOCK_DOC :\
 > &nbsp;&nbsp; `/*!` ( _BlockCommentOrDoc_ | ~\[`*/` CR] )<sup>\*</sup> `*/`
 >
 > OUTER_LINE_DOC :\
-> &nbsp;&nbsp; `///` (~`/` ~\[`\n` CR]<sup>\*</sup>)<sup>?</sup>
+> &nbsp;&nbsp; `///` (~`/` ~\[LF CR]<sup>\*</sup>)<sup>?</sup>
 >
 > OUTER_BLOCK_DOC :\
 > &nbsp;&nbsp; `/**` (~`*` | _BlockCommentOrDoc_ )

--- a/src/comments.md
+++ b/src/comments.md
@@ -3,7 +3,7 @@ r[comments]
 
 r[comments.syntax]
 ```grammar,lexer
-LINE_COMMENT ->
+@root LINE_COMMENT ->
       `//` (~[`/` `!` LF] | `//`) ~LF*
     | `//`
 
@@ -15,13 +15,13 @@ BLOCK_COMMENT ->
     | `/**/`
     | `/***/`
 
-INNER_LINE_DOC ->
+@root INNER_LINE_DOC ->
     `//!` ~[LF CR]*
 
 INNER_BLOCK_DOC ->
     `/*!` ( BlockCommentOrDoc | ~[`*/` CR] )* `*/`
 
-OUTER_LINE_DOC ->
+@root OUTER_LINE_DOC ->
     `///` (~`/` ~[LF CR]*)?
 
 OUTER_BLOCK_DOC ->

--- a/src/comments.md
+++ b/src/comments.md
@@ -14,25 +14,22 @@ r[comments.syntax]
 > &nbsp;&nbsp; | `/***/`
 >
 > INNER_LINE_DOC :\
-> &nbsp;&nbsp; `//!` ~\[`\n` _IsolatedCR_]<sup>\*</sup>
+> &nbsp;&nbsp; `//!` ~\[`\n` CR]<sup>\*</sup>
 >
 > INNER_BLOCK_DOC :\
-> &nbsp;&nbsp; `/*!` ( _BlockCommentOrDoc_ | ~\[`*/` _IsolatedCR_] )<sup>\*</sup> `*/`
+> &nbsp;&nbsp; `/*!` ( _BlockCommentOrDoc_ | ~\[`*/` CR] )<sup>\*</sup> `*/`
 >
 > OUTER_LINE_DOC :\
-> &nbsp;&nbsp; `///` (~`/` ~\[`\n` _IsolatedCR_]<sup>\*</sup>)<sup>?</sup>
+> &nbsp;&nbsp; `///` (~`/` ~\[`\n` CR]<sup>\*</sup>)<sup>?</sup>
 >
 > OUTER_BLOCK_DOC :\
 > &nbsp;&nbsp; `/**` (~`*` | _BlockCommentOrDoc_ )
->              (_BlockCommentOrDoc_ | ~\[`*/` _IsolatedCR_])<sup>\*</sup> `*/`
+>              (_BlockCommentOrDoc_ | ~\[`*/` CR])<sup>\*</sup> `*/`
 >
 > _BlockCommentOrDoc_ :\
 > &nbsp;&nbsp; &nbsp;&nbsp; BLOCK_COMMENT\
 > &nbsp;&nbsp; | OUTER_BLOCK_DOC\
 > &nbsp;&nbsp; | INNER_BLOCK_DOC
->
-> _IsolatedCR_ :\
-> &nbsp;&nbsp; \\r
 
 r[comments.normal]
 ## Non-doc comments

--- a/src/comments.md
+++ b/src/comments.md
@@ -2,34 +2,39 @@ r[comments]
 # Comments
 
 r[comments.syntax]
-> **<sup>Lexer</sup>**\
-> LINE_COMMENT :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `//` (~\[`/` `!` LF] | `//`) ~LF<sup>\*</sup>\
-> &nbsp;&nbsp; | `//`
->
-> BLOCK_COMMENT :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `/*` (~\[`*` `!`] | `**` | _BlockCommentOrDoc_)
->      (_BlockCommentOrDoc_ | ~`*/`)<sup>\*</sup> `*/`\
-> &nbsp;&nbsp; | `/**/`\
-> &nbsp;&nbsp; | `/***/`
->
-> INNER_LINE_DOC :\
-> &nbsp;&nbsp; `//!` ~\[LF CR]<sup>\*</sup>
->
-> INNER_BLOCK_DOC :\
-> &nbsp;&nbsp; `/*!` ( _BlockCommentOrDoc_ | ~\[`*/` CR] )<sup>\*</sup> `*/`
->
-> OUTER_LINE_DOC :\
-> &nbsp;&nbsp; `///` (~`/` ~\[LF CR]<sup>\*</sup>)<sup>?</sup>
->
-> OUTER_BLOCK_DOC :\
-> &nbsp;&nbsp; `/**` (~`*` | _BlockCommentOrDoc_ )
->              (_BlockCommentOrDoc_ | ~\[`*/` CR])<sup>\*</sup> `*/`
->
-> _BlockCommentOrDoc_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; BLOCK_COMMENT\
-> &nbsp;&nbsp; | OUTER_BLOCK_DOC\
-> &nbsp;&nbsp; | INNER_BLOCK_DOC
+```grammar,lexer
+LINE_COMMENT ->
+      `//` (~[`/` `!` LF] | `//`) ~LF*
+    | `//`
+
+BLOCK_COMMENT ->
+      `/*`
+        ( ~[`*` `!`] | `**` | BlockCommentOrDoc )
+        ( BlockCommentOrDoc | ~`*/` )*
+      `*/`
+    | `/**/`
+    | `/***/`
+
+INNER_LINE_DOC ->
+    `//!` ~[LF CR]*
+
+INNER_BLOCK_DOC ->
+    `/*!` ( BlockCommentOrDoc | ~[`*/` CR] )* `*/`
+
+OUTER_LINE_DOC ->
+    `///` (~`/` ~[LF CR]*)?
+
+OUTER_BLOCK_DOC ->
+    `/**`
+      ( ~`*` | BlockCommentOrDoc )
+      ( BlockCommentOrDoc | ~[`*/` CR] )*
+    `*/`
+
+BlockCommentOrDoc ->
+      BLOCK_COMMENT
+    | OUTER_BLOCK_DOC
+    | INNER_BLOCK_DOC
+```
 
 r[comments.normal]
 ## Non-doc comments

--- a/src/comments.md
+++ b/src/comments.md
@@ -1,6 +1,7 @@
-r[comments.syntax]
+r[comments]
 # Comments
 
+r[comments.syntax]
 > **<sup>Lexer</sup>**\
 > LINE_COMMENT :\
 > &nbsp;&nbsp; &nbsp;&nbsp; `//` (~\[`/` `!` `\n`] | `//`) ~`\n`<sup>\*</sup>\

--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -315,7 +315,7 @@ r[cfg.attr]
 
 r[cfg.attr.syntax]
 ```grammar,configuration
-CfgAttribute -> `cfg` `(` ConfigurationPredicate `)`
+@root CfgAttribute -> `cfg` `(` ConfigurationPredicate `)`
 ```
 
 <!-- should we say they're active attributes here? -->
@@ -382,7 +382,7 @@ r[cfg.cfg_attr]
 
 r[cfg.cfg_attr.syntax]
 ```grammar,configuration
-CfgAttrAttribute -> `cfg_attr` `(` ConfigurationPredicate `,` CfgAttrs? `)`
+@root CfgAttrAttribute -> `cfg_attr` `(` ConfigurationPredicate `,` CfgAttrs? `)`
 
 CfgAttrs -> Attr (`,` Attr)* `,`?
 ```

--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -2,27 +2,28 @@ r[cfg]
 # Conditional compilation
 
 r[cfg.syntax]
-> **<sup>Syntax</sup>**\
-> _ConfigurationPredicate_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; _ConfigurationOption_\
-> &nbsp;&nbsp; | _ConfigurationAll_\
-> &nbsp;&nbsp; | _ConfigurationAny_\
-> &nbsp;&nbsp; | _ConfigurationNot_
->
-> _ConfigurationOption_ :\
-> &nbsp;&nbsp; [IDENTIFIER]&nbsp;(`=` ([STRING_LITERAL] | [RAW_STRING_LITERAL]))<sup>?</sup>
->
-> _ConfigurationAll_ :\
-> &nbsp;&nbsp; `all` `(` _ConfigurationPredicateList_<sup>?</sup> `)`
->
-> _ConfigurationAny_ :\
-> &nbsp;&nbsp; `any` `(` _ConfigurationPredicateList_<sup>?</sup> `)`
->
-> _ConfigurationNot_ :\
-> &nbsp;&nbsp; `not` `(` _ConfigurationPredicate_ `)`
->
-> _ConfigurationPredicateList_ :\
-> &nbsp;&nbsp; _ConfigurationPredicate_ (`,` _ConfigurationPredicate_)<sup>\*</sup> `,`<sup>?</sup>
+```grammar,configuration
+ConfigurationPredicate ->
+      ConfigurationOption
+    | ConfigurationAll
+    | ConfigurationAny
+    | ConfigurationNot
+
+ConfigurationOption ->
+    IDENTIFIER ( `=` ( STRING_LITERAL | RAW_STRING_LITERAL ) )?
+
+ConfigurationAll ->
+    `all` `(` ConfigurationPredicateList? `)`
+
+ConfigurationAny ->
+    `any` `(` ConfigurationPredicateList? `)`
+
+ConfigurationNot ->
+    `not` `(` ConfigurationPredicate `)`
+
+ConfigurationPredicateList ->
+    ConfigurationPredicate (`,` ConfigurationPredicate)* `,`?
+```
 
 r[cfg.general]
 *Conditionally compiled source code* is source code that is compiled only under certain conditions.
@@ -313,9 +314,9 @@ r[cfg.attr]
 ### The `cfg` attribute
 
 r[cfg.attr.syntax]
-> **<sup>Syntax</sup>**\
-> _CfgAttribute_ :\
-> &nbsp;&nbsp; `cfg` `(` _ConfigurationPredicate_ `)`
+```grammar,configuration
+CfgAttribute -> `cfg` `(` ConfigurationPredicate `)`
+```
 
 <!-- should we say they're active attributes here? -->
 
@@ -380,12 +381,11 @@ r[cfg.cfg_attr]
 ### The `cfg_attr` attribute
 
 r[cfg.cfg_attr.syntax]
-> **<sup>Syntax</sup>**\
-> _CfgAttrAttribute_ :\
-> &nbsp;&nbsp; `cfg_attr` `(` _ConfigurationPredicate_ `,` _CfgAttrs_<sup>?</sup> `)`
->
-> _CfgAttrs_ :\
-> &nbsp;&nbsp; [_Attr_]&nbsp;(`,` [_Attr_])<sup>\*</sup> `,`<sup>?</sup>
+```grammar,configuration
+CfgAttrAttribute -> `cfg_attr` `(` ConfigurationPredicate `,` CfgAttrs? `)`
+
+CfgAttrs -> Attr (`,` Attr)* `,`?
+```
 
 r[cfg.cfg_attr.general]
 The `cfg_attr` [attribute] conditionally includes [attributes] based on a
@@ -447,11 +447,7 @@ let machine_kind = if cfg!(unix) {
 println!("I'm running on a {} machine!", machine_kind);
 ```
 
-[IDENTIFIER]: identifiers.md
-[RAW_STRING_LITERAL]: tokens.md#raw-string-literals
-[STRING_LITERAL]: tokens.md#string-literals
 [Testing]: attributes/testing.md
-[_Attr_]: attributes.md
 [`--cfg`]: ../rustc/command-line-arguments.html#--cfg-configure-the-compilation-environment
 [`--test`]: ../rustc/command-line-arguments.html#--test-build-a-test-harness
 [`cfg`]: #the-cfg-attribute

--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -12,16 +12,16 @@ r[cfg.syntax]
 > _ConfigurationOption_ :\
 > &nbsp;&nbsp; [IDENTIFIER]&nbsp;(`=` ([STRING_LITERAL] | [RAW_STRING_LITERAL]))<sup>?</sup>
 >
-> _ConfigurationAll_\
+> _ConfigurationAll_ :\
 > &nbsp;&nbsp; `all` `(` _ConfigurationPredicateList_<sup>?</sup> `)`
 >
-> _ConfigurationAny_\
+> _ConfigurationAny_ :\
 > &nbsp;&nbsp; `any` `(` _ConfigurationPredicateList_<sup>?</sup> `)`
 >
-> _ConfigurationNot_\
+> _ConfigurationNot_ :\
 > &nbsp;&nbsp; `not` `(` _ConfigurationPredicate_ `)`
 >
-> _ConfigurationPredicateList_\
+> _ConfigurationPredicateList_ :\
 > &nbsp;&nbsp; _ConfigurationPredicate_ (`,` _ConfigurationPredicate_)<sup>\*</sup> `,`<sup>?</sup>
 
 r[cfg.general]

--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -314,7 +314,7 @@ r[cfg.attr]
 
 r[cfg.attr.syntax]
 > **<sup>Syntax</sup>**\
-> _CfgAttrAttribute_ :\
+> _CfgAttribute_ :\
 > &nbsp;&nbsp; `cfg` `(` _ConfigurationPredicate_ `)`
 
 <!-- should we say they're active attributes here? -->

--- a/src/crates-and-source-files.md
+++ b/src/crates-and-source-files.md
@@ -2,10 +2,11 @@ r[crate]
 # Crates and source files
 
 r[crate.syntax]
-> **<sup>Syntax</sup>**\
-> _Crate_ :\
-> &nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>\
-> &nbsp;&nbsp; [_Item_]<sup>\*</sup>
+```grammar,items
+Crate ->
+    InnerAttribute*
+    Item*
+```
 
 > [!NOTE]
 > Although Rust, like any other language, can be implemented by an interpreter as well as a compiler, the only existing implementation is a compiler, and the language has always been designed to be compiled. For these reasons, this section assumes a compiler.
@@ -40,7 +41,7 @@ extension `.rs`.
 r[crate.module-def]
 A Rust source file describes a module, the name and location of which &mdash;
 in the module tree of the current crate &mdash; are defined from outside the
-source file: either by an explicit [_Module_][module] item in a referencing
+source file: either by an explicit [Module][grammar-Module] item in a referencing
 source file, or by the name of the crate itself.
 
 r[crate.inline-module]
@@ -49,7 +50,7 @@ module, but not every module needs its own source file: [module
 definitions][module] can be nested within one file.
 
 r[crate.items]
-Each source file contains a sequence of zero or more [_Item_] definitions, and
+Each source file contains a sequence of zero or more [Item] definitions, and
 may optionally begin with any number of [attributes]
 that apply to the containing module, most of which influence the behavior of
 the compiler.
@@ -139,7 +140,7 @@ r[crate.crate_name]
 
 r[crate.crate_name.general]
 The *`crate_name` [attribute]* may be applied at the crate level to specify the
-name of the crate with the [_MetaNameValueStr_] syntax.
+name of the crate with the [MetaNameValueStr] syntax.
 
 ```rust
 #![crate_name = "mycrate"]
@@ -159,9 +160,6 @@ or `_` (U+005F) characters.
 
 [Unicode alphanumeric]: char::is_alphanumeric
 [`!`]: types/never.md
-[_InnerAttribute_]: attributes.md
-[_Item_]: items.md
-[_MetaNameValueStr_]: attributes.md#meta-item-attribute-syntax
 [`ExitCode`]: std::process::ExitCode
 [`Infallible`]: std::convert::Infallible
 [`Termination`]: std::process::Termination

--- a/src/crates-and-source-files.md
+++ b/src/crates-and-source-files.md
@@ -3,7 +3,7 @@ r[crate]
 
 r[crate.syntax]
 ```grammar,items
-Crate ->
+@root Crate ->
     InnerAttribute*
     Item*
 ```

--- a/src/expressions.md
+++ b/src/expressions.md
@@ -2,48 +2,49 @@ r[expr]
 # Expressions
 
 r[expr.syntax]
-> **<sup>Syntax</sup>**\
-> _Expression_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; _ExpressionWithoutBlock_\
-> &nbsp;&nbsp; | _ExpressionWithBlock_
->
-> _ExpressionWithoutBlock_ :\
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup>[†](#expression-attributes)\
-> &nbsp;&nbsp; (\
-> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; [_LiteralExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_PathExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_OperatorExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_GroupedExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_ArrayExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_AwaitExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_IndexExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_TupleExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_TupleIndexingExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_StructExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_CallExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_MethodCallExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_FieldExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_ClosureExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_AsyncBlockExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_ContinueExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_BreakExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_RangeExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_ReturnExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_UnderscoreExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_MacroInvocation_]\
-> &nbsp;&nbsp; )
->
-> _ExpressionWithBlock_ :\
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup>[†](#expression-attributes)\
-> &nbsp;&nbsp; (\
-> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; [_BlockExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_ConstBlockExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_UnsafeBlockExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_LoopExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_IfExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_IfLetExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_MatchExpression_]\
-> &nbsp;&nbsp; )
+```grammar,expressions
+Expression ->
+      ExpressionWithoutBlock
+    | ExpressionWithBlock
+
+ExpressionWithoutBlock ->
+    OuterAttribute*
+    (
+        LiteralExpression
+      | PathExpression
+      | OperatorExpression
+      | GroupedExpression
+      | ArrayExpression
+      | AwaitExpression
+      | IndexExpression
+      | TupleExpression
+      | TupleIndexingExpression
+      | StructExpression
+      | CallExpression
+      | MethodCallExpression
+      | FieldExpression
+      | ClosureExpression
+      | AsyncBlockExpression
+      | ContinueExpression
+      | BreakExpression
+      | RangeExpression
+      | ReturnExpression
+      | UnderscoreExpression
+      | MacroInvocation
+    )
+
+ExpressionWithBlock ->
+    OuterAttribute*
+    (
+        BlockExpression
+      | ConstBlockExpression
+      | UnsafeBlockExpression
+      | LoopExpression
+      | IfExpression
+      | IfLetExpression
+      | MatchExpression
+    )
+```
 
 r[expr.intro]
 An expression may have two roles: it always produces a *value*, and it may have *effects* (otherwise known as "side effects").
@@ -188,13 +189,13 @@ An *assignee expression* is an expression that appears in the left operand of an
 Explicitly, the assignee expressions are:
 
 - Place expressions.
-- [Underscores][_UnderscoreExpression_].
-- [Tuples][_TupleExpression_] of assignee expressions.
-- [Slices][_ArrayExpression_] of assignee expressions.
-- [Tuple structs][_StructExpression_] of assignee expressions.
-- [Structs][_StructExpression_] of assignee expressions (with optionally named
+- [Underscores].
+- [Tuples] of assignee expressions.
+- [Slices][expr.array.index] of assignee expressions.
+- [Tuple structs] of assignee expressions.
+- [Structs] of assignee expressions (with optionally named
   fields).
-- [Unit structs][_StructExpression_].
+- [Unit structs]
 
 r[expr.place-value.parenthesis]
 Arbitrary parenthesisation is permitted inside assignee expressions.
@@ -296,7 +297,7 @@ r[expr.attr]
 ## Expression Attributes
 
 r[expr.attr.restriction]
-[Outer attributes][_OuterAttribute_] before an expression are allowed only in a few specific cases:
+[Outer attributes] before an expression are allowed only in a few specific cases:
 
 * Before an expression used as a [statement].
 * Elements of [array expressions], [tuple expressions], [call expressions], and tuple-style [struct] expressions.
@@ -305,82 +306,49 @@ r[expr.attr.restriction]
 
 r[expr.attr.never-before]
 They are never allowed before:
-* [Range][_RangeExpression_] expressions.
-* Binary operator expressions ([_ArithmeticOrLogicalExpression_], [_ComparisonExpression_], [_LazyBooleanExpression_], [_TypeCastExpression_], [_AssignmentExpression_], [_CompoundAssignmentExpression_]).
-
-[block expressions]:    expressions/block-expr.md
-[call expressions]:     expressions/call-expr.md
-[field]:                expressions/field-expr.md
-[functional update]:    expressions/struct-expr.md#functional-update-syntax
-[`if let`]:             expressions/if-expr.md#if-let-expressions
-[match]:                expressions/match-expr.md
-[method-call]:          expressions/method-call-expr.md
-[paths]:                expressions/path-expr.md
-[struct]:               expressions/struct-expr.md
-[tuple expressions]:    expressions/tuple-expr.md
-[`while let`]:          expressions/loop-expr.md#predicate-pattern-loops
-
-[array expressions]:    expressions/array-expr.md
-[array indexing]:       expressions/array-expr.md#array-and-slice-indexing-expressions
-
-[assign]:               expressions/operator-expr.md#assignment-expressions
-[borrow]:               expressions/operator-expr.md#borrow-operators
-[comparison]:           expressions/operator-expr.md#comparison-operators
-[compound assignment]:  expressions/operator-expr.md#compound-assignment-expressions
-[deref]:                expressions/operator-expr.md#the-dereference-operator
-
-[destructors]:          destructors.md
-[drop scope]:           destructors.md#drop-scopes
+* [Range] expressions.
+* Binary operator expressions ([ArithmeticOrLogicalExpression], [ComparisonExpression], [LazyBooleanExpression], [TypeCastExpression], [AssignmentExpression], [CompoundAssignmentExpression]).
 
 [`Copy`]:               special-types-and-traits.md#copy
 [`Drop`]:               special-types-and-traits.md#drop
+[`if let`]:             expressions/if-expr.md#if-let-expressions
 [`Sized`]:              special-types-and-traits.md#sized
+[`while let`]:          expressions/loop-expr.md#predicate-pattern-loops
+[array expressions]:    expressions/array-expr.md
+[array indexing]:       expressions/array-expr.md#array-and-slice-indexing-expressions
+[assign]:               expressions/operator-expr.md#assignment-expressions
+[block expressions]:    expressions/block-expr.md
+[borrow]:               expressions/operator-expr.md#borrow-operators
+[call expressions]:     expressions/call-expr.md
+[comparison]:           expressions/operator-expr.md#comparison-operators
+[compound assignment]:  expressions/operator-expr.md#compound-assignment-expressions
+[deref]:                expressions/operator-expr.md#the-dereference-operator
+[destructors]:          destructors.md
+[drop scope]:           destructors.md#drop-scopes
+[field]:                expressions/field-expr.md
+[functional update]:    expressions/struct-expr.md#functional-update-syntax
 [implicit borrow]:      #implicit-borrows
 [implicitly mutably borrowed]: #implicit-borrows
 [interior mutability]:  interior-mutability.md
 [let statement]:        statements.md#let-statements
+[match]:                expressions/match-expr.md
+[method-call]:          expressions/method-call-expr.md
 [Mutable `static` items]: items/static-items.md#mutable-statics
-[scrutinee]:            glossary.md#scrutinee
+[Outer attributes]:     attributes.md
+[paths]:                expressions/path-expr.md
 [promoted]:             destructors.md#constant-promotion
+[Range]:                expressions/range-expr.md
 [raw borrow]:           expressions/operator-expr.md#raw-borrow-operators
+[scrutinee]:            glossary.md#scrutinee
 [slice]:                types/slice.md
 [statement]:            statements.md
 [static variables]:     items/static-items.md
+[struct]:               expressions/struct-expr.md
+[Structs]:              expr.struct
 [Temporary values]:     #temporaries
+[tuple expressions]:    expressions/tuple-expr.md
+[Tuple structs]:        expr.struct.tuple
+[Tuples]:               expressions/tuple-expr.md
+[Underscores]:          expressions/underscore-expr.md
+[Unit structs]:         expr.struct.unit
 [Variables]:            variables.md
-
-[_ArithmeticOrLogicalExpression_]: expressions/operator-expr.md#arithmetic-and-logical-binary-operators
-[_ArrayExpression_]:              expressions/array-expr.md
-[_AsyncBlockExpression_]:         expressions/block-expr.md#async-blocks
-[_AwaitExpression_]:              expressions/await-expr.md
-[_AssignmentExpression_]:         expressions/operator-expr.md#assignment-expressions
-[_BlockExpression_]:              expressions/block-expr.md
-[_BreakExpression_]:              expressions/loop-expr.md#break-expressions
-[_CallExpression_]:               expressions/call-expr.md
-[_ClosureExpression_]:            expressions/closure-expr.md
-[_ComparisonExpression_]:         expressions/operator-expr.md#comparison-operators
-[_CompoundAssignmentExpression_]: expressions/operator-expr.md#compound-assignment-expressions
-[_ConstBlockExpression_]:         expressions/block-expr.md#const-blocks
-[_ContinueExpression_]:           expressions/loop-expr.md#continue-expressions
-[_FieldExpression_]:              expressions/field-expr.md
-[_GroupedExpression_]:            expressions/grouped-expr.md
-[_IfExpression_]:                 expressions/if-expr.md#if-expressions
-[_IfLetExpression_]:              expressions/if-expr.md#if-let-expressions
-[_IndexExpression_]:              expressions/array-expr.md#array-and-slice-indexing-expressions
-[_LazyBooleanExpression_]:        expressions/operator-expr.md#lazy-boolean-operators
-[_LiteralExpression_]:            expressions/literal-expr.md
-[_LoopExpression_]:               expressions/loop-expr.md
-[_MacroInvocation_]:              macros.md#macro-invocation
-[_MatchExpression_]:              expressions/match-expr.md
-[_MethodCallExpression_]:         expressions/method-call-expr.md
-[_OperatorExpression_]:           expressions/operator-expr.md
-[_OuterAttribute_]:               attributes.md
-[_PathExpression_]:               expressions/path-expr.md
-[_RangeExpression_]:              expressions/range-expr.md
-[_ReturnExpression_]:             expressions/return-expr.md
-[_StructExpression_]:             expressions/struct-expr.md
-[_TupleExpression_]:              expressions/tuple-expr.md
-[_TupleIndexingExpression_]:      expressions/tuple-expr.md#tuple-indexing-expressions
-[_TypeCastExpression_]:           expressions/operator-expr.md#type-cast-expressions
-[_UnderscoreExpression_]:         expressions/underscore-expr.md
-[_UnsafeBlockExpression_]:        expressions/block-expr.md#unsafe-blocks

--- a/src/expressions/array-expr.md
+++ b/src/expressions/array-expr.md
@@ -4,13 +4,13 @@ r[expr.array]
 ## Array expressions
 
 r[expr.array.syntax]
-> **<sup>Syntax</sup>**\
-> _ArrayExpression_ :\
-> &nbsp;&nbsp; `[` _ArrayElements_<sup>?</sup> `]`
->
-> _ArrayElements_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_Expression_] ( `,` [_Expression_] )<sup>\*</sup> `,`<sup>?</sup>\
-> &nbsp;&nbsp; | [_Expression_] `;` [_Expression_]
+```grammar,expressions
+ArrayExpression -> `[` ArrayElements? `]`
+
+ArrayElements ->
+      Expression ( `,` Expression )* `,`?
+    | Expression `;` Expression
+```
 
 r[expr.array.constructor]
 *Array expressions* construct [arrays][array].
@@ -67,9 +67,9 @@ r[expr.array.index]
 ## Array and slice indexing expressions
 
 r[expr.array.index.syntax]
-> **<sup>Syntax</sup>**\
-> _IndexExpression_ :\
-> &nbsp;&nbsp; [_Expression_] `[` [_Expression_] `]`
+```grammar,expressions
+IndexExpression -> Expression `[` Expression `]`
+```
 
 r[expr.array.index.array]
 [Array] and [slice]-typed values can be indexed by writing a square-bracket-enclosed expression of type `usize` (the index) after them.
@@ -110,7 +110,6 @@ The array index expression can be implemented for types other than arrays and sl
 [`Copy`]: ../special-types-and-traits.md#copy
 [IndexMut]: std::ops::IndexMut
 [Index]: std::ops::Index
-[_Expression_]: ../expressions.md
 [array]: ../types/array.md
 [constant expression]: ../const_eval.md#constant-expressions
 [constant item]: ../items/constant-items.md

--- a/src/expressions/array-expr.md
+++ b/src/expressions/array-expr.md
@@ -66,6 +66,7 @@ const EMPTY: Vec<i32> = Vec::new();
 r[expr.array.index]
 ## Array and slice indexing expressions
 
+r[expr.array.index.syntax]
 > **<sup>Syntax</sup>**\
 > _IndexExpression_ :\
 > &nbsp;&nbsp; [_Expression_] `[` [_Expression_] `]`

--- a/src/expressions/await-expr.md
+++ b/src/expressions/await-expr.md
@@ -2,9 +2,9 @@ r[expr.await]
 # Await expressions
 
 r[expr.await.syntax]
-> **<sup>Syntax</sup>**\
-> _AwaitExpression_ :\
-> &nbsp;&nbsp; [_Expression_] `.` `await`
+```grammar,expressions
+AwaitExpression -> Expression `.` `await`
+```
 
 r[expr.await.intro]
 An `await` expression is a syntactic construct for suspending a computation
@@ -58,7 +58,6 @@ match operand.into_future() {
 where the `yield` pseudo-code returns `Poll::Pending` and, when re-invoked, resumes execution from that point.
 The variable `current_context` refers to the context taken from the async environment.
 
-[_Expression_]: ../expressions.md
 [`async fn`]: ../items/functions.md#async-functions
 [`async` closure]: closure-expr.md#async-closures
 [`async` block]: block-expr.md#async-blocks

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -222,10 +222,12 @@ if false {
 r[expr.block.unsafe]
 ## `unsafe` blocks
 
+r[expr.block.unsafe.syntax]
 > **<sup>Syntax</sup>**\
 > _UnsafeBlockExpression_ :\
 > &nbsp;&nbsp; `unsafe` _BlockExpression_
 
+r[expr.block.unsafe.intro]
 _See [`unsafe` blocks] for more information on when to use `unsafe`_.
 
 A block of code can be prefixed with the `unsafe` keyword to permit [unsafe operations].

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -2,17 +2,18 @@ r[expr.block]
 # Block expressions
 
 r[expr.block.syntax]
-> **<sup>Syntax</sup>**\
-> _BlockExpression_ :\
-> &nbsp;&nbsp; `{`\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>\
-> &nbsp;&nbsp; &nbsp;&nbsp; _Statements_<sup>?</sup>\
-> &nbsp;&nbsp; `}`
->
-> _Statements_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_Statement_]<sup>\+</sup>\
-> &nbsp;&nbsp; | [_Statement_]<sup>\+</sup> [_ExpressionWithoutBlock_]\
-> &nbsp;&nbsp; | [_ExpressionWithoutBlock_]
+```grammar,expressions
+BlockExpression ->
+    `{`
+        InnerAttribute*
+        Statements?
+    `}`
+
+Statements ->
+      Statement+
+    | Statement+ ExpressionWithoutBlock
+    | ExpressionWithoutBlock
+```
 
 r[expr.block.intro]
 A *block expression*, or *block*, is a control flow expression and anonymous namespace scope for items and variable declarations.
@@ -91,9 +92,9 @@ r[expr.block.async]
 ## `async` blocks
 
 r[expr.block.async.syntax]
-> **<sup>Syntax</sup>**\
-> _AsyncBlockExpression_ :\
-> &nbsp;&nbsp; `async` `move`<sup>?</sup> _BlockExpression_
+```grammar,expressions
+AsyncBlockExpression -> `async` `move`? BlockExpression
+```
 
 r[expr.block.async.intro]
 An *async block* is a variant of a block expression which evaluates to a future.
@@ -158,9 +159,9 @@ r[expr.block.const]
 ## `const` blocks
 
 r[expr.block.const.syntax]
-> **<sup>Syntax</sup>**\
-> _ConstBlockExpression_ :\
-> &nbsp;&nbsp; `const` _BlockExpression_
+```grammar,expressions
+ConstBlockExpression -> `const` BlockExpression
+```
 
 r[expr.block.const.intro]
 A *const block* is a variant of a block expression whose body evaluates at compile-time instead of at runtime.
@@ -223,9 +224,9 @@ r[expr.block.unsafe]
 ## `unsafe` blocks
 
 r[expr.block.unsafe.syntax]
-> **<sup>Syntax</sup>**\
-> _UnsafeBlockExpression_ :\
-> &nbsp;&nbsp; `unsafe` _BlockExpression_
+```grammar,expressions
+UnsafeBlockExpression -> `unsafe` BlockExpression
+```
 
 r[expr.block.unsafe.intro]
 _See [`unsafe` blocks] for more information on when to use `unsafe`_.
@@ -276,9 +277,6 @@ fn is_unix_platform() -> bool {
 }
 ```
 
-[_ExpressionWithoutBlock_]: ../expressions.md
-[_InnerAttribute_]: ../attributes.md
-[_Statement_]: ../statements.md
 [`await` expressions]: await-expr.md
 [`cfg`]: ../conditional-compilation.md
 [`for`]: loop-expr.md#iterator-loops

--- a/src/expressions/call-expr.md
+++ b/src/expressions/call-expr.md
@@ -2,12 +2,11 @@ r[expr.call]
 # Call expressions
 
 r[expr.call.syntax]
-> **<sup>Syntax</sup>**\
-> _CallExpression_ :\
-> &nbsp;&nbsp; [_Expression_] `(` _CallParams_<sup>?</sup> `)`
->
-> _CallParams_ :\
-> &nbsp;&nbsp; [_Expression_]&nbsp;( `,` [_Expression_] )<sup>\*</sup> `,`<sup>?</sup>
+```grammar,expressions
+CallExpression -> Expression `(` CallParams? `)`
+
+CallParams -> Expression ( `,` Expression )* `,`?
+```
 
 r[expr.call.intro]
 A *call expression* calls a function.
@@ -104,7 +103,6 @@ fn main() {
 Refer to [RFC 132] for further details and motivations.
 
 [RFC 132]: https://github.com/rust-lang/rfcs/blob/master/text/0132-ufcs.md
-[_Expression_]: ../expressions.md
 [`default()`]: std::default::Default::default
 [`size_of()`]: std::mem::size_of
 [automatically dereferenced]: field-expr.md#automatic-dereferencing

--- a/src/expressions/closure-expr.md
+++ b/src/expressions/closure-expr.md
@@ -2,20 +2,19 @@ r[expr.closure]
 # Closure expressions
 
 r[expr.closure.syntax]
-> **<sup>Syntax</sup>**\
-> _ClosureExpression_ :\
-> &nbsp;&nbsp; `async`[^cl-async-edition]<sup>?</sup>\
-> &nbsp;&nbsp; `move`<sup>?</sup>\
-> &nbsp;&nbsp; ( `||` | `|` _ClosureParameters_<sup>?</sup> `|` )\
-> &nbsp;&nbsp; ([_Expression_] | `->` [_TypeNoBounds_]&nbsp;[_BlockExpression_])
->
-> _ClosureParameters_ :\
-> &nbsp;&nbsp; _ClosureParam_ (`,` _ClosureParam_)<sup>\*</sup> `,`<sup>?</sup>
->
-> _ClosureParam_ :\
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> [_PatternNoTopAlt_]&nbsp;( `:` [_Type_] )<sup>?</sup>
->
-> [^cl-async-edition]: The `async` qualifier is not allowed in the 2015 edition.
+```grammar,expressions
+ClosureExpression ->
+    `async`?[^cl-async-edition]
+    `move`?
+    ( `||` | `|` ClosureParameters? `|` )
+    (Expression | `->` TypeNoBounds BlockExpression)
+
+ClosureParameters -> ClosureParam (`,` ClosureParam)* `,`?
+
+ClosureParam -> OuterAttribute* PatternNoTopAlt ( `:` Type )?
+```
+
+[^cl-async-edition]: The `async` qualifier is not allowed in the 2015 edition.
 
 r[expr.closure.intro]
 A *closure expression*, also known as a lambda expression or a lambda, defines a [closure type] and evaluates to a value of that type.
@@ -105,15 +104,9 @@ ten_times(move |j| println!("{}, {}", word, j));
 r[expr.closure.param-attributes]
 Attributes on closure parameters follow the same rules and restrictions as [regular function parameters].
 
-[_Expression_]: ../expressions.md
-[_BlockExpression_]: block-expr.md
-[_TypeNoBounds_]: ../types.md#type-expressions
-[_PatternNoTopAlt_]: ../patterns.md
-[_Type_]: ../types.md#type-expressions
 [`let` binding]: ../statements.md#let-statements
 [`Send`]: ../special-types-and-traits.md#send
 [`Sync`]: ../special-types-and-traits.md#sync
-[_OuterAttribute_]: ../attributes.md
 [block]: block-expr.md
 [call traits and coercions]: ../types/closure.md#call-traits-and-coercions
 [closure type]: ../types/closure.md

--- a/src/expressions/field-expr.md
+++ b/src/expressions/field-expr.md
@@ -2,9 +2,9 @@ r[expr.field]
 # Field access expressions
 
 r[expr.field.syntax]
-> **<sup>Syntax</sup>**\
-> _FieldExpression_ :\
-> &nbsp;&nbsp; [_Expression_] `.` [IDENTIFIER]
+```grammar,expressions
+FieldExpression -> Expression `.` IDENTIFIER
+```
 
 r[expr.field.intro]
 A *field expression* is a [place expression] that evaluates to the location of a field of a [struct] or [union].
@@ -70,11 +70,10 @@ let c: &String = &x.f2;         // Can borrow again
 let d: String = x.f3;           // Move out of x.f3
 ```
 
-[_Expression_]: ../expressions.md
 [`Box`]: ../special-types-and-traits.md#boxt
 [`Deref`]: ../special-types-and-traits.md#deref-and-derefmut
 [`drop`]: ../special-types-and-traits.md#drop
-[IDENTIFIER]: ../identifiers.md
+[identifier]: ../identifiers.md
 [call expression]: call-expr.md
 [method call expression]: method-call-expr.md
 [mutable]: ../expressions.md#mutability

--- a/src/expressions/grouped-expr.md
+++ b/src/expressions/grouped-expr.md
@@ -2,9 +2,9 @@ r[expr.paren]
 # Grouped expressions
 
 r[expr.paren.syntax]
-> **<sup>Syntax</sup>**\
-> _GroupedExpression_ :\
-> &nbsp;&nbsp; `(` [_Expression_] `)`
+```grammar,expressions
+GroupedExpression -> `(` Expression `)`
+```
 
 r[expr.paren.intro]
 A *parenthesized expression* wraps a single expression, evaluating to that expression.
@@ -46,5 +46,4 @@ assert_eq!( a.f (), "The method f");
 assert_eq!((a.f)(), "The field f");
 ```
 
-[_Expression_]: ../expressions.md
 [place]: ../expressions.md#place-expressions-and-value-expressions

--- a/src/expressions/if-expr.md
+++ b/src/expressions/if-expr.md
@@ -4,13 +4,12 @@ r[expr.if]
 ## `if` expressions
 
 r[expr.if.syntax]
-> **<sup>Syntax</sup>**\
-> _IfExpression_ :\
-> &nbsp;&nbsp; `if` [_Expression_]<sub>_except struct expression_</sub> [_BlockExpression_]\
-> &nbsp;&nbsp; (`else` (
->   [_BlockExpression_]
-> | _IfExpression_
-> | _IfLetExpression_ ) )<sup>\?</sup>
+```grammar,expressions
+IfExpression ->
+    `if` Expression _except [StructExprStruct]_ BlockExpression
+    (`else` ( BlockExpression | IfExpression | IfLetExpression ) )?
+```
+<!-- TODO: The exception above isn't accurate, see https://github.com/rust-lang/reference/issues/569 -->
 
 r[expr.if.intro]
 An `if` expression is a conditional branch in program control.
@@ -56,14 +55,11 @@ r[expr.if.let]
 ## `if let` expressions
 
 r[expr.if.let.syntax]
-> **<sup>Syntax</sup>**\
-> _IfLetExpression_ :\
-> &nbsp;&nbsp; `if` `let` [_Pattern_] `=` [_Scrutinee_]<sub>_except lazy boolean operator expression_</sub>
->              [_BlockExpression_]\
-> &nbsp;&nbsp; (`else` (
->   [_BlockExpression_]
-> | _IfExpression_
-> | _IfLetExpression_ ) )<sup>\?</sup>
+```grammar,expressions
+IfLetExpression ->
+    `if` `let` Pattern `=` Scrutinee _except [LazyBooleanExpression]_ BlockExpression
+    (`else` ( BlockExpression | IfExpression | IfLetExpression ) )?
+```
 
 r[expr.if.let.intro]
 An `if let` expression is semantically similar to an `if` expression but in place of a condition operand it expects the keyword `let` followed by a pattern, an `=` and a [scrutinee] operand.
@@ -153,7 +149,7 @@ if let E::X(n) | E::Y(n) = v {
 ```
 
 r[expr.if.let.lazy-bool]
-The expression cannot be a [lazy boolean operator expression][_LazyBooleanOperatorExpression_].
+The expression cannot be a [lazy boolean operator expression][expr.bool-logic].
 Use of a lazy boolean operator is ambiguous with a planned feature change of the language (the implementation of if-let chains - see [eRFC 2947][_eRFCIfLetChain_]).
 When lazy boolean operator expression is desired, this can be achieved by using parenthesis as below:
 
@@ -172,11 +168,6 @@ if let PAT = EXPR || EXPR { .. }
 if let PAT = ( EXPR || EXPR ) { .. }
 ```
 
-[_BlockExpression_]: block-expr.md
-[_Expression_]: ../expressions.md
-[_LazyBooleanOperatorExpression_]: operator-expr.md#lazy-boolean-operators
-[_Pattern_]: ../patterns.md
-[_Scrutinee_]: match-expr.md
 [_eRFCIfLetChain_]: https://github.com/rust-lang/rfcs/blob/master/text/2497-if-let-chains.md#rollout-plan-and-transitioning-to-rust-2018
 [`match` expression]: match-expr.md
 [boolean type]: ../types/boolean.md

--- a/src/expressions/literal-expr.md
+++ b/src/expressions/literal-expr.md
@@ -2,19 +2,21 @@ r[expr.literal]
 # Literal expressions
 
 r[expr.literal.syntax]
-> **<sup>Syntax</sup>**\
-> _LiteralExpression_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [CHAR_LITERAL]\
-> &nbsp;&nbsp; | [STRING_LITERAL]\
-> &nbsp;&nbsp; | [RAW_STRING_LITERAL]\
-> &nbsp;&nbsp; | [BYTE_LITERAL]\
-> &nbsp;&nbsp; | [BYTE_STRING_LITERAL]\
-> &nbsp;&nbsp; | [RAW_BYTE_STRING_LITERAL]\
-> &nbsp;&nbsp; | [C_STRING_LITERAL]\
-> &nbsp;&nbsp; | [RAW_C_STRING_LITERAL]\
-> &nbsp;&nbsp; | [INTEGER_LITERAL]\
-> &nbsp;&nbsp; | [FLOAT_LITERAL]\
-> &nbsp;&nbsp; | `true` | `false`
+```grammar,expressions
+LiteralExpression ->
+      CHAR_LITERAL
+    | STRING_LITERAL
+    | RAW_STRING_LITERAL
+    | BYTE_LITERAL
+    | BYTE_STRING_LITERAL
+    | RAW_BYTE_STRING_LITERAL
+    | C_STRING_LITERAL
+    | RAW_C_STRING_LITERAL
+    | INTEGER_LITERAL
+    | FLOAT_LITERAL
+    | `true`
+    | `false`
+```
 
 r[expr.literal.intro]
 A _literal expression_ is an expression consisting of a single token, rather than a sequence of tokens, that immediately and directly denotes the value it evaluates to, rather than referring to it by name or some other evaluation rule.
@@ -524,13 +526,3 @@ The expression's type is the primitive [boolean type], and its value is:
 [Unicode scalar values]: http://www.unicode.org/glossary/#unicode_scalar_value
 [`f32::from_str`]: ../../core/primitive.f32.md#method.from_str
 [`f64::from_str`]: ../../core/primitive.f64.md#method.from_str
-[CHAR_LITERAL]: ../tokens.md#character-literals
-[STRING_LITERAL]: ../tokens.md#string-literals
-[RAW_STRING_LITERAL]: ../tokens.md#raw-string-literals
-[BYTE_LITERAL]: ../tokens.md#byte-literals
-[BYTE_STRING_LITERAL]: ../tokens.md#byte-string-literals
-[RAW_BYTE_STRING_LITERAL]: ../tokens.md#raw-byte-string-literals
-[C_STRING_LITERAL]: ../tokens.md#c-string-literals
-[RAW_C_STRING_LITERAL]: ../tokens.md#raw-c-string-literals
-[INTEGER_LITERAL]: ../tokens.md#integer-literals
-[FLOAT_LITERAL]: ../tokens.md#floating-point-literals

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -292,6 +292,7 @@ A `break` expression is only permitted in the body of a loop, and has one of the
 r[expr.loop.block-labels]
 ## Labelled block expressions
 
+r[expr.loop.block-labels.syntax]
 > **<sup>Syntax</sup>**\
 > _LabelBlockExpression_ :\
 > &nbsp;&nbsp; [_BlockExpression_]

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -2,22 +2,16 @@ r[expr.loop]
 # Loops and other breakable expressions
 
 r[expr.loop.syntax]
-> **<sup>Syntax</sup>**\
-> _LoopExpression_ :\
-> &nbsp;&nbsp; [_LoopLabel_]<sup>?</sup> (\
-> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; [_InfiniteLoopExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_PredicateLoopExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_PredicatePatternLoopExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_IteratorLoopExpression_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_LabelBlockExpression_]\
-> &nbsp;&nbsp; )
-
-[_LoopLabel_]: #loop-labels
-[_InfiniteLoopExpression_]: #infinite-loops
-[_PredicateLoopExpression_]: #predicate-loops
-[_PredicatePatternLoopExpression_]: #predicate-pattern-loops
-[_IteratorLoopExpression_]: #iterator-loops
-[_LabelBlockExpression_]: #labelled-block-expressions
+```grammar,expressions
+LoopExpression ->
+    LoopLabel? (
+        InfiniteLoopExpression
+      | PredicateLoopExpression
+      | PredicatePatternLoopExpression
+      | IteratorLoopExpression
+      | LabelBlockExpression
+    )
+```
 
 r[expr.loop.intro]
 Rust supports five loop expressions:
@@ -41,9 +35,9 @@ r[expr.loop.infinite]
 ## Infinite loops
 
 r[expr.loop.infinite.syntax]
-> **<sup>Syntax</sup>**\
-> _InfiniteLoopExpression_ :\
-> &nbsp;&nbsp; `loop` [_BlockExpression_]
+```grammar,expressions
+InfiniteLoopExpression -> `loop` BlockExpression
+```
 
 r[expr.loop.infinite.intro]
 A `loop` expression repeats execution of its body continuously:
@@ -59,9 +53,10 @@ r[expr.loop.while]
 ## Predicate loops
 
 r[expr.loop.while.syntax]
-> **<sup>Syntax</sup>**\
-> _PredicateLoopExpression_ :\
-> &nbsp;&nbsp; `while` [_Expression_]<sub>_except struct expression_</sub> [_BlockExpression_]
+```grammar,expressions
+PredicateLoopExpression -> `while` Expression _except [StructExprStruct]_ BlockExpression
+```
+<!-- TODO: The exception above isn't accurate, see https://github.com/rust-lang/reference/issues/569 -->
 
 r[expr.loop.while.intro]
 A `while` loop begins by evaluating the [boolean] loop conditional operand.
@@ -85,10 +80,10 @@ r[expr.loop.while.let]
 ## Predicate pattern loops
 
 r[expr.loop.while.let.syntax]
-> **<sup>Syntax</sup>**\
-> [_PredicatePatternLoopExpression_] :\
-> &nbsp;&nbsp; `while` `let` [_Pattern_] `=` [_Scrutinee_]<sub>_except lazy boolean operator expression_</sub>
->              [_BlockExpression_]
+```grammar,expressions
+PredicatePatternLoopExpression ->
+    `while` `let` Pattern `=` Scrutinee _except [LazyBooleanExpression]_ BlockExpression
+```
 
 r[expr.loop.while.let.intro]
 A `while let` loop is semantically similar to a `while` loop but in place of a condition expression it expects the keyword `let` followed by a pattern, an `=`, a [scrutinee] expression and a block expression.
@@ -145,16 +140,17 @@ while let Some(v @ 1) | Some(v @ 2) = vals.pop() {
 ```
 
 r[expr.loop.while.let.lazy-bool]
-As is the case in [`if let` expressions], the scrutinee cannot be a [lazy boolean operator expression][_LazyBooleanOperatorExpression_].
+As is the case in [`if let` expressions], the scrutinee cannot be a [lazy boolean operator expression][expr.bool-logic].
 
 r[expr.loop.for]
 ## Iterator loops
 
 r[expr.loop.for.syntax]
-> **<sup>Syntax</sup>**\
-> _IteratorLoopExpression_ :\
-> &nbsp;&nbsp; `for` [_Pattern_] `in` [_Expression_]<sub>_except struct expression_</sub>
->              [_BlockExpression_]
+```grammar,expressions
+IteratorLoopExpression ->
+    `for` Pattern `in` Expression _except [StructExprStruct]_ BlockExpression
+```
+<!-- TODO: The exception above isn't accurate, see https://github.com/rust-lang/reference/issues/569 -->
 
 r[expr.loop.for.intro]
 A `for` expression is a syntactic construct for looping over elements provided by an implementation of `std::iter::IntoIterator`.
@@ -225,9 +221,9 @@ r[expr.loop.label]
 ## Loop labels
 
 r[expr.loop.label.syntax]
-> **<sup>Syntax</sup>**\
-> _LoopLabel_ :\
-> &nbsp;&nbsp; [LIFETIME_OR_LABEL] `:`
+```grammar,expressions
+LoopLabel -> LIFETIME_OR_LABEL `:`
+```
 
 r[expr.loop.label.intro]
 A loop expression may optionally have a _label_. The label is written as a lifetime preceding the loop expression, as in `'foo: loop { break 'foo; }`, `'bar: while false {}`, `'humbug: for _ in 0..0 {}`.
@@ -255,9 +251,9 @@ r[expr.loop.break]
 ## `break` expressions
 
 r[expr.loop.break.syntax]
-> **<sup>Syntax</sup>**\
-> _BreakExpression_ :\
-> &nbsp;&nbsp; `break` [LIFETIME_OR_LABEL]<sup>?</sup> [_Expression_]<sup>?</sup>
+```grammar,expressions
+BreakExpression -> `break` LIFETIME_OR_LABEL? Expression?
+```
 
 r[expr.loop.break.intro]
 When `break` is encountered, execution of the associated loop body is immediately terminated, for example:
@@ -293,9 +289,9 @@ r[expr.loop.block-labels]
 ## Labelled block expressions
 
 r[expr.loop.block-labels.syntax]
-> **<sup>Syntax</sup>**\
-> _LabelBlockExpression_ :\
-> &nbsp;&nbsp; [_BlockExpression_]
+```grammar,expressions
+LabelBlockExpression -> BlockExpression
+```
 
 r[expr.loop.block-labels.intro]
 Labelled block expressions are exactly like block expressions, except that they allow using `break` expressions within the block.
@@ -329,9 +325,9 @@ r[expr.loop.continue]
 ## `continue` expressions
 
 r[expr.loop.continue.syntax]
-> **<sup>Syntax</sup>**\
-> _ContinueExpression_ :\
-> &nbsp;&nbsp; `continue` [LIFETIME_OR_LABEL]<sup>?</sup>
+```grammar,expressions
+ContinueExpression -> `continue` LIFETIME_OR_LABEL?
+```
 
 r[expr.loop.continue.intro]
 When `continue` is encountered, the current iteration of the associated loop body is immediately terminated, returning control to the loop *head*.
@@ -373,14 +369,8 @@ r[expr.loop.break-value.loop]
 In the case a `loop` has an associated `break`, it is not considered diverging, and the `loop` must have a type compatible with each `break` expression.
 `break` without an expression is considered identical to `break` with expression `()`.
 
-[LIFETIME_OR_LABEL]: ../tokens.md#lifetimes-and-loop-labels
-[_BlockExpression_]: block-expr.md
-[_Expression_]: ../expressions.md
-[_Pattern_]: ../patterns.md
-[_Scrutinee_]: match-expr.md
 [`match` expression]: match-expr.md
 [boolean]: ../types/boolean.md
 [scrutinee]: ../glossary.md#scrutinee
 [temporary values]: ../expressions.md#temporaries
-[_LazyBooleanOperatorExpression_]: operator-expr.md#lazy-boolean-operators
 [`if let` expressions]: if-expr.md#if-let-expressions

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -2,28 +2,24 @@ r[expr.match]
 # `match` expressions
 
 r[expr.match.syntax]
-> **<sup>Syntax</sup>**\
-> _MatchExpression_ :\
-> &nbsp;&nbsp; `match` _Scrutinee_ `{`\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>\
-> &nbsp;&nbsp; &nbsp;&nbsp; _MatchArms_<sup>?</sup>\
-> &nbsp;&nbsp; `}`
->
-> _Scrutinee_ :\
-> &nbsp;&nbsp; [_Expression_]<sub>_except struct expression_</sub>
->
-> _MatchArms_ :\
-> &nbsp;&nbsp; ( _MatchArm_ `=>`
->                             ( [_ExpressionWithoutBlock_][_Expression_] `,`
->                             | [_ExpressionWithBlock_][_Expression_] `,`<sup>?</sup> )
->                           )<sup>\*</sup>\
-> &nbsp;&nbsp; _MatchArm_ `=>` [_Expression_] `,`<sup>?</sup>
->
-> _MatchArm_ :\
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> [_Pattern_] _MatchArmGuard_<sup>?</sup>
->
-> _MatchArmGuard_ :\
-> &nbsp;&nbsp; `if` [_Expression_]
+```grammar,expressions
+MatchExpression ->
+    `match` Scrutinee `{`
+        InnerAttribute*
+        MatchArms?
+    `}`
+
+Scrutinee -> Expression _except [StructExprStruct]_
+
+MatchArms ->
+    ( MatchArm `=>` ( ExpressionWithoutBlock `,` | ExpressionWithBlock `,`? ) )*
+    MatchArm `=>` Expression `,`?
+
+MatchArm -> OuterAttribute* Pattern MatchArmGuard?
+
+MatchArmGuard -> `if` Expression
+```
+<!-- TODO: The exception above isn't accurate, see https://github.com/rust-lang/reference/issues/569 -->
 
 r[expr.match.intro]
 A *`match` expression* branches on a pattern.
@@ -164,19 +160,14 @@ The only attributes that have meaning on match arms are [`cfg`] and the [lint ch
 r[expr.match.attributes.inner]
 [Inner attributes] are allowed directly after the opening brace of the match expression in the same expression contexts as [attributes on block expressions].
 
-[_Expression_]: ../expressions.md
-[place expression]: ../expressions.md#place-expressions-and-value-expressions
-[value expression]: ../expressions.md#place-expressions-and-value-expressions
-[_InnerAttribute_]: ../attributes.md
-[_OuterAttribute_]: ../attributes.md
 [`cfg`]: ../conditional-compilation.md
-[lint check attributes]: ../attributes/diagnostics.md#lint-check-attributes
-[Range Expression]: range-expr.md
-
-[_Pattern_]: ../patterns.md
-[pattern]: ../patterns.md
-[Inner attributes]: ../attributes.md
-[Range Pattern]: ../patterns.md#range-patterns
 [attributes on block expressions]: block-expr.md#attributes-on-block-expressions
 [binding mode]: ../patterns.md#binding-modes
+[Inner attributes]: ../attributes.md
+[lint check attributes]: ../attributes/diagnostics.md#lint-check-attributes
+[pattern]: ../patterns.md
+[place expression]: ../expressions.md#place-expressions-and-value-expressions
+[Range Expression]: range-expr.md
+[Range Pattern]: ../patterns.md#range-patterns
 [scrutinee]: ../glossary.md#scrutinee
+[value expression]: ../expressions.md#place-expressions-and-value-expressions

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -9,7 +9,7 @@ r[expr.match.syntax]
 > &nbsp;&nbsp; &nbsp;&nbsp; _MatchArms_<sup>?</sup>\
 > &nbsp;&nbsp; `}`
 >
->_Scrutinee_ :\
+> _Scrutinee_ :\
 > &nbsp;&nbsp; [_Expression_]<sub>_except struct expression_</sub>
 >
 > _MatchArms_ :\

--- a/src/expressions/method-call-expr.md
+++ b/src/expressions/method-call-expr.md
@@ -2,9 +2,9 @@ r[expr.method]
 # Method-call expressions
 
 r[expr.method.syntax]
-> **<sup>Syntax</sup>**\
-> _MethodCallExpression_ :\
-> &nbsp;&nbsp; [_Expression_] `.` [_PathExprSegment_] `(`[_CallParams_]<sup>?</sup> `)`
+```grammar,expressions
+MethodCallExpression -> Expression `.` PathExprSegment `(`CallParams? `)`
+```
 
 r[expr.method.intro]
 A _method call_ consists of an expression (the *receiver*) followed by a single dot, an expression path segment, and a parenthesized expression-list.
@@ -93,9 +93,6 @@ r[expr.method.edition2021]
 > There is no way to call the inherent method.
 > Just don't define inherent methods on trait objects with the same name as a trait method and you'll be fine.
 
-[_CallParams_]: call-expr.md
-[_Expression_]: ../expressions.md
-[_PathExprSegment_]: ../paths.md#paths-in-expressions
 [visible]: ../visibility-and-privacy.md
 [array type]: ../types/array.md
 [trait objects]: ../types/trait-object.md

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -2,18 +2,19 @@ r[expr.operator]
 # Operator expressions
 
 r[expr.operator.syntax]
-> **<sup>Syntax</sup>**\
-> _OperatorExpression_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_BorrowExpression_]\
-> &nbsp;&nbsp; | [_DereferenceExpression_]\
-> &nbsp;&nbsp; | [_ErrorPropagationExpression_]\
-> &nbsp;&nbsp; | [_NegationExpression_]\
-> &nbsp;&nbsp; | [_ArithmeticOrLogicalExpression_]\
-> &nbsp;&nbsp; | [_ComparisonExpression_]\
-> &nbsp;&nbsp; | [_LazyBooleanExpression_]\
-> &nbsp;&nbsp; | [_TypeCastExpression_]\
-> &nbsp;&nbsp; | [_AssignmentExpression_]\
-> &nbsp;&nbsp; | [_CompoundAssignmentExpression_]
+```grammar,expressions
+OperatorExpression ->
+      BorrowExpression
+    | DereferenceExpression
+    | ErrorPropagationExpression
+    | NegationExpression
+    | ArithmeticOrLogicalExpression
+    | ComparisonExpression
+    | LazyBooleanExpression
+    | TypeCastExpression
+    | AssignmentExpression
+    | CompoundAssignmentExpression
+```
 
 r[expr.operator.intro]
 Operators are defined for built in types by the Rust language.
@@ -55,12 +56,13 @@ r[expr.operator.borrow]
 ## Borrow operators
 
 r[expr.operator.borrow.syntax]
-> **<sup>Syntax</sup>**\
-> _BorrowExpression_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; (`&`|`&&`) [_Expression_]\
-> &nbsp;&nbsp; | (`&`|`&&`) `mut` [_Expression_]\
-> &nbsp;&nbsp; | (`&`|`&&`) `raw` `const` [_Expression_]\
-> &nbsp;&nbsp; | (`&`|`&&`) `raw` `mut` [_Expression_]
+```grammar,expressions
+BorrowExpression ->
+      (`&`|`&&`) Expression
+    | (`&`|`&&`) `mut` Expression
+    | (`&`|`&&`) `raw` `const` Expression
+    | (`&`|`&&`) `raw` `mut` Expression
+```
 
 r[expr.operator.borrow.intro]
 The `&` (shared borrow) and `&mut` (mutable borrow) operators are unary prefix operators.
@@ -160,9 +162,9 @@ r[expr.deref]
 ## The dereference operator
 
 r[expr.deref.syntax]
-> **<sup>Syntax</sup>**\
-> _DereferenceExpression_ :\
-> &nbsp;&nbsp; `*` [_Expression_]
+```grammar,expressions
+DereferenceExpression -> `*` Expression
+```
 
 r[expr.deref.intro]
 The `*` (dereference) operator is also a unary prefix operator.
@@ -191,9 +193,9 @@ r[expr.try]
 ## The question mark operator
 
 r[expr.try.syntax]
-> **<sup>Syntax</sup>**\
-> _ErrorPropagationExpression_ :\
-> &nbsp;&nbsp; [_Expression_] `?`
+```grammar,expressions
+ErrorPropagationExpression -> Expression `?`
+```
 
 r[expr.try.intro]
 The question mark operator (`?`) unwraps valid values or returns erroneous values, propagating them to the calling function.
@@ -253,10 +255,11 @@ r[expr.negate]
 ## Negation operators
 
 r[expr.negate.syntax]
-> **<sup>Syntax</sup>**\
-> _NegationExpression_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `-` [_Expression_]\
-> &nbsp;&nbsp; | `!` [_Expression_]
+```grammar,expressions
+NegationExpression ->
+      `-` Expression
+    | `!` Expression
+```
 
 r[expr.negate.intro]
 These are the last two unary operators.
@@ -286,18 +289,19 @@ r[expr.arith-logic]
 ## Arithmetic and Logical Binary Operators
 
 r[expr.arith-logic.syntax]
-> **<sup>Syntax</sup>**\
-> _ArithmeticOrLogicalExpression_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_Expression_] `+` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `-` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `*` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `/` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `%` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `&` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `|` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `^` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `<<` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `>>` [_Expression_]
+```grammar,expressions
+ArithmeticOrLogicalExpression ->
+      Expression `+` Expression
+    | Expression `-` Expression
+    | Expression `*` Expression
+    | Expression `/` Expression
+    | Expression `%` Expression
+    | Expression `&` Expression
+    | Expression `|` Expression
+    | Expression `^` Expression
+    | Expression `<<` Expression
+    | Expression `>>` Expression
+```
 
 r[expr.arith-logic.intro]
 Binary operators expressions are all written with infix notation.
@@ -348,14 +352,15 @@ r[expr.cmp]
 ## Comparison Operators
 
 r[expr.cmp.syntax]
-> **<sup>Syntax</sup>**\
-> _ComparisonExpression_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_Expression_] `==` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `!=` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `>` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `<` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `>=` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `<=` [_Expression_]
+```grammar,expressions
+ComparisonExpression ->
+      Expression `==` Expression
+    | Expression `!=` Expression
+    | Expression `>` Expression
+    | Expression `<` Expression
+    | Expression `>=` Expression
+    | Expression `<=` Expression
+```
 
 r[expr.cmp.intro]
 Comparison operators are also defined both for primitive types and many types in the standard library.
@@ -406,10 +411,11 @@ r[expr.bool-logic]
 ## Lazy boolean operators
 
 r[expr.bool-logic.syntax]
-> **<sup>Syntax</sup>**\
-> _LazyBooleanExpression_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_Expression_] `||` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `&&` [_Expression_]
+```grammar,expressions
+LazyBooleanExpression ->
+      Expression `||` Expression
+    | Expression `&&` Expression
+```
 
 r[expr.bool-logic.intro]
 The operators `||` and `&&` may be applied to operands of boolean type.
@@ -428,9 +434,9 @@ r[expr.as]
 ## Type cast expressions
 
 r[expr.as.syntax]
-> **<sup>Syntax</sup>**\
-> _TypeCastExpression_ :\
-> &nbsp;&nbsp; [_Expression_] `as` [_TypeNoBounds_]
+```grammar,expressions
+TypeCastExpression -> Expression `as` TypeNoBounds
+```
 
 r[expr.as.intro]
 A type cast expression is denoted with the binary operator `as`.
@@ -689,9 +695,9 @@ r[expr.assign]
 ## Assignment expressions
 
 r[expr.assign.syntax]
-> **<sup>Syntax</sup>**\
-> _AssignmentExpression_ :\
-> &nbsp;&nbsp; [_Expression_] `=` [_Expression_]
+```grammar,expressions
+AssignmentExpression -> Expression `=` Expression
+```
 
 r[expr.assign.intro]
 An *assignment expression* moves a value into a specified place.
@@ -792,7 +798,7 @@ r[expr.assign.destructure.repeat-ident]
 Identifiers are not forbidden from being used multiple times in a single assignee expression.
 
 r[expr.assign.destructure.discard-value]
-[Underscore expressions][_UnderscoreExpression_] and empty [range expressions][_RangeExpression_] may be used to ignore certain values, without binding them.
+[Underscore expressions] and empty [range expressions] may be used to ignore certain values, without binding them.
 
 r[expr.assign.destructure.default-binding]
 Note that default binding modes do not apply for the desugared expression.
@@ -801,18 +807,19 @@ r[expr.compound-assign]
 ## Compound assignment expressions
 
 r[expr.compound-assign.syntax]
-> **<sup>Syntax</sup>**\
-> _CompoundAssignmentExpression_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_Expression_] `+=` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `-=` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `*=` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `/=` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `%=` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `&=` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `|=` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `^=` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `<<=` [_Expression_]\
-> &nbsp;&nbsp; | [_Expression_] `>>=` [_Expression_]
+```grammar,expressions
+CompoundAssignmentExpression ->
+      Expression `+=` Expression
+    | Expression `-=` Expression
+    | Expression `*=` Expression
+    | Expression `/=` Expression
+    | Expression `%=` Expression
+    | Expression `&=` Expression
+    | Expression `|=` Expression
+    | Expression `^=` Expression
+    | Expression `<<=` Expression
+    | Expression `>>=` Expression
+```
 
 r[expr.compound-assign.intro]
 *Compound assignment expressions* combine arithmetic and logical binary operators with assignment expressions.
@@ -899,22 +906,8 @@ Like assignment expressions, compound assignment expressions always produce [the
 [Function pointer]: ../types/function-pointer.md
 [Function item]: ../types/function-item.md
 [undefined behavior]: ../behavior-considered-undefined.md
-
-[_BorrowExpression_]: #borrow-operators
-[_DereferenceExpression_]: #the-dereference-operator
-[_ErrorPropagationExpression_]: #the-question-mark-operator
-[_NegationExpression_]: #negation-operators
-[_ArithmeticOrLogicalExpression_]: #arithmetic-and-logical-binary-operators
-[_ComparisonExpression_]: #comparison-operators
-[_LazyBooleanExpression_]: #lazy-boolean-operators
-[_TypeCastExpression_]: #type-cast-expressions
-[_AssignmentExpression_]: #assignment-expressions
-[_CompoundAssignmentExpression_]: #compound-assignment-expressions
-
-[_Expression_]: ../expressions.md
-[_TypeNoBounds_]: ../types.md#type-expressions
-[_RangeExpression_]: ./range-expr.md
-[_UnderscoreExpression_]: ./underscore-expr.md
+[Underscore expressions]: ./underscore-expr.md
+[range expressions]: ./range-expr.md
 
 <script>
 (function() {

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -54,6 +54,7 @@ r[expr.operator.int-overflow.shift]
 r[expr.operator.borrow]
 ## Borrow operators
 
+r[expr.operator.borrow.syntax]
 > **<sup>Syntax</sup>**\
 > _BorrowExpression_ :\
 > &nbsp;&nbsp; &nbsp;&nbsp; (`&`|`&&`) [_Expression_]\

--- a/src/expressions/path-expr.md
+++ b/src/expressions/path-expr.md
@@ -2,10 +2,11 @@ r[expr.path]
 # Path expressions
 
 r[expr.path.syntax]
-> **<sup>Syntax</sup>**\
-> _PathExpression_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_PathInExpression_]\
-> &nbsp;&nbsp; | [_QualifiedPathInExpression_]
+```grammar,expressions
+PathExpression ->
+      PathInExpression
+    | QualifiedPathInExpression
+```
 
 r[expr.path.intro]
 A [path] used as an expression context denotes either a local variable or an item.
@@ -33,8 +34,6 @@ let slice_reverse = <[i32]>::reverse;
 r[expr.path.const]
 Evaluation of associated constants is handled the same way as [`const` blocks].
 
-[_PathInExpression_]: ../paths.md#paths-in-expressions
-[_QualifiedPathInExpression_]: ../paths.md#qualified-paths
 [place expressions]: ../expressions.md#place-expressions-and-value-expressions
 [value expressions]: ../expressions.md#place-expressions-and-value-expressions
 [path]: ../paths.md

--- a/src/expressions/range-expr.md
+++ b/src/expressions/range-expr.md
@@ -1,33 +1,29 @@
+
 r[expr.range]
 # Range expressions
 
 r[expr.range.syntax]
-> **<sup>Syntax</sup>**\
-> _RangeExpression_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; _RangeExpr_\
-> &nbsp;&nbsp; | _RangeFromExpr_\
-> &nbsp;&nbsp; | _RangeToExpr_\
-> &nbsp;&nbsp; | _RangeFullExpr_\
-> &nbsp;&nbsp; | _RangeInclusiveExpr_\
-> &nbsp;&nbsp; | _RangeToInclusiveExpr_
->
-> _RangeExpr_ :\
-> &nbsp;&nbsp; [_Expression_] `..` [_Expression_]
->
-> _RangeFromExpr_ :\
-> &nbsp;&nbsp; [_Expression_] `..`
->
-> _RangeToExpr_ :\
-> &nbsp;&nbsp; `..` [_Expression_]
->
-> _RangeFullExpr_ :\
-> &nbsp;&nbsp; `..`
->
-> _RangeInclusiveExpr_ :\
-> &nbsp;&nbsp; [_Expression_] `..=` [_Expression_]
->
-> _RangeToInclusiveExpr_ :\
-> &nbsp;&nbsp; `..=` [_Expression_]
+```grammar,expressions
+RangeExpression ->
+      RangeExpr
+    | RangeFromExpr
+    | RangeToExpr
+    | RangeFullExpr
+    | RangeInclusiveExpr
+    | RangeToInclusiveExpr
+
+RangeExpr -> Expression `..` Expression
+
+RangeFromExpr -> Expression `..`
+
+RangeToExpr -> `..` Expression
+
+RangeFullExpr -> `..`
+
+RangeInclusiveExpr -> Expression `..=` Expression
+
+RangeToInclusiveExpr -> `..=` Expression
+```
 
 r[expr.range.behavior]
 The `..` and `..=` operators will construct an object of one of the `std::ops::Range` (or `core::ops::Range`) variants, according to the following table:
@@ -70,5 +66,3 @@ for i in 1..11 {
     println!("{}", i);
 }
 ```
-
-[_Expression_]: ../expressions.md

--- a/src/expressions/return-expr.md
+++ b/src/expressions/return-expr.md
@@ -2,9 +2,9 @@ r[expr.return]
 # `return` expressions
 
 r[expr.return.syntax]
-> **<sup>Syntax</sup>**\
-> _ReturnExpression_ :\
-> &nbsp;&nbsp; `return` [_Expression_]<sup>?</sup>
+```grammar,expressions
+ReturnExpression -> `return` Expression?
+```
 
 r[expr.return.intro]
 Return expressions are denoted with the keyword `return`.
@@ -22,5 +22,3 @@ fn max(a: i32, b: i32) -> i32 {
     return b;
 }
 ```
-
-[_Expression_]: ../expressions.md

--- a/src/expressions/struct-expr.md
+++ b/src/expressions/struct-expr.md
@@ -2,34 +2,34 @@ r[expr.struct]
 # Struct expressions
 
 r[expr.struct.syntax]
-> **<sup>Syntax</sup>**\
-> _StructExpression_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; _StructExprStruct_\
-> &nbsp;&nbsp; | _StructExprTuple_\
-> &nbsp;&nbsp; | _StructExprUnit_
->
-> _StructExprStruct_ :\
-> &nbsp;&nbsp; [_PathInExpression_] `{` (_StructExprFields_ | _StructBase_)<sup>?</sup> `}`
->
-> _StructExprFields_ :\
-> &nbsp;&nbsp; _StructExprField_ (`,` _StructExprField_)<sup>\*</sup> (`,` _StructBase_ | `,`<sup>?</sup>)
->
-> _StructExprField_ :\
-> &nbsp;&nbsp; [_OuterAttribute_] <sup>\*</sup>\
-> &nbsp;&nbsp; (\
-> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; [IDENTIFIER]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | ([IDENTIFIER] | [TUPLE_INDEX]) `:` [_Expression_]\
-> &nbsp;&nbsp; )
->
-> _StructBase_ :\
-> &nbsp;&nbsp; `..` [_Expression_]
->
-> _StructExprTuple_ :\
-> &nbsp;&nbsp; [_PathInExpression_] `(`\
-> &nbsp;&nbsp; &nbsp;&nbsp; ( [_Expression_] (`,` [_Expression_])<sup>\*</sup> `,`<sup>?</sup> )<sup>?</sup>\
-> &nbsp;&nbsp; `)`
->
-> _StructExprUnit_ : [_PathInExpression_]
+```grammar,expressions
+StructExpression ->
+      StructExprStruct
+    | StructExprTuple
+    | StructExprUnit
+
+StructExprStruct ->
+    PathInExpression `{` (StructExprFields | StructBase)? `}`
+
+StructExprFields ->
+    StructExprField (`,` StructExprField)* (`,` StructBase | `,`?)
+
+StructExprField ->
+    OuterAttribute*
+    (
+        IDENTIFIER
+      | (IDENTIFIER | TUPLE_INDEX) `:` Expression
+    )
+
+StructBase -> `..` Expression
+
+StructExprTuple ->
+    PathInExpression `(`
+      ( Expression (`,` Expression)* `,`? )?
+    `)`
+
+StructExprUnit -> PathInExpression
+```
 
 r[expr.struct.intro]
 A *struct expression* creates a struct, enum, or union value.
@@ -142,11 +142,6 @@ let a = Gamma;  // Gamma unit value.
 let b = Gamma{};  // Exact same value as `a`.
 ```
 
-[_OuterAttribute_]: ../attributes.md
-[IDENTIFIER]: ../identifiers.md
-[TUPLE_INDEX]: ../tokens.md#tuple-index
-[_Expression_]: ../expressions.md
-[_PathInExpression_]: ../paths.md#paths-in-expressions
 [call expression]: call-expr.md
 [enum variant]: ../items/enumerations.md
 [if let]: if-expr.md#if-let-expressions

--- a/src/expressions/tuple-expr.md
+++ b/src/expressions/tuple-expr.md
@@ -4,12 +4,11 @@ r[expr.tuple]
 ## Tuple expressions
 
 r[expr.tuple.syntax]
-> **<sup>Syntax</sup>**\
-> _TupleExpression_ :\
-> &nbsp;&nbsp; `(` _TupleElements_<sup>?</sup> `)`
->
-> _TupleElements_ :\
-> &nbsp;&nbsp; ( [_Expression_] `,` )<sup>+</sup> [_Expression_]<sup>?</sup>
+```grammar,expressions
+TupleExpression -> `(` TupleElements? `)`
+
+TupleElements -> ( Expression `,` )+ Expression?
+```
 
 r[expr.tuple.result]
 A *tuple expression* constructs [tuple values][tuple type].
@@ -46,9 +45,9 @@ r[expr.tuple-index]
 ## Tuple indexing expressions
 
 r[expr.tuple-index.syntax]
-> **<sup>Syntax</sup>**\
-> _TupleIndexingExpression_ :\
-> &nbsp;&nbsp; [_Expression_] `.` [TUPLE_INDEX]
+```grammar,expressions
+TupleIndexingExpression -> Expression `.` TUPLE_INDEX
+```
 
 r[expr.tuple-index.intro]
 A *tuple indexing expression* accesses fields of [tuples][tuple type] and [tuple structs][tuple struct].
@@ -89,7 +88,6 @@ assert_eq!(point.1, 0.0);
 > [!NOTE]
 > Although arrays and slices also have elements, you must use an [array or slice indexing expression] or a [slice pattern] to access their elements.
 
-[_Expression_]: ../expressions.md
 [array or slice indexing expression]: array-expr.md#array-and-slice-indexing-expressions
 [call expression]: ./call-expr.md
 [decimal literal]: ../tokens.md#integer-literals
@@ -100,5 +98,4 @@ assert_eq!(point.1, 0.0);
 [slice pattern]: ../patterns.md#slice-patterns
 [tuple type]: ../types/tuple.md
 [tuple struct]: ../types/struct.md
-[TUPLE_INDEX]: ../tokens.md#tuple-index
 [value expression]: ../expressions.md#place-expressions-and-value-expressions

--- a/src/expressions/underscore-expr.md
+++ b/src/expressions/underscore-expr.md
@@ -2,9 +2,9 @@ r[expr.placeholder]
 # `_` expressions
 
 r[expr.placeholder.syntax]
-> **<sup>Syntax</sup>**\
-> _UnderscoreExpression_ :\
-> &nbsp;&nbsp; `_`
+```grammar,expressions
+UnderscoreExpression -> `_`
+```
 
 r[expr.placeholder.intro]
 Underscore expressions, denoted with the symbol `_`, are used to signify a

--- a/src/grammar.md
+++ b/src/grammar.md
@@ -1,0 +1,5 @@
+# Grammar summary
+
+The following is a summary of the grammar production rules.
+
+{{ grammar-summary }}

--- a/src/identifiers.md
+++ b/src/identifiers.md
@@ -2,23 +2,23 @@ r[ident]
 # Identifiers
 
 r[ident.syntax]
-> **<sup>Lexer:</sup>**\
-> IDENTIFIER_OR_KEYWORD :\
-> &nbsp;&nbsp; &nbsp;&nbsp; XID_Start XID_Continue<sup>\*</sup>\
-> &nbsp;&nbsp; | `_` XID_Continue<sup>+</sup>
->
-> XID_Start : \<`XID_Start` defined by Unicode\>
->
-> XID_Continue : \<`XID_Continue` defined by Unicode\>
->
-> RAW_IDENTIFIER : `r#` IDENTIFIER_OR_KEYWORD <sub>*except `crate`, `self`, `super`, `Self`*</sub>
->
-> NON_KEYWORD_IDENTIFIER : IDENTIFIER_OR_KEYWORD <sub>*except a [strict] or [reserved] keyword*</sub>
->
-> IDENTIFIER :\
-> NON_KEYWORD_IDENTIFIER | RAW_IDENTIFIER
->
-> RESERVED_RAW_IDENTIFIER : `r#_`
+```grammar,lexer
+IDENTIFIER_OR_KEYWORD ->
+      XID_Start XID_Continue*
+    | `_` XID_Continue+
+
+XID_Start -> <`XID_Start` defined by Unicode>
+
+XID_Continue -> <`XID_Continue` defined by Unicode>
+
+RAW_IDENTIFIER -> `r#` IDENTIFIER_OR_KEYWORD _except `crate`, `self`, `super`, `Self`_
+
+NON_KEYWORD_IDENTIFIER -> IDENTIFIER_OR_KEYWORD _except a [strict][lex.keywords.strict] or [reserved][lex.keywords.reserved] keyword_
+
+IDENTIFIER -> NON_KEYWORD_IDENTIFIER | RAW_IDENTIFIER
+
+RESERVED_RAW_IDENTIFIER -> `r#_`
+```
 
 <!-- When updating the version, update the UAX links, too. -->
 r[ident.unicode]
@@ -76,9 +76,8 @@ Unlike a normal identifier, a raw identifier may be any strict or reserved
 keyword except the ones listed above for `RAW_IDENTIFIER`.
 
 r[ident.raw.reserved]
-It is an error to use the RESERVED_RAW_IDENTIFIER token `r#_` in order to avoid confusion with the [_WildcardPattern_].
+It is an error to use the [RESERVED_RAW_IDENTIFIER] token `r#_` in order to avoid confusion with the [WildcardPattern].
 
-[_WildcardPattern_]: patterns.md#wildcard-pattern
 [`extern crate`]: items/extern-crates.md
 [`no_mangle`]: abi.md#the-no_mangle-attribute
 [`path` attribute]: items/modules.md#the-path-attribute

--- a/src/identifiers.md
+++ b/src/identifiers.md
@@ -7,6 +7,10 @@ r[ident.syntax]
 > &nbsp;&nbsp; &nbsp;&nbsp; XID_Start XID_Continue<sup>\*</sup>\
 > &nbsp;&nbsp; | `_` XID_Continue<sup>+</sup>
 >
+> XID_Start : \<`XID_Start` defined by Unicode\>
+>
+> XID_Continue : \<`XID_Continue` defined by Unicode\>
+>
 > RAW_IDENTIFIER : `r#` IDENTIFIER_OR_KEYWORD <sub>*except `crate`, `self`, `super`, `Self`*</sub>
 >
 > NON_KEYWORD_IDENTIFIER : IDENTIFIER_OR_KEYWORD <sub>*except a [strict] or [reserved] keyword*</sub>

--- a/src/identifiers.md
+++ b/src/identifiers.md
@@ -7,9 +7,9 @@ r[ident.syntax]
 > &nbsp;&nbsp; &nbsp;&nbsp; XID_Start XID_Continue<sup>\*</sup>\
 > &nbsp;&nbsp; | `_` XID_Continue<sup>+</sup>
 >
-> RAW_IDENTIFIER : `r#` IDENTIFIER_OR_KEYWORD <sub>*Except `crate`, `self`, `super`, `Self`*</sub>
+> RAW_IDENTIFIER : `r#` IDENTIFIER_OR_KEYWORD <sub>*except `crate`, `self`, `super`, `Self`*</sub>
 >
-> NON_KEYWORD_IDENTIFIER : IDENTIFIER_OR_KEYWORD <sub>*Except a [strict] or [reserved] keyword*</sub>
+> NON_KEYWORD_IDENTIFIER : IDENTIFIER_OR_KEYWORD <sub>*except a [strict] or [reserved] keyword*</sub>
 >
 > IDENTIFIER :\
 > NON_KEYWORD_IDENTIFIER | RAW_IDENTIFIER

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -106,14 +106,7 @@ These conventions are documented here.
 
   All examples are written for the latest edition unless otherwise stated.
 
-* The grammar and lexical structure is in blockquotes with either "Lexer" or "Syntax" in <sup>**bold superscript**</sup> as the first line.
-
-  > **<sup>Syntax</sup>**\
-  > _ExampleGrammar_:\
-  > &nbsp;&nbsp; &nbsp;&nbsp; `~` [_Expression_]\
-  > &nbsp;&nbsp; | `box` [_Expression_]
-
-  See [Notation] for more detail.
+* The grammar and lexical productions are described in the [Notation] chapter.
 
 r[example.rule.label]
 * Rule identifiers appear before each language rule enclosed in square brackets. These identifiers provide a way to refer to and link to a specific rule in the language ([e.g.][example rule]). The rule identifier uses periods to separate sections from most general to most specific ([destructors.scope.nesting.function-body] for example). On narrow screens, the rule name will collapse to display `[*]`.
@@ -141,7 +134,6 @@ We also want the reference to be as normative as possible, so if you see anythin
 [standard library]: std
 [the Rust Reference repository]: https://github.com/rust-lang/reference/
 [Unstable Book]: https://doc.rust-lang.org/nightly/unstable-book/
-[_Expression_]: expressions.md
 [cargo book]: ../cargo/index.html
 [cargo reference]: ../cargo/reference/index.html
 [example rule]: example.rule.label

--- a/src/items.md
+++ b/src/items.md
@@ -2,33 +2,32 @@ r[items]
 # Items
 
 r[items.syntax]
-> **<sup>Syntax:</sup>**\
-> _Item_:\
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup>\
-> &nbsp;&nbsp; &nbsp;&nbsp; _VisItem_\
-> &nbsp;&nbsp; | _MacroItem_
->
-> _VisItem_:\
-> &nbsp;&nbsp; [_Visibility_]<sup>?</sup>\
-> &nbsp;&nbsp; (\
-> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp;  [_Module_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_ExternCrate_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_UseDeclaration_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_Function_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_TypeAlias_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_Struct_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_Enumeration_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_Union_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_ConstantItem_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_StaticItem_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_Trait_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_Implementation_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [_ExternBlock_]\
-> &nbsp;&nbsp; )
->
-> _MacroItem_:\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_MacroInvocationSemi_]\
-> &nbsp;&nbsp; | [_MacroRulesDefinition_]
+```grammar,items
+Item ->
+    OuterAttribute* ( VisItem | MacroItem )
+
+VisItem ->
+    Visibility?
+    (
+        Module
+      | ExternCrate
+      | UseDeclaration
+      | Function
+      | TypeAlias
+      | Struct
+      | Enumeration
+      | Union
+      | ConstantItem
+      | StaticItem
+      | Trait
+      | Implementation
+      | ExternBlock
+    )
+
+MacroItem ->
+      MacroInvocationSemi
+    | MacroRulesDefinition
+```
 
 r[items.intro]
 An _item_ is a component of a crate. Items are organized within a crate by a
@@ -74,23 +73,6 @@ r[items.name-resolution]
 
 See [item scopes] for information on the scoping rules of items.
 
-[_ConstantItem_]: items/constant-items.md
-[_Enumeration_]: items/enumerations.md
-[_ExternBlock_]: items/external-blocks.md
-[_ExternCrate_]: items/extern-crates.md
-[_Function_]: items/functions.md
-[_Implementation_]: items/implementations.md
-[_MacroInvocationSemi_]: macros.md#macro-invocation
-[_MacroRulesDefinition_]: macros-by-example.md
-[_Module_]: items/modules.md
-[_OuterAttribute_]: attributes.md
-[_StaticItem_]: items/static-items.md
-[_Struct_]: items/structs.md
-[_Trait_]: items/traits.md
-[_TypeAlias_]: items/type-aliases.md
-[_Union_]: items/unions.md
-[_UseDeclaration_]: items/use-declarations.md
-[_Visibility_]: visibility-and-privacy.md
 [`extern crate` declarations]: items/extern-crates.md
 [`extern` blocks]: items/external-blocks.md
 [`macro_rules`]: macros-by-example.md

--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -2,12 +2,13 @@ r[items.associated]
 # Associated Items
 
 r[items.associated.syntax]
-> **<sup>Syntax</sup>**\
-> _AssociatedItem_ :\
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> (\
-> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; [_MacroInvocationSemi_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | ( [_Visibility_]<sup>?</sup> ( [_TypeAlias_] | [_ConstantItem_] | [_Function_] ) )\
-> &nbsp;&nbsp; )
+```grammar,items
+AssociatedItem ->
+    OuterAttribute* (
+        MacroInvocationSemi
+      | ( Visibility? ( TypeAlias | ConstantItem | Function ) )
+    )
+```
 
 r[items.associated.intro]
 *Associated Items* are the items declared in [traits] or defined in
@@ -553,12 +554,6 @@ fn main() {
 }
 ```
 
-[_ConstantItem_]: constant-items.md
-[_Function_]: functions.md
-[_MacroInvocationSemi_]: ../macros.md#macro-invocation
-[_OuterAttribute_]: ../attributes.md
-[_TypeAlias_]: type-aliases.md
-[_Visibility_]: ../visibility-and-privacy.md
 [`Arc<Self>`]: ../special-types-and-traits.md#arct
 [`Box<Self>`]: ../special-types-and-traits.md#boxt
 [`Pin<P>`]: ../special-types-and-traits.md#pinp

--- a/src/items/constant-items.md
+++ b/src/items/constant-items.md
@@ -2,9 +2,10 @@ r[items.const]
 # Constant items
 
 r[items.const.syntax]
-> **<sup>Syntax</sup>**\
-> _ConstantItem_ :\
-> &nbsp;&nbsp; `const` ( [IDENTIFIER] | `_` ) `:` [_Type_] ( `=` [_Expression_] )<sup>?</sup> `;`
+```grammar,items
+ConstantItem ->
+    `const` ( IDENTIFIER | `_` ) `:` Type ( `=` Expression )? `;`
+```
 
 r[items.const.intro]
 A *constant item* is an optionally named _[constant value]_ which is not associated
@@ -128,10 +129,7 @@ fn unused_generic_function<T>() {
 [free]: ../glossary.md#free-item
 [static lifetime elision]: ../lifetime-elision.md#const-and-static-elision
 [trait definition]: traits.md
-[IDENTIFIER]: ../identifiers.md
 [underscore imports]: use-declarations.md#underscore-imports
-[_Type_]: ../types.md#type-expressions
-[_Expression_]: ../expressions.md
 [`Copy`]: ../special-types-and-traits.md#copy
 [value namespace]: ../names/namespaces.md
 [promotion]: ../destructors.md#constant-promotion

--- a/src/items/enumerations.md
+++ b/src/items/enumerations.md
@@ -2,30 +2,22 @@ r[items.enum]
 # Enumerations
 
 r[items.enum.syntax]
-> **<sup>Syntax</sup>**\
-> _Enumeration_ :\
-> &nbsp;&nbsp; `enum`
->    [IDENTIFIER]&nbsp;
->    [_GenericParams_]<sup>?</sup>
->    [_WhereClause_]<sup>?</sup>
->    `{` _EnumItems_<sup>?</sup> `}`
->
-> _EnumItems_ :\
-> &nbsp;&nbsp; _EnumItem_ ( `,` _EnumItem_ )<sup>\*</sup> `,`<sup>?</sup>
->
-> _EnumItem_ :\
-> &nbsp;&nbsp; _OuterAttribute_<sup>\*</sup> [_Visibility_]<sup>?</sup>\
-> &nbsp;&nbsp; [IDENTIFIER]&nbsp;( _EnumItemTuple_ | _EnumItemStruct_ )<sup>?</sup>
->                                _EnumItemDiscriminant_<sup>?</sup>
->
-> _EnumItemTuple_ :\
-> &nbsp;&nbsp; `(` [_TupleFields_]<sup>?</sup> `)`
->
-> _EnumItemStruct_ :\
-> &nbsp;&nbsp; `{` [_StructFields_]<sup>?</sup> `}`
->
-> _EnumItemDiscriminant_ :\
-> &nbsp;&nbsp; `=` [_Expression_]
+```grammar,items
+Enumeration ->
+    `enum` IDENTIFIER GenericParams? WhereClause? `{` EnumItems? `}`
+
+EnumItems -> EnumItem ( `,` EnumItem )* `,`?
+
+EnumItem ->
+    OuterAttribute* Visibility?
+    IDENTIFIER ( EnumItemTuple | EnumItemStruct )? EnumItemDiscriminant?
+
+EnumItemTuple -> `(` TupleFields? `)`
+
+EnumItemStruct -> `{` StructFields? `}`
+
+EnumItemDiscriminant -> `=` Expression
+```
 
 r[items.enum.intro]
 An *enumeration*, also referred to as an *enum*, is a simultaneous definition of a
@@ -332,7 +324,7 @@ let y: u32 = x; // mismatched type error
 r[items.enum.variant-visibility]
 ## Variant visibility
 
-Enum variants syntactically allow a [_Visibility_] annotation, but this is
+Enum variants syntactically allow a [Visibility] annotation, but this is
 rejected when the enum is validated. This allows items to be parsed with a
 unified syntax across different contexts where they are used.
 
@@ -361,18 +353,11 @@ enum E {
 }
 ```
 
-[_Expression_]: ../expressions.md
-[_GenericParams_]: generics.md
-[_StructFields_]: structs.md
-[_TupleFields_]: structs.md
-[_Visibility_]: ../visibility-and-privacy.md
-[_WhereClause_]: generics.md#where-clauses
 [`C` representation]: ../type-layout.md#the-c-representation
 [call expression]: ../expressions/call-expr.md
 [constant expression]: ../const_eval.md#constant-expressions
 [enumerated type]: ../types/enum.md
 [Field-less enums]: #field-less-enum
-[IDENTIFIER]: ../identifiers.md
 [never type]: ../types/never.md
 [numeric cast]: ../expressions/operator-expr.md#semantics
 [path expression]: ../expressions/path-expr.md

--- a/src/items/extern-crates.md
+++ b/src/items/extern-crates.md
@@ -2,15 +2,13 @@ r[items.extern-crate]
 # Extern crate declarations
 
 r[items.extern-crate.syntax]
-> **<sup>Syntax:</sup>**\
-> _ExternCrate_ :\
-> &nbsp;&nbsp; `extern` `crate` _CrateRef_ _AsClause_<sup>?</sup> `;`
->
-> _CrateRef_ :\
-> &nbsp;&nbsp; [IDENTIFIER] | `self`
->
-> _AsClause_ :\
-> &nbsp;&nbsp; `as` ( [IDENTIFIER] | `_` )
+```grammar,items
+ExternCrate -> `extern` `crate` CrateRef AsClause? `;`
+
+CrateRef -> IDENTIFIER | `self`
+
+AsClause -> `as` ( IDENTIFIER | `_` )
+```
 
 r[items.extern-crate.intro]
 An _`extern crate` declaration_ specifies a dependency on an external crate.
@@ -82,7 +80,7 @@ The *`no_link` attribute* may be specified on an `extern crate` item to
 prevent linking the crate into the output. This is commonly used to load a
 crate to access only its macros.
 
-[IDENTIFIER]: ../identifiers.md
+[identifier]: ../identifiers.md
 [RFC 940]: https://github.com/rust-lang/rfcs/blob/master/text/0940-hyphens-considered-harmful.md
 [`macro_use` attribute]: ../macros-by-example.md#the-macro_use-attribute
 [extern prelude]: ../names/preludes.md#extern-prelude

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -2,20 +2,22 @@ r[items.extern]
 # External blocks
 
 r[items.extern.syntax]
-> **<sup>Syntax</sup>**\
-> _ExternBlock_ :\
-> &nbsp;&nbsp; `unsafe`<sup>?</sup>[^unsafe-2024] `extern` [_Abi_]<sup>?</sup> `{`\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>\
-> &nbsp;&nbsp; &nbsp;&nbsp; _ExternalItem_<sup>\*</sup>\
-> &nbsp;&nbsp; `}`
->
-> _ExternalItem_ :\
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> (\
-> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; [_MacroInvocationSemi_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | ( [_Visibility_]<sup>?</sup> ( [_StaticItem_] | [_Function_] ) )\
-> &nbsp;&nbsp; )
->
-> [^unsafe-2024]: Starting with the 2024 Edition, the `unsafe` keyword is required semantically.
+```grammar,items
+ExternBlock ->
+    `unsafe`?[^unsafe-2024] `extern` Abi? `{`
+        InnerAttribute*
+        ExternalItem*
+    `}`
+
+ExternalItem ->
+    OuterAttribute* (
+        MacroInvocationSemi
+      | Visibility? StaticItem
+      | Visibility? Function
+    )
+```
+
+[^unsafe-2024]: Starting with the 2024 Edition, the `unsafe` keyword is required semantically.
 
 r[items.extern.intro]
 External blocks provide _declarations_ of items that are not _defined_ in the
@@ -194,7 +196,7 @@ The *`link` attribute* specifies the name of a native library that the
 compiler should link with for the items within an `extern` block.
 
 r[items.extern.attributes.link.syntax]
-It uses the [_MetaListNameValueStr_] syntax to specify its inputs. The `name` key is the
+It uses the [MetaListNameValueStr] syntax to specify its inputs. The `name` key is the
 name of the native library to link. The `kind` key is an optional value which
 specifies the kind of library with the following possible values:
 
@@ -392,7 +394,7 @@ The *`link_name` attribute* may be specified on declarations inside an `extern`
 block to indicate the symbol to import for the given function or static.
 
 r[items.extern.attributes.link_name.syntax]
-It uses the [_MetaNameValueStr_] syntax to specify the name of the symbol.
+It uses the [MetaNameValueStr] syntax to specify the name of the symbol.
 
 ```rust
 unsafe extern {
@@ -441,19 +443,9 @@ r[items.extern.attributes.fn-parameters]
 Attributes on extern function parameters follow the same rules and
 restrictions as [regular function parameters].
 
-[IDENTIFIER]: ../identifiers.md
 [PE Format]: https://learn.microsoft.com/windows/win32/debug/pe-format#import-name-type
 [UEFI]: https://uefi.org/specifications
 [WebAssembly module]: https://webassembly.github.io/spec/core/syntax/modules.html
-[_Abi_]: functions.md
-[_Function_]: functions.md
-[_InnerAttribute_]: ../attributes.md
-[_MacroInvocationSemi_]: ../macros.md#macro-invocation
-[_MetaListNameValueStr_]: ../attributes.md#meta-item-attribute-syntax
-[_MetaNameValueStr_]: ../attributes.md#meta-item-attribute-syntax
-[_OuterAttribute_]: ../attributes.md
-[_StaticItem_]: static-items.md
-[_Visibility_]: ../visibility-and-privacy.md
 [`bundle` documentation for rustc]: ../../rustc/command-line-arguments.html#linking-modifiers-bundle
 [`dylib` versus `raw-dylib`]: #dylib-versus-raw-dylib
 [`verbatim` documentation for rustc]: ../../rustc/command-line-arguments.html#linking-modifiers-verbatim

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -2,57 +2,47 @@ r[items.fn]
 # Functions
 
 r[items.fn.syntax]
-> **<sup>Syntax</sup>**\
-> _Function_ :\
-> &nbsp;&nbsp; _FunctionQualifiers_ `fn` [IDENTIFIER]&nbsp;[_GenericParams_]<sup>?</sup>\
-> &nbsp;&nbsp; &nbsp;&nbsp; `(` _FunctionParameters_<sup>?</sup> `)`\
-> &nbsp;&nbsp; &nbsp;&nbsp; _FunctionReturnType_<sup>?</sup> [_WhereClause_]<sup>?</sup>\
-> &nbsp;&nbsp; &nbsp;&nbsp; ( [_BlockExpression_] | `;` )
->
-> _FunctionQualifiers_ :\
-> &nbsp;&nbsp; `const`<sup>?</sup> `async`[^async-edition]<sup>?</sup> _ItemSafety_<sup>?</sup>[^extern-qualifiers] (`extern` _Abi_<sup>?</sup>)<sup>?</sup>
->
-> _ItemSafety_ :\
-> &nbsp;&nbsp; `safe`[^extern-safe] | `unsafe`
->
-> _Abi_ :\
-> &nbsp;&nbsp; [STRING_LITERAL] | [RAW_STRING_LITERAL]
->
-> _FunctionParameters_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; _SelfParam_ `,`<sup>?</sup>\
-> &nbsp;&nbsp; | (_SelfParam_ `,`)<sup>?</sup> _FunctionParam_ (`,` _FunctionParam_)<sup>\*</sup> `,`<sup>?</sup>
->
-> _SelfParam_ :\
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> ( _ShorthandSelf_ | _TypedSelf_ )
->
-> _ShorthandSelf_ :\
-> &nbsp;&nbsp;  (`&` | `&` [_Lifetime_])<sup>?</sup> `mut`<sup>?</sup> `self`
->
-> _TypedSelf_ :\
-> &nbsp;&nbsp; `mut`<sup>?</sup> `self` `:` [_Type_]
->
-> _FunctionParam_ :\
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> (
->   _FunctionParamPattern_ | `...` | [_Type_] [^fn-param-2015]
-> )
->
-> _FunctionParamPattern_ :\
-> &nbsp;&nbsp; [_PatternNoTopAlt_] `:` ( [_Type_] | `...` )
->
-> _FunctionReturnType_ :\
-> &nbsp;&nbsp; `->` [_Type_]
->
-> [^async-edition]: The `async` qualifier is not allowed in the 2015 edition.
->
-> [^extern-safe]: The `safe` function qualifier is only allowed semantically within
->   `extern` blocks.
->
-> [^extern-qualifiers]: *Relevant to editions earlier than Rust 2024*: Within
->   `extern` blocks, the `safe` or `unsafe` function qualifier is only allowed
->   when the `extern` is qualified as `unsafe`.
->
-> [^fn-param-2015]: Function parameters with only a type are only allowed
->   in an associated function of a [trait item] in the 2015 edition.
+```grammar,items
+Function ->
+    FunctionQualifiers `fn` IDENTIFIER GenericParams?
+        `(` FunctionParameters? `)`
+        FunctionReturnType? WhereClause?
+        ( BlockExpression | `;` )
+
+FunctionQualifiers -> `const`? `async`?[^async-edition] ItemSafety?[^extern-qualifiers] (`extern` Abi?)?
+
+ItemSafety -> `safe`[^extern-safe] | `unsafe`
+
+Abi -> STRING_LITERAL | RAW_STRING_LITERAL
+
+FunctionParameters ->
+      SelfParam `,`?
+    | (SelfParam `,`)? FunctionParam (`,` FunctionParam)* `,`?
+
+SelfParam -> OuterAttribute* ( ShorthandSelf | TypedSelf )
+
+ShorthandSelf -> (`&` | `&` Lifetime)? `mut`? `self`
+
+TypedSelf -> `mut`? `self` `:` Type
+
+FunctionParam -> OuterAttribute* ( FunctionParamPattern | `...` | Type[^fn-param-2015] )
+
+FunctionParamPattern -> PatternNoTopAlt `:` ( Type | `...` )
+
+FunctionReturnType -> `->` Type
+```
+
+[^async-edition]: The `async` qualifier is not allowed in the 2015 edition.
+
+[^extern-safe]: The `safe` function qualifier is only allowed semantically within
+  `extern` blocks.
+
+[^extern-qualifiers]: *Relevant to editions earlier than Rust 2024*: Within
+  `extern` blocks, the `safe` or `unsafe` function qualifier is only allowed
+  when the `extern` is qualified as `unsafe`.
+
+[^fn-param-2015]: Function parameters with only a type are only allowed
+  in an associated function of a [trait item] in the 2015 edition.
 
 r[items.fn.intro]
 A _function_ consists of a [block] (that's the _body_ of the function),
@@ -465,16 +455,6 @@ fn foo_oof(#[some_inert_attribute] arg: u8) {
 }
 ```
 
-[IDENTIFIER]: ../identifiers.md
-[RAW_STRING_LITERAL]: ../tokens.md#raw-string-literals
-[STRING_LITERAL]: ../tokens.md#string-literals
-[_BlockExpression_]: ../expressions/block-expr.md
-[_GenericParams_]: generics.md
-[_Lifetime_]: ../trait-bounds.md
-[_PatternNoTopAlt_]: ../patterns.md
-[_Type_]: ../types.md#type-expressions
-[_WhereClause_]: generics.md#where-clauses
-[_OuterAttribute_]: ../attributes.md
 [const contexts]: ../const_eval.md#const-context
 [const functions]: ../const_eval.md#const-functions
 [tuple struct]: structs.md

--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -2,22 +2,21 @@ r[items.generics]
 # Generic parameters
 
 r[items.generics.syntax]
-> **<sup>Syntax</sup>**\
-> _GenericParams_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `<` `>`\
-> &nbsp;&nbsp;  | `<` (_GenericParam_ `,`)<sup>\*</sup> _GenericParam_ `,`<sup>?</sup> `>`
->
-> _GenericParam_ :\
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> ( _LifetimeParam_ | _TypeParam_ | _ConstParam_ )
->
-> _LifetimeParam_ :\
-> &nbsp;&nbsp; [_Lifetime_]&nbsp;( `:` [_LifetimeBounds_] )<sup>?</sup>
->
-> _TypeParam_ :\
-> &nbsp;&nbsp; [IDENTIFIER]&nbsp;( `:` [_TypeParamBounds_]<sup>?</sup> )<sup>?</sup> ( `=` [_Type_] )<sup>?</sup>
->
-> _ConstParam_:\
-> &nbsp;&nbsp; `const` [IDENTIFIER] `:` [_Type_] ( `=` _[BlockExpression][block]_ | [IDENTIFIER] | `-`<sup>?</sup>[_LiteralExpression_][literal] )<sup>?</sup>
+```grammar,items
+GenericParams ->
+      `<` `>`
+    | `<` (GenericParam `,`)* GenericParam `,`? `>`
+
+GenericParam -> OuterAttribute* ( LifetimeParam | TypeParam | ConstParam )
+
+LifetimeParam -> Lifetime ( `:` LifetimeBounds )?
+
+TypeParam -> IDENTIFIER ( `:` TypeParamBounds? )? ( `=` Type )?
+
+ConstParam ->
+    `const` IDENTIFIER `:` Type
+    ( `=` BlockExpression | IDENTIFIER | `-`?LiteralExpression )?
+```
 
 r[items.generics.syntax.intro]
 [Functions], [type aliases], [structs], [enumerations], [unions], [traits], and
@@ -234,19 +233,17 @@ r[items.generics.where]
 ## Where clauses
 
 r[items.generics.where.syntax]
-> **<sup>Syntax</sup>**\
-> _WhereClause_ :\
-> &nbsp;&nbsp; `where` ( _WhereClauseItem_ `,` )<sup>\*</sup> _WhereClauseItem_ <sup>?</sup>
->
-> _WhereClauseItem_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; _LifetimeWhereClauseItem_\
-> &nbsp;&nbsp; | _TypeBoundWhereClauseItem_
->
-> _LifetimeWhereClauseItem_ :\
-> &nbsp;&nbsp; [_Lifetime_] `:` [_LifetimeBounds_]
->
-> _TypeBoundWhereClauseItem_ :\
-> &nbsp;&nbsp; [_ForLifetimes_]<sup>?</sup> [_Type_] `:` [_TypeParamBounds_]<sup>?</sup>
+```grammar,items
+WhereClause -> `where` ( WhereClauseItem `,` )* WhereClauseItem ?
+
+WhereClauseItem ->
+      LifetimeWhereClauseItem
+    | TypeBoundWhereClauseItem
+
+LifetimeWhereClauseItem -> Lifetime `:` LifetimeBounds
+
+TypeBoundWhereClauseItem -> ForLifetimes? Type `:` TypeParamBounds?
+```
 
 r[items.generics.where.intro]
 *Where clauses* provide another way to specify bounds on type and lifetime
@@ -255,7 +252,7 @@ parameters.
 
 r[items.generics.where.higher-ranked-lifetimes]
 The `for` keyword can be used to introduce [higher-ranked lifetimes]. It only
-allows [_LifetimeParam_] parameters.
+allows [LifetimeParam] parameters.
 
 ```rust
 struct A<T>
@@ -288,16 +285,6 @@ struct Foo<#[my_flexible_clone(unbounded)] H> {
     a: *const H
 }
 ```
-
-[IDENTIFIER]: ../identifiers.md
-
-[_ForLifetimes_]: ../trait-bounds.md#higher-ranked-trait-bounds
-[_LifetimeParam_]: #generic-parameters
-[_LifetimeBounds_]: ../trait-bounds.md
-[_Lifetime_]: ../trait-bounds.md
-[_OuterAttribute_]: ../attributes.md
-[_Type_]: ../types.md#type-expressions
-[_TypeParamBounds_]: ../trait-bounds.md
 
 [array repeat expression]: ../expressions/array-expr.md
 [arrays]: ../types/array.md

--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -17,7 +17,7 @@ r[items.generics.syntax]
 > &nbsp;&nbsp; [IDENTIFIER]&nbsp;( `:` [_TypeParamBounds_]<sup>?</sup> )<sup>?</sup> ( `=` [_Type_] )<sup>?</sup>
 >
 > _ConstParam_:\
-> &nbsp;&nbsp; `const` [IDENTIFIER] `:` [_Type_] ( `=` _[Block][block]_ | [IDENTIFIER] | -<sup>?</sup>[LITERAL] )<sup>?</sup>
+> &nbsp;&nbsp; `const` [IDENTIFIER] `:` [_Type_] ( `=` _[BlockExpression][block]_ | [IDENTIFIER] | `-`<sup>?</sup>[_LiteralExpression_][literal] )<sup>?</sup>
 
 r[items.generics.syntax.intro]
 [Functions], [type aliases], [structs], [enumerations], [unions], [traits], and

--- a/src/items/implementations.md
+++ b/src/items/implementations.md
@@ -2,24 +2,23 @@ r[items.impl]
 # Implementations
 
 r[items.impl.syntax]
-> **<sup>Syntax</sup>**\
-> _Implementation_ :\
-> &nbsp;&nbsp; _InherentImpl_ | _TraitImpl_
->
-> _InherentImpl_ :\
-> &nbsp;&nbsp; `impl` [_GenericParams_]<sup>?</sup>&nbsp;[_Type_]&nbsp;[_WhereClause_]<sup>?</sup> `{`\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_AssociatedItem_]<sup>\*</sup>\
-> &nbsp;&nbsp; `}`
->
-> _TraitImpl_ :\
-> &nbsp;&nbsp; `unsafe`<sup>?</sup> `impl` [_GenericParams_]<sup>?</sup> `!`<sup>?</sup>
->              [_TypePath_] `for` [_Type_]\
-> &nbsp;&nbsp; [_WhereClause_]<sup>?</sup>\
-> &nbsp;&nbsp; `{`\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_AssociatedItem_]<sup>\*</sup>\
-> &nbsp;&nbsp; `}`
+```grammar,items
+Implementation -> InherentImpl | TraitImpl
+
+InherentImpl ->
+    `impl` GenericParams? Type WhereClause? `{`
+        InnerAttribute*
+        AssociatedItem*
+    `}`
+
+TraitImpl ->
+    `unsafe`? `impl` GenericParams? `!`? TypePath `for` Type
+    WhereClause?
+    `{`
+        InnerAttribute*
+        AssociatedItem*
+    `}`
+```
 
 r[items.impl.intro]
 An _implementation_ is an item that associates items with an _implementing type_.
@@ -301,12 +300,6 @@ attributes must come before any associated items. The attributes that have
 meaning here are [`cfg`], [`deprecated`], [`doc`], and [the lint check
 attributes].
 
-[_AssociatedItem_]: associated-items.md
-[_GenericParams_]: generics.md
-[_InnerAttribute_]: ../attributes.md
-[_TypePath_]: ../paths.md#paths-in-types
-[_Type_]: ../types.md#type-expressions
-[_WhereClause_]: generics.md#where-clauses
 [trait]: traits.md
 [associated constants]: associated-items.md#associated-constants
 [associated functions]: associated-items.md#associated-functions-and-methods

--- a/src/items/modules.md
+++ b/src/items/modules.md
@@ -2,13 +2,14 @@ r[items.mod]
 # Modules
 
 r[items.mod.syntax]
-> **<sup>Syntax:</sup>**\
-> _Module_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `unsafe`<sup>?</sup> `mod` [IDENTIFIER] `;`\
-> &nbsp;&nbsp; | `unsafe`<sup>?</sup> `mod` [IDENTIFIER] `{`\
-> &nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>\
-> &nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp; [_Item_]<sup>\*</sup>\
-> &nbsp;&nbsp; &nbsp;&nbsp; `}`
+```grammar,items
+Module ->
+      `unsafe`? `mod` IDENTIFIER `;`
+    | `unsafe`? `mod` IDENTIFIER `{`
+        InnerAttribute*
+        Item*
+      `}`
+```
 
 r[items.mod.intro]
 A module is a container for zero or more [items].
@@ -158,14 +159,11 @@ The built-in attributes that have meaning on a module are [`cfg`],
 [`deprecated`], [`doc`], [the lint check attributes], [`path`], and
 [`no_implicit_prelude`]. Modules also accept macro attributes.
 
-[_InnerAttribute_]: ../attributes.md
-[_Item_]: ../items.md
 [`cfg`]: ../conditional-compilation.md
 [`deprecated`]: ../attributes/diagnostics.md#the-deprecated-attribute
 [`doc`]: ../../rustdoc/the-doc-attribute.html
 [`no_implicit_prelude`]: ../names/preludes.md#the-no_implicit_prelude-attribute
 [`path`]: #the-path-attribute
-[IDENTIFIER]: ../identifiers.md
 [attribute]: ../attributes.md
 [items]: ../items.md
 [module path]: ../paths.md

--- a/src/items/static-items.md
+++ b/src/items/static-items.md
@@ -2,13 +2,12 @@ r[items.static]
 # Static items
 
 r[items.static.syntax]
-> **<sup>Syntax</sup>**\
-> _StaticItem_ :\
-> &nbsp;&nbsp; [_ItemSafety_]<sup>?</sup>[^extern-safety] `static` `mut`<sup>?</sup> [IDENTIFIER] `:` [_Type_]
->              ( `=` [_Expression_] )<sup>?</sup> `;`
->
-> [^extern-safety]: The `safe` and `unsafe` function qualifiers are only
->   allowed semantically within `extern` blocks.
+```grammar,items
+StaticItem ->
+    ItemSafety?[^extern-safety] `static` `mut`? IDENTIFIER `:` Type ( `=` Expression )? `;`
+```
+
+[^extern-safety]: The `safe` and `unsafe` function qualifiers are only allowed semantically within `extern` blocks.
 
 r[items.static.intro]
 A *static item* is similar to a [constant], except that it represents an allocated object in the
@@ -167,9 +166,5 @@ following are true:
 [constant expression]: ../const_eval.md#constant-expressions
 [external block]: external-blocks.md
 [interior mutable]: ../interior-mutability.md
-[IDENTIFIER]: ../identifiers.md
-[_Type_]: ../types.md#type-expressions
-[_Expression_]: ../expressions.md
 [value namespace]: ../names/namespaces.md
-[_ItemSafety_]: functions.md
 [promoteds]: ../destructors.md#constant-promotion

--- a/src/items/structs.md
+++ b/src/items/structs.md
@@ -2,41 +2,25 @@ r[items.struct]
 # Structs
 
 r[items.struct.syntax]
-> **<sup>Syntax</sup>**\
-> _Struct_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; _StructStruct_\
-> &nbsp;&nbsp; | _TupleStruct_
->
-> _StructStruct_ :\
-> &nbsp;&nbsp; `struct`
->   [IDENTIFIER]&nbsp;
->   [_GenericParams_]<sup>?</sup>
->   [_WhereClause_]<sup>?</sup>
->   ( `{` _StructFields_<sup>?</sup> `}` | `;` )
->
-> _TupleStruct_ :\
-> &nbsp;&nbsp; `struct`
->   [IDENTIFIER]&nbsp;
->   [_GenericParams_]<sup>?</sup>
->   `(` _TupleFields_<sup>?</sup> `)`
->   [_WhereClause_]<sup>?</sup>
->   `;`
->
-> _StructFields_ :\
-> &nbsp;&nbsp; _StructField_ (`,` _StructField_)<sup>\*</sup> `,`<sup>?</sup>
->
-> _StructField_ :\
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup>\
-> &nbsp;&nbsp; [_Visibility_]<sup>?</sup>\
-> &nbsp;&nbsp; [IDENTIFIER] `:` [_Type_]
->
-> _TupleFields_ :\
-> &nbsp;&nbsp; _TupleField_ (`,` _TupleField_)<sup>\*</sup> `,`<sup>?</sup>
->
-> _TupleField_ :\
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup>\
-> &nbsp;&nbsp; [_Visibility_]<sup>?</sup>\
-> &nbsp;&nbsp; [_Type_]
+```grammar,items
+Struct ->
+      StructStruct
+    | TupleStruct
+
+StructStruct ->
+    `struct` IDENTIFIER GenericParams? WhereClause? ( `{` StructFields? `}` | `;` )
+
+TupleStruct ->
+    `struct` IDENTIFIER GenericParams? `(` TupleFields? `)` WhereClause? `;`
+
+StructFields -> StructField (`,` StructField)* `,`?
+
+StructField -> OuterAttribute* Visibility? IDENTIFIER `:` Type
+
+TupleFields -> TupleField (`,` TupleField)* `,`?
+
+TupleField -> OuterAttribute* Visibility? Type
+```
 
 r[items.struct.intro]
 A _struct_ is a nominal [struct type] defined with the keyword `struct`.
@@ -86,13 +70,7 @@ r[items.struct.layout]
 The precise memory layout of a struct is not specified. One can specify a
 particular layout using the [`repr` attribute].
 
-[_GenericParams_]: generics.md
-[_OuterAttribute_]: ../attributes.md
-[_Type_]: ../types.md#type-expressions
-[_Visibility_]: ../visibility-and-privacy.md
-[_WhereClause_]: generics.md#where-clauses
 [`repr` attribute]: ../type-layout.md#representations
-[IDENTIFIER]: ../identifiers.md
 [constant]: constant-items.md
 [struct type]: ../types/struct.md
 [tuple type]: ../types/tuple.md

--- a/src/items/traits.md
+++ b/src/items/traits.md
@@ -2,15 +2,14 @@ r[items.traits]
 # Traits
 
 r[items.traits.syntax]
-> **<sup>Syntax</sup>**\
-> _Trait_ :\
-> &nbsp;&nbsp; `unsafe`<sup>?</sup> `trait` [IDENTIFIER]&nbsp;
->              [_GenericParams_]<sup>?</sup>
->              ( `:` [_TypeParamBounds_]<sup>?</sup> )<sup>?</sup>
->              [_WhereClause_]<sup>?</sup> `{`\
-> &nbsp;&nbsp;&nbsp;&nbsp; [_InnerAttribute_]<sup>\*</sup>\
-> &nbsp;&nbsp;&nbsp;&nbsp; [_AssociatedItem_]<sup>\*</sup>\
-> &nbsp;&nbsp; `}`
+```grammar,items
+Trait ->
+    `unsafe`? `trait` IDENTIFIER GenericParams? ( `:` TypeParamBounds? )? WhereClause?
+    `{`
+        InnerAttribute*
+        AssociatedItem*
+    `}`
+```
 
 r[items.traits.intro]
 A _trait_ describes an abstract interface that types can implement. This
@@ -288,7 +287,7 @@ r[items.traits.params]
 ## Parameter patterns
 
 r[items.traits.params.patterns-no-body]
-Parameters in associated functions without a body only allow [IDENTIFIER] or `_` [wild card][WildcardPattern] patterns, as well as the form allowed by [_SelfParam_]. `mut` [IDENTIFIER] is currently allowed, but it is deprecated and will become a hard error in the future.
+Parameters in associated functions without a body only allow [IDENTIFIER] or `_` [wild card][WildcardPattern] patterns, as well as the form allowed by [SelfParam]. `mut` [IDENTIFIER] is currently allowed, but it is deprecated and will become a hard error in the future.
 <!-- https://github.com/rust-lang/rust/issues/35203 -->
 
 ```rust
@@ -356,7 +355,7 @@ r[items.traits.associated-visibility]
 ## Item visibility
 
 r[items.traits.associated-visibility.intro]
-Trait items syntactically allow a [_Visibility_] annotation, but this is
+Trait items syntactically allow a [Visibility] annotation, but this is
 rejected when the trait is validated. This allows items to be parsed with a
 unified syntax across different contexts where they are used. As an example,
 an empty `vis` macro fragment specifier can be used for trait items, where the
@@ -390,15 +389,7 @@ fn main() {
 }
 ```
 
-[IDENTIFIER]: ../identifiers.md
 [WildcardPattern]: ../patterns.md#wildcard-pattern
-[_AssociatedItem_]: associated-items.md
-[_GenericParams_]: generics.md
-[_InnerAttribute_]: ../attributes.md
-[_SelfParam_]: functions.md
-[_TypeParamBounds_]: ../trait-bounds.md
-[_Visibility_]: ../visibility-and-privacy.md
-[_WhereClause_]: generics.md#where-clauses
 [bounds]: ../trait-bounds.md
 [trait object]: ../types/trait-object.md
 [associated items]: associated-items.md

--- a/src/items/type-aliases.md
+++ b/src/items/type-aliases.md
@@ -2,11 +2,12 @@ r[items.type]
 # Type aliases
 
 r[items.type.syntax]
-> **<sup>Syntax</sup>**\
-> _TypeAlias_ :\
-> &nbsp;&nbsp; `type` [IDENTIFIER]&nbsp;[_GenericParams_]<sup>?</sup>
->              ( `:` [_TypeParamBounds_] )<sup>?</sup>
->              [_WhereClause_]<sup>?</sup> ( `=` [_Type_] [_WhereClause_]<sup>?</sup>)<sup>?</sup> `;`
+```grammar,items
+TypeAlias ->
+    `type` IDENTIFIER GenericParams? ( `:` TypeParamBounds )?
+        WhereClause?
+        ( `=` Type WhereClause?)? `;`
+```
 
 r[items.type.intro]
 A _type alias_ defines a new name for an existing [type] in the [type namespace] of the module or block where it is located.
@@ -35,29 +36,24 @@ let _ = TypeAlias(5); // Doesn't work
 ```
 
 r[items.type.associated-type]
-A type alias, when not used as an [associated type], must include a [_Type_] and
-may not include [_TypeParamBounds_].
+A type alias, when not used as an [associated type], must include a [Type][grammar-Type] and
+may not include [TypeParamBounds].
 
 r[items.type.associated-trait]
 A type alias, when used as an [associated type] in a [trait], must not include a
-[_Type_] specification but may include [_TypeParamBounds_].
+[Type][grammar-Type] specification but may include [TypeParamBounds].
 
 r[items.type.associated-impl]
 A type alias, when used as an [associated type] in a [trait impl], must include
-a [_Type_] specification and may not include [_TypeParamBounds_].
+a [Type][grammar-Type] specification and may not include [TypeParamBounds].
 
 r[items.type.deprecated]
 Where clauses before the equals sign on a type alias in a [trait impl] (like
 `type TypeAlias<T> where T: Foo = Bar<T>`) are deprecated. Where clauses after
 the equals sign (like `type TypeAlias<T> = Bar<T> where T: Foo`) are preferred.
 
-[IDENTIFIER]: ../identifiers.md
-[_GenericParams_]: generics.md
-[_TypeParamBounds_]: ../trait-bounds.md
-[_WhereClause_]: generics.md#where-clauses
-[_Type_]: ../types.md#type-expressions
 [associated type]: associated-items.md#associated-types
-[trait]: traits.md
-[type]: ../types.md
 [trait impl]: implementations.md#trait-implementations
+[trait]: traits.md
 [type namespace]: ../names/namespaces.md
+[type]: ../types.md

--- a/src/items/unions.md
+++ b/src/items/unions.md
@@ -2,10 +2,10 @@ r[items.union]
 # Unions
 
 r[items.union.syntax]
-> **<sup>Syntax</sup>**\
-> _Union_ :\
-> &nbsp;&nbsp; `union` [IDENTIFIER]&nbsp;[_GenericParams_]<sup>?</sup> [_WhereClause_]<sup>?</sup>
->   `{`[_StructFields_]<sup>?</sup> `}`
+```grammar,items
+Union ->
+    `union` IDENTIFIER GenericParams? WhereClause? `{` StructFields? `}`
+```
 
 r[items.union.intro]
 A union declaration uses the same syntax as a struct declaration, except with
@@ -213,10 +213,6 @@ aspects of Rust language (such as privacy, name resolution, type inference,
 generics, trait implementations, inherent implementations, coherence, pattern
 checking, etc etc etc).
 
-[IDENTIFIER]: ../identifiers.md
-[_GenericParams_]: generics.md
-[_WhereClause_]: generics.md#where-clauses
-[_StructFields_]: structs.md
 [`transmute`]: std::mem::transmute
 [boolean type]: ../types/boolean.md
 [the C representation]: ../type-layout.md#reprc-unions

--- a/src/items/use-declarations.md
+++ b/src/items/use-declarations.md
@@ -2,14 +2,14 @@ r[items.use]
 # Use declarations
 
 r[items.use.syntax]
-> **<sup>Syntax:</sup>**\
-> _UseDeclaration_ :\
-> &nbsp;&nbsp; `use` _UseTree_ `;`
->
-> _UseTree_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; ([_SimplePath_]<sup>?</sup> `::`)<sup>?</sup> `*`\
-> &nbsp;&nbsp; | ([_SimplePath_]<sup>?</sup> `::`)<sup>?</sup> `{` (_UseTree_ ( `,`  _UseTree_ )<sup>\*</sup> `,`<sup>?</sup>)<sup>?</sup> `}`\
-> &nbsp;&nbsp; | [_SimplePath_]&nbsp;( `as` ( [IDENTIFIER] | `_` ) )<sup>?</sup>
+```grammar,items
+UseDeclaration -> `use` UseTree `;`
+
+UseTree ->
+      (SimplePath? `::`)? `*`
+    | (SimplePath? `::`)? `{` (UseTree ( `,`  UseTree )* `,`?)? `}`
+    | SimplePath ( `as` ( IDENTIFIER | `_` ) )?
+```
 
 r[items.use.intro]
 A _use declaration_ creates one or more local name bindings synonymous with
@@ -108,7 +108,7 @@ r[items.use.path]
 ## `use` Paths
 
 r[items.use.path.intro]
-The [paths] that are allowed in a `use` item follow the [_SimplePath_] grammar and are similar to the paths that may be used in an expression.
+The [paths] that are allowed in a `use` item follow the [SimplePath] grammar and are similar to the paths that may be used in an expression.
 They may create bindings for:
 
 * Nameable [items]
@@ -442,7 +442,6 @@ fn main() {
 }
 ```
 
-[_SimplePath_]: ../paths.md#simple-paths
 [`extern crate`]: extern-crates.md
 [`macro_rules`]: ../macros-by-example.md
 [`self`]: ../paths.md#self
@@ -453,7 +452,6 @@ fn main() {
 [Enum variants]: enumerations.md
 [extern prelude]: ../names/preludes.md#extern-prelude
 [generic parameters]: generics.md
-[IDENTIFIER]: ../identifiers.md
 [items]: ../items.md
 [local variables]: ../variables.md
 [namespace]: ../names/namespaces.md

--- a/src/keywords.md
+++ b/src/keywords.md
@@ -131,18 +131,17 @@ r[lex.keywords.weak.lifetime-static]
   fn invalid_lifetime_parameter<'static>(s: &'static str) -> &'static str { s }
   ```
 
-r[lex.keywords.weak.dyn]
-* In the 2015 edition, [`dyn`] is a keyword when used in a type position
-  followed by a path that does not start with `::` or `<`, a lifetime, a question mark, a `for`
-  keyword or an opening parenthesis.
-
-  Beginning in the 2018 edition, `dyn` has been promoted to a strict keyword.
-
 r[lex.keywords.weak.safe]
 * `safe` is used for functions and statics, which has meaning in [external blocks].
 
 r[lex.keywords.weak.raw]
 * `raw` is used for [raw borrow operators], and is only a keyword when matching a raw borrow operator form (such as `&raw const expr` or `&raw mut expr`).
+
+r[lex.keywords.weak.dyn.edition2018]
+> [!EDITION-2018]
+> In the 2015 edition, [`dyn`] is a keyword when used in a type position followed by a path that does not start with `::` or `<`, a lifetime, a question mark, a `for` keyword or an opening parenthesis.
+>
+> Beginning in the 2018 edition, `dyn` has been promoted to a strict keyword.
 
 [items]: items.md
 [Variables]: variables.md

--- a/src/keywords.md
+++ b/src/keywords.md
@@ -99,6 +99,7 @@ The following keywords are reserved beginning in the 2018 edition.
 > **<sup>Lexer 2018+</sup>**\
 > KW_TRY   : `try`
 
+r[lex.keywords.reserved.edition2024]
 The following keywords are reserved beginning in the 2024 edition.
 
 > **<sup>Lexer 2024+</sup>**\

--- a/src/keywords.md
+++ b/src/keywords.md
@@ -24,50 +24,50 @@ be used as the names of:
 * [Crates]
 
 r[lex.keywords.strict.list]
-> **<sup>Lexer:<sup>**\
-> KW_AS             : `as`\
-> KW_BREAK          : `break`\
-> KW_CONST          : `const`\
-> KW_CONTINUE       : `continue`\
-> KW_CRATE          : `crate`\
-> KW_ELSE           : `else`\
-> KW_ENUM           : `enum`\
-> KW_EXTERN         : `extern`\
-> KW_FALSE          : `false`\
-> KW_FN             : `fn`\
-> KW_FOR            : `for`\
-> KW_IF             : `if`\
-> KW_IMPL           : `impl`\
-> KW_IN             : `in`\
-> KW_LET            : `let`\
-> KW_LOOP           : `loop`\
-> KW_MATCH          : `match`\
-> KW_MOD            : `mod`\
-> KW_MOVE           : `move`\
-> KW_MUT            : `mut`\
-> KW_PUB            : `pub`\
-> KW_REF            : `ref`\
-> KW_RETURN         : `return`\
-> KW_SELFVALUE      : `self`\
-> KW_SELFTYPE       : `Self`\
-> KW_STATIC         : `static`\
-> KW_STRUCT         : `struct`\
-> KW_SUPER          : `super`\
-> KW_TRAIT          : `trait`\
-> KW_TRUE           : `true`\
-> KW_TYPE           : `type`\
-> KW_UNSAFE         : `unsafe`\
-> KW_USE            : `use`\
-> KW_WHERE          : `where`\
-> KW_WHILE          : `while`
+The following keywords are in all editions:
+
+- `as`
+- `break`
+- `const`
+- `continue`
+- `crate`
+- `else`
+- `enum`
+- `extern`
+- `false`
+- `fn`
+- `for`
+- `if`
+- `impl`
+- `in`
+- `let`
+- `loop`
+- `match`
+- `mod`
+- `move`
+- `mut`
+- `pub`
+- `ref`
+- `return`
+- `self`
+- `Self`
+- `static`
+- `struct`
+- `super`
+- `trait`
+- `true`
+- `type`
+- `unsafe`
+- `use`
+- `where`
+- `while`
 
 r[lex.keywords.strict.edition2018]
 The following keywords were added beginning in the 2018 edition.
 
-> **<sup>Lexer 2018+</sup>**\
-> KW_ASYNC          : `async`\
-> KW_AWAIT          : `await`\
-> KW_DYN            : `dyn`
+- `async`
+- `await`
+- `dyn`
 
 r[lex.keywords.reserved]
 ## Reserved keywords
@@ -79,31 +79,28 @@ current programs forward compatible with future versions of Rust by forbidding
 them to use these keywords.
 
 r[lex.keywords.reserved.list]
-> **<sup>Lexer</sup>**\
-> KW_ABSTRACT       : `abstract`\
-> KW_BECOME         : `become`\
-> KW_BOX            : `box`\
-> KW_DO             : `do`\
-> KW_FINAL          : `final`\
-> KW_MACRO          : `macro`\
-> KW_OVERRIDE       : `override`\
-> KW_PRIV           : `priv`\
-> KW_TYPEOF         : `typeof`\
-> KW_UNSIZED        : `unsized`\
-> KW_VIRTUAL        : `virtual`\
-> KW_YIELD          : `yield`
+- `abstract`
+- `become`
+- `box`
+- `do`
+- `final`
+- `macro`
+- `override`
+- `priv`
+- `typeof`
+- `unsized`
+- `virtual`
+- `yield`
 
 r[lex.keywords.reserved.edition2018]
 The following keywords are reserved beginning in the 2018 edition.
 
-> **<sup>Lexer 2018+</sup>**\
-> KW_TRY   : `try`
+- `try`
 
 r[lex.keywords.reserved.edition2024]
 The following keywords are reserved beginning in the 2024 edition.
 
-> **<sup>Lexer 2024+</sup>**\
-> KW_GEN   : `gen`
+- `gen`
 
 r[lex.keywords.weak]
 ## Weak keywords
@@ -112,15 +109,11 @@ r[lex.keywords.weak.intro]
 These keywords have special meaning only in certain contexts. For example, it
 is possible to declare a variable or method with the name `union`.
 
-> **<sup>Lexer</sup>**\
-> KW_MACRO_RULES    : `macro_rules`\
-> KW_UNION          : `union`\
-> KW_STATICLIFETIME : `'static`\
-> KW_SAFE           : `safe`\
-> KW_RAW            : `raw`
->
-> **<sup>Lexer 2015</sup>**\
-> KW_DYN            : `dyn`
+- `'static`
+- `macro_rules`
+- `raw`
+- `safe`
+- `union`
 
 r[lex.keywords.weak.macro_rules]
 * `macro_rules` is used to create custom [macros].

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -2,44 +2,42 @@ r[macro.decl]
 # Macros By Example
 
 r[macro.decl.syntax]
-> **<sup>Syntax</sup>**\
-> _MacroRulesDefinition_ :\
-> &nbsp;&nbsp; `macro_rules` `!` [IDENTIFIER] _MacroRulesDef_
->
-> _MacroRulesDef_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `(` _MacroRules_ `)` `;`\
-> &nbsp;&nbsp; | `[` _MacroRules_ `]` `;`\
-> &nbsp;&nbsp; | `{` _MacroRules_ `}`
->
-> _MacroRules_ :\
-> &nbsp;&nbsp; _MacroRule_ ( `;` _MacroRule_ )<sup>\*</sup> `;`<sup>?</sup>
->
-> _MacroRule_ :\
-> &nbsp;&nbsp; _MacroMatcher_ `=>` _MacroTranscriber_
->
-> _MacroMatcher_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `(` _MacroMatch_<sup>\*</sup> `)`\
-> &nbsp;&nbsp; | `[` _MacroMatch_<sup>\*</sup> `]`\
-> &nbsp;&nbsp; | `{` _MacroMatch_<sup>\*</sup> `}`
->
-> _MacroMatch_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_Token_]<sub>_except `$` and [delimiters]_</sub>\
-> &nbsp;&nbsp; | _MacroMatcher_\
-> &nbsp;&nbsp; | `$` ( [IDENTIFIER_OR_KEYWORD] <sub>_except `crate`_</sub> | [RAW_IDENTIFIER] | `_` ) `:` _MacroFragSpec_\
-> &nbsp;&nbsp; | `$` `(` _MacroMatch_<sup>+</sup> `)` _MacroRepSep_<sup>?</sup> _MacroRepOp_
->
-> _MacroFragSpec_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `block` | `expr` | `expr_2021` | `ident` | `item` | `lifetime` | `literal`\
-> &nbsp;&nbsp; | `meta` | `pat` | `pat_param` | `path` | `stmt` | `tt` | `ty` | `vis`
->
-> _MacroRepSep_ :\
-> &nbsp;&nbsp; [_Token_]<sub>_except [delimiters] and MacroRepOp_</sub>
->
-> _MacroRepOp_ :\
-> &nbsp;&nbsp; `*` | `+` | `?`
->
-> _MacroTranscriber_ :\
-> &nbsp;&nbsp; [_DelimTokenTree_]
+```grammar,macros
+MacroRulesDefinition ->
+    `macro_rules` `!` IDENTIFIER MacroRulesDef
+
+MacroRulesDef ->
+      `(` MacroRules `)` `;`
+    | `[` MacroRules `]` `;`
+    | `{` MacroRules `}`
+
+MacroRules ->
+    MacroRule ( `;` MacroRule )* `;`?
+
+MacroRule ->
+    MacroMatcher `=>` MacroTranscriber
+
+MacroMatcher ->
+      `(` MacroMatch* `)`
+    | `[` MacroMatch* `]`
+    | `{` MacroMatch* `}`
+
+MacroMatch ->
+      Token _except `$` and [delimiters][lex.token.delim]_
+    | MacroMatcher
+    | `$` ( IDENTIFIER_OR_KEYWORD _except `crate`_ | RAW_IDENTIFIER | `_` ) `:` MacroFragSpec
+    | `$` `(` MacroMatch+ `)` MacroRepSep? MacroRepOp
+
+MacroFragSpec ->
+      `block` | `expr` | `expr_2021` | `ident` | `item` | `lifetime` | `literal`
+    | `meta` | `pat` | `pat_param` | `path` | `stmt` | `tt` | `ty` | `vis`
+
+MacroRepSep -> Token _except [delimiters][lex.token.delim] and [MacroRepOp]_
+
+MacroRepOp -> `*` | `+` | `?`
+
+MacroTranscriber -> DelimTokenTree
+```
 
 r[macro.decl.intro]
 `macro_rules` allows users to define syntax extension in a declarative way.  We
@@ -133,21 +131,21 @@ fragment of the kind specified and binds it to the metavariable `$`_name_.
 r[macro.decl.meta.specifier]
 Valid fragment specifiers are:
 
-  * `block`: a [_BlockExpression_]
-  * `expr`: an [_Expression_]
-  * `expr_2021`: an [_Expression_] except [_UnderscoreExpression_] and [_ConstBlockExpression_] (see [macro.decl.meta.edition2024])
+  * `block`: a [BlockExpression]
+  * `expr`: an [Expression]
+  * `expr_2021`: an [Expression] except [UnderscoreExpression] and [ConstBlockExpression] (see [macro.decl.meta.edition2024])
   * `ident`: an [IDENTIFIER_OR_KEYWORD] or [RAW_IDENTIFIER]
-  * `item`: an [_Item_]
+  * `item`: an [Item]
   * `lifetime`: a [LIFETIME_TOKEN]
-  * `literal`: matches `-`<sup>?</sup>[_LiteralExpression_]
-  * `meta`: an [_Attr_], the contents of an attribute
-  * `pat`: a [_Pattern_] (see [macro.decl.meta.edition2021])
-  * `pat_param`: a [_PatternNoTopAlt_]
-  * `path`: a [_TypePath_] style path
-  * `stmt`: a [_Statement_] without the trailing semicolon (except for item statements that require semicolons)
-  * `tt`: a [_TokenTree_]&nbsp;(a single [token] or tokens in matching delimiters `()`, `[]`, or `{}`)
-  * `ty`: a [_Type_]
-  * `vis`: a possibly empty [_Visibility_] qualifier
+  * `literal`: matches `-`<sup>?</sup>[LiteralExpression]
+  * `meta`: an [Attr], the contents of an attribute
+  * `pat`: a [Pattern] (see [macro.decl.meta.edition2021])
+  * `pat_param`: a [PatternNoTopAlt]
+  * `path`: a [TypePath] style path
+  * `stmt`: a [Statement][grammar-Statement] without the trailing semicolon (except for item statements that require semicolons)
+  * `tt`: a [TokenTree]&nbsp;(a single [token] or tokens in matching delimiters `()`, `[]`, or `{}`)
+  * `ty`: a [Type][grammar-Type]
+  * `vis`: a possibly empty [Visibility] qualifier
 
 r[macro.decl.meta.transcription]
 In the transcriber, metavariables are referred to simply by `$`_name_, since
@@ -160,15 +158,15 @@ transcribed more than once or not at all.
 
 r[macro.decl.meta.edition2021]
 > [!EDITION-2021]
-> Starting with the 2021 edition, `pat` fragment-specifiers match top-level or-patterns (that is, they accept [_Pattern_]).
+> Starting with the 2021 edition, `pat` fragment-specifiers match top-level or-patterns (that is, they accept [Pattern]).
 >
-> Before the 2021 edition, they match exactly the same fragments as `pat_param` (that is, they accept [_PatternNoTopAlt_]).
+> Before the 2021 edition, they match exactly the same fragments as `pat_param` (that is, they accept [PatternNoTopAlt]).
 >
 > The relevant edition is the one in effect for the `macro_rules!` definition.
 
 r[macro.decl.meta.edition2024]
 > [!EDITION-2024]
-> Before the 2024 edition, `expr` fragment specifiers do not match [_UnderscoreExpression_] or [_ConstBlockExpression_] at the top level. They are allowed within subexpressions.
+> Before the 2024 edition, `expr` fragment specifiers do not match [UnderscoreExpression] or [ConstBlockExpression] at the top level. They are allowed within subexpressions.
 >
 > The `expr_2021` fragment specifier exists to maintain backwards compatibility with editions before 2024.
 
@@ -354,7 +352,7 @@ imported this way are imported into the [`macro_use` prelude], not textually,
 which means that they can be shadowed by any other name. While macros imported
 by `#[macro_use]` can be used before the import statement, in case of a
 conflict, the last macro imported wins. Optionally, a list of macros to import
-can be specified using the [_MetaListIdents_] syntax; this is not supported
+can be specified using the [MetaListIdents] syntax; this is not supported
 when `#[macro_use]` is applied to a module.
 
 <!-- ignore: requires external crates -->
@@ -587,33 +585,12 @@ expansions, taking separators into account. This means:
 
 For more detail, see the [formal specification].
 
+[`macro_use` prelude]: names/preludes.md#macro_use-prelude
 [block labels]: expressions/loop-expr.md#labelled-block-expressions
+[delimiters]: tokens.md#delimiters
+[formal specification]: macro-ambiguity.md
 [Hygiene]: #hygiene
-[IDENTIFIER]: identifiers.md
-[IDENTIFIER_OR_KEYWORD]: identifiers.md
-[RAW_IDENTIFIER]: identifiers.md
-[LIFETIME_TOKEN]: tokens.md#lifetimes-and-loop-labels
+[loop labels]: expressions/loop-expr.md#loop-labels
 [Metavariables]: #metavariables
 [Repetitions]: #repetitions
-[_Attr_]: attributes.md
-[_BlockExpression_]: expressions/block-expr.md
-[_ConstBlockExpression_]: expressions/block-expr.md#const-blocks
-[_DelimTokenTree_]: macros.md
-[_Expression_]: expressions.md
-[_Item_]: items.md
-[_LiteralExpression_]: expressions/literal-expr.md
-[loop labels]: expressions/loop-expr.md#loop-labels
-[_MetaListIdents_]: attributes.md#meta-item-attribute-syntax
-[_Pattern_]: patterns.md
-[_PatternNoTopAlt_]: patterns.md
-[_Statement_]: statements.md
-[_TokenTree_]: macros.md#macro-invocation
-[_Token_]: tokens.md
-[delimiters]: tokens.md#delimiters
-[_TypePath_]: paths.md#paths-in-types
-[_Type_]: types.md#type-expressions
-[_UnderscoreExpression_]: expressions/underscore-expr.md
-[_Visibility_]: visibility-and-privacy.md
-[formal specification]: macro-ambiguity.md
 [token]: tokens.md
-[`macro_use` prelude]: names/preludes.md#macro_use-prelude

--- a/src/macros.md
+++ b/src/macros.md
@@ -16,22 +16,23 @@ r[macro.invocation]
 ## Macro Invocation
 
 r[macro.invocation.syntax]
-> **<sup>Syntax</sup>**\
-> _MacroInvocation_ :\
-> &nbsp;&nbsp; [_SimplePath_] `!` _DelimTokenTree_
->
-> _DelimTokenTree_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp;  `(` _TokenTree_<sup>\*</sup> `)`\
-> &nbsp;&nbsp; | `[` _TokenTree_<sup>\*</sup> `]`\
-> &nbsp;&nbsp; | `{` _TokenTree_<sup>\*</sup> `}`
->
-> _TokenTree_ :\
-> &nbsp;&nbsp; [_Token_]<sub>_except [delimiters]_</sub> | _DelimTokenTree_
->
-> _MacroInvocationSemi_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_SimplePath_] `!` `(` _TokenTree_<sup>\*</sup> `)` `;`\
-> &nbsp;&nbsp; | [_SimplePath_] `!` `[` _TokenTree_<sup>\*</sup> `]` `;`\
-> &nbsp;&nbsp; | [_SimplePath_] `!` `{` _TokenTree_<sup>\*</sup> `}`
+```grammar,macros
+MacroInvocation ->
+    SimplePath `!` DelimTokenTree
+
+DelimTokenTree ->
+      `(` TokenTree* `)`
+    | `[` TokenTree* `]`
+    | `{` TokenTree* `}`
+
+TokenTree ->
+    Token _except [delimiters][lex.token.delim]_ | DelimTokenTree
+
+MacroInvocationSemi ->
+      SimplePath `!` `(` TokenTree* `)` `;`
+    | SimplePath `!` `[` TokenTree* `]` `;`
+    | SimplePath `!` `{` TokenTree* `}`
+```
 
 r[macro.invocation.intro]
 A macro invocation expands a macro at compile time and replaces the
@@ -107,8 +108,6 @@ example!();
 
 [Macros by Example]: macros-by-example.md
 [Procedural Macros]: procedural-macros.md
-[_SimplePath_]: paths.md#simple-paths
-[_Token_]: tokens.md
 [associated items]: items/associated-items.md
 [delimiters]: tokens.md#delimiters
 [expressions]: expressions.md

--- a/src/names/scopes.md
+++ b/src/names/scopes.md
@@ -86,7 +86,7 @@ r[names.scopes.generic-parameters]
 ## Generic parameter scopes
 
 r[names.scopes.generic-parameters.param-list]
-Generic parameters are declared in a [_GenericParams_] list.
+Generic parameters are declared in a [GenericParams] list.
 The scope of a generic parameter is within the item it is declared on.
 
 r[names.scopes.generic-parameters.order-independent]
@@ -150,7 +150,7 @@ trait SomeTrait<'a, T, const N: usize> {
 r[names.scopes.lifetimes]
 ### Lifetime scopes
 
-Lifetime parameters are declared in a [_GenericParams_] list and [higher-ranked trait bounds][hrtb].
+Lifetime parameters are declared in a [GenericParams] list and [higher-ranked trait bounds][hrtb].
 
 r[names.scopes.lifetimes.special]
 The `'static` lifetime and [placeholder lifetime] `'_` have a special meaning and cannot be declared as a parameter.
@@ -166,9 +166,9 @@ r[names.scopes.lifetimes.generic]
 r[names.scopes.lifetimes.higher-ranked]
 The scope of a lifetime parameter declared as a [higher-ranked trait bound][hrtb] depends on the scenario where it is used.
 
-* As a [_TypeBoundWhereClauseItem_] the declared lifetimes are in scope in the type and the type bounds.
-* As a [_TraitBound_] the declared lifetimes are in scope within the bound type path.
-* As a [_BareFunctionType_] the declared lifetimes are in scope within the function parameters and return type.
+* As a [TypeBoundWhereClauseItem] the declared lifetimes are in scope in the type and the type bounds.
+* As a [TraitBound] the declared lifetimes are in scope within the bound type path.
+* As a [BareFunctionType] the declared lifetimes are in scope within the function parameters and return type.
 
 ```rust
 # trait Trait<'a>{}
@@ -337,10 +337,6 @@ impl ImplExample {
 }
 ```
 
-[_BareFunctionType_]: ../types/function-pointer.md
-[_GenericParams_]: ../items/generics.md
-[_TraitBound_]: ../trait-bounds.md
-[_TypeBoundWhereClauseItem_]: ../items/generics.md
 [`derive` attribute]: ../attributes/derive.md
 [`for` loop]: ../expressions/loop-expr.md#iterator-loops
 [`for`]: ../expressions/loop-expr.md#iterator-loops

--- a/src/notation.md
+++ b/src/notation.md
@@ -52,6 +52,8 @@ The following are common definitions used in the grammar.
 
 r[input.syntax]
 ```grammar,lexer
+CHAR -> <a Unicode scalar value>
+
 NUL -> U+0000
 
 TAB -> U+0009

--- a/src/notation.md
+++ b/src/notation.md
@@ -35,6 +35,13 @@ When such a string in `monospace` font occurs inside the grammar,
 it is an implicit reference to a single member of such a string table
 production. See [tokens] for more information.
 
+## Common productions
+
+The following are common definitions used in the grammar.
+
+> **<sup>Lexer</sup>**\
+> CR : U+000D
+
 [binary operators]: expressions/operator-expr.md#arithmetic-and-logical-binary-operators
 [keywords]: keywords.md
 [tokens]: tokens.md

--- a/src/notation.md
+++ b/src/notation.md
@@ -52,7 +52,7 @@ The following are common definitions used in the grammar.
 
 r[input.syntax]
 ```grammar,lexer
-CHAR -> <a Unicode scalar value>
+@root CHAR -> <a Unicode scalar value>
 
 NUL -> U+0000
 

--- a/src/notation.md
+++ b/src/notation.md
@@ -38,14 +38,16 @@ production. See [tokens] for more information.
 
 The following are common definitions used in the grammar.
 
-> **<sup>Lexer</sup>**\
-> NUL : U+0000
->
-> TAB : U+0009
->
-> LF : U+000A
->
-> CR : U+000D
+r[input.syntax]
+```grammar,lexer
+NUL -> U+0000
+
+TAB -> U+0009
+
+LF -> U+000A
+
+CR -> U+000D
+```
 
 [binary operators]: expressions/operator-expr.md#arithmetic-and-logical-binary-operators
 [keywords]: keywords.md

--- a/src/notation.md
+++ b/src/notation.md
@@ -40,6 +40,12 @@ production. See [tokens] for more information.
 The following are common definitions used in the grammar.
 
 > **<sup>Lexer</sup>**\
+> NUL : U+0000
+>
+> TAB : U+0009
+>
+> LF : U+000A
+>
 > CR : U+000D
 
 [binary operators]: expressions/operator-expr.md#arithmetic-and-logical-binary-operators

--- a/src/notation.md
+++ b/src/notation.md
@@ -9,7 +9,6 @@ The following notations are used by the *Lexer* and *Syntax* grammar snippets:
 | CAPITAL           | KW_IF, INTEGER_LITERAL        | A token produced by the lexer             |
 | _ItalicCamelCase_ | _LetStatement_, _Item_        | A syntactical production                  |
 | `string`          | `x`, `while`, `*`             | The exact character(s)                    |
-| \\x               | \\n, \\r, \\t, \\0            | The character represented by this escape  |
 | x<sup>?</sup>     | `pub`<sup>?</sup>             | An optional item                          |
 | x<sup>\*</sup>    | _OuterAttribute_<sup>\*</sup> | 0 or more of x                            |
 | x<sup>+</sup>     |  _MacroMatch_<sup>+</sup>     | 1 or more of x                            |

--- a/src/notation.md
+++ b/src/notation.md
@@ -13,12 +13,18 @@ The following notations are used by the *Lexer* and *Syntax* grammar snippets:
 | x<sup>\*</sup>    | _OuterAttribute_<sup>\*</sup> | 0 or more of x                            |
 | x<sup>+</sup>     |  _MacroMatch_<sup>+</sup>     | 1 or more of x                            |
 | x<sup>a..b</sup>  | HEX_DIGIT<sup>1..6</sup>      | a to b repetitions of x                   |
+| Rule1 Rule2       | `fn` _Name_ _Parameters_      | Sequence of rules in order                |
 | \|                | `u8` \| `u16`, Block \| Item  | Either one or another                     |
 | \[ ]               | \[`b` `B`]                     | Any of the characters listed              |
 | \[ - ]             | \[`a`-`z`]                     | Any of the characters in the range        |
 | ~\[ ]              | ~\[`b` `B`]                    | Any characters, except those listed       |
 | ~`string`         | ~`\n`, ~`*/`                  | Any characters, except this sequence      |
 | ( )               | (`,` _Parameter_)<sup>?</sup> | Groups items                              |
+| U+xxxx            | U+0060                        | A single unicode character                |
+| \<text\>          | \<any ASCII char except CR\>  | An English description of what should be matched |
+| Rule <sub>suffix</sub> | IDENTIFIER_OR_KEYWORD <sub>_except `crate`_</sub> | A modification to the previous rule |
+
+Sequences have a higher precedence than `|` alternation.
 
 ## String table productions
 
@@ -33,6 +39,12 @@ entries.
 When such a string in `monospace` font occurs inside the grammar,
 it is an implicit reference to a single member of such a string table
 production. See [tokens] for more information.
+
+## Railroad visualizations
+
+Below each grammar block is a button to toggle the display of a [railroad diagram]. A square element is a non-terminal rule, and a rounded rectangle is a terminal.
+
+[railroad diagram]: https://en.wikipedia.org/wiki/Syntax_diagram
 
 ## Common productions
 

--- a/src/paths.md
+++ b/src/paths.md
@@ -19,12 +19,13 @@ r[paths.simple]
 ### Simple Paths
 
 r[paths.simple.syntax]
-> **<sup>Syntax</sup>**\
-> _SimplePath_ :\
-> &nbsp;&nbsp; `::`<sup>?</sup> _SimplePathSegment_ (`::` _SimplePathSegment_)<sup>\*</sup>
->
-> _SimplePathSegment_ :\
-> &nbsp;&nbsp; [IDENTIFIER] | `super` | `self` | `crate` | `$crate`
+```grammar,paths
+SimplePath ->
+    `::`? SimplePathSegment (`::` SimplePathSegment)*
+
+SimplePathSegment ->
+    IDENTIFIER | `super` | `self` | `crate` | `$crate`
+```
 
 r[paths.simple.intro]
 Simple paths are used in [visibility] markers, [attributes], [macros][mbe], and [`use`] items.
@@ -42,34 +43,35 @@ r[paths.expr]
 ### Paths in expressions
 
 r[paths.expr.syntax]
-> **<sup>Syntax</sup>**\
-> _PathInExpression_ :\
-> &nbsp;&nbsp; `::`<sup>?</sup> _PathExprSegment_ (`::` _PathExprSegment_)<sup>\*</sup>
->
-> _PathExprSegment_ :\
-> &nbsp;&nbsp; _PathIdentSegment_ (`::` _GenericArgs_)<sup>?</sup>
->
-> _PathIdentSegment_ :\
-> &nbsp;&nbsp; [IDENTIFIER] | `super` | `self` | `Self` | `crate` | `$crate`
->
-> _GenericArgs_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `<` `>`\
-> &nbsp;&nbsp; | `<` ( _GenericArg_ `,` )<sup>\*</sup> _GenericArg_ `,`<sup>?</sup> `>`
->
-> _GenericArg_ :\
-> &nbsp;&nbsp; [_Lifetime_] | [_Type_] | _GenericArgsConst_ | _GenericArgsBinding_ | _GenericArgsBounds_
->
-> _GenericArgsConst_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_BlockExpression_]\
-> &nbsp;&nbsp; | [_LiteralExpression_]\
-> &nbsp;&nbsp; | `-` [_LiteralExpression_]\
-> &nbsp;&nbsp; | [_SimplePathSegment_]
->
-> _GenericArgsBinding_ :\
-> &nbsp;&nbsp; [IDENTIFIER] _GenericArgs_<sup>?</sup> `=` [_Type_]
->
-> _GenericArgsBounds_ :\
-> &nbsp;&nbsp; [IDENTIFIER] _GenericArgs_<sup>?</sup> `:` [_TypeParamBounds_]
+```grammar,paths
+PathInExpression ->
+    `::`? PathExprSegment (`::` PathExprSegment)*
+
+PathExprSegment ->
+    PathIdentSegment (`::` GenericArgs)?
+
+PathIdentSegment ->
+    IDENTIFIER | `super` | `self` | `Self` | `crate` | `$crate`
+
+GenericArgs ->
+      `<` `>`
+    | `<` ( GenericArg `,` )* GenericArg `,`? `>`
+
+GenericArg ->
+    Lifetime | Type | GenericArgsConst | GenericArgsBinding | GenericArgsBounds
+
+GenericArgsConst ->
+      BlockExpression
+    | LiteralExpression
+    | `-` LiteralExpression
+    | SimplePathSegment
+
+GenericArgsBinding ->
+    IDENTIFIER GenericArgs? `=` Type
+
+GenericArgsBounds ->
+    IDENTIFIER GenericArgs? `:` TypeParamBounds
+```
 
 r[paths.expr.intro]
 Paths in expressions allow for paths with generic arguments to be specified. They are
@@ -100,15 +102,13 @@ r[paths.qualified]
 ## Qualified paths
 
 r[paths.qualified.syntax]
-> **<sup>Syntax</sup>**\
-> _QualifiedPathInExpression_ :\
-> &nbsp;&nbsp; _QualifiedPathType_ (`::` _PathExprSegment_)<sup>+</sup>
->
-> _QualifiedPathType_ :\
-> &nbsp;&nbsp; `<` [_Type_] (`as` _TypePath_)<sup>?</sup> `>`
->
-> _QualifiedPathInType_ :\
-> &nbsp;&nbsp; _QualifiedPathType_ (`::` _TypePathSegment_)<sup>+</sup>
+```grammar,paths
+QualifiedPathInExpression -> QualifiedPathType (`::` PathExprSegment)+
+
+QualifiedPathType -> `<` Type (`as` TypePath)? `>`
+
+QualifiedPathInType -> QualifiedPathType (`::` TypePathSegment)+
+```
 
 r[paths.qualified.intro]
 Fully qualified paths allow for disambiguating the path for [trait implementations] and
@@ -137,18 +137,15 @@ r[paths.type]
 ### Paths in types
 
 r[paths.type.syntax]
-> **<sup>Syntax</sup>**\
-> _TypePath_ :\
-> &nbsp;&nbsp; `::`<sup>?</sup> _TypePathSegment_ (`::` _TypePathSegment_)<sup>\*</sup>
->
-> _TypePathSegment_ :\
-> &nbsp;&nbsp; _PathIdentSegment_ (`::`<sup>?</sup> ([_GenericArgs_] | _TypePathFn_))<sup>?</sup>
->
-> _TypePathFn_ :\
-> &nbsp;&nbsp; `(` _TypePathFnInputs_<sup>?</sup> `)` (`->` [_TypeNoBounds_])<sup>?</sup>
->
-> _TypePathFnInputs_ :\
-> &nbsp;&nbsp; [_Type_] (`,` [_Type_])<sup>\*</sup> `,`<sup>?</sup>
+```grammar,paths
+TypePath -> `::`? TypePathSegment (`::` TypePathSegment)*
+
+TypePathSegment -> PathIdentSegment (`::`? (GenericArgs | TypePathFn))?
+
+TypePathFn -> `(` TypePathFnInputs? `)` (`->` TypeNoBounds)?
+
+TypePathFnInputs -> Type (`,` Type)* `,`?
+```
 
 r[paths.type.intro]
 Type paths are used within type definitions, trait bounds, type parameter bounds,
@@ -475,20 +472,10 @@ mod without { // crate::without
 # fn main() {}
 ```
 
-[_BlockExpression_]: expressions/block-expr.md
-[_Expression_]: expressions.md
-[_GenericArgs_]: #paths-in-expressions
-[_Lifetime_]: trait-bounds.md
-[_LiteralExpression_]: expressions/literal-expr.md
-[_SimplePathSegment_]: #simple-paths
-[_Type_]: types.md#type-expressions
-[_TypeNoBounds_]: types.md#type-expressions
-[_TypeParamBounds_]: trait-bounds.md
 [implementations]: items/implementations.md
 [items]: items.md
 [literal]: expressions/literal-expr.md
 [use declarations]: items/use-declarations.md
-[IDENTIFIER]: identifiers.md
 [`Self` scope]: names/scopes.md#self-scope
 [`use`]: items/use-declarations.md
 [attributes]: attributes.md

--- a/src/paths.md
+++ b/src/paths.md
@@ -145,10 +145,10 @@ r[paths.type.syntax]
 > &nbsp;&nbsp; _PathIdentSegment_ (`::`<sup>?</sup> ([_GenericArgs_] | _TypePathFn_))<sup>?</sup>
 >
 > _TypePathFn_ :\
-> `(` _TypePathFnInputs_<sup>?</sup> `)` (`->` [_TypeNoBounds_])<sup>?</sup>
+> &nbsp;&nbsp; `(` _TypePathFnInputs_<sup>?</sup> `)` (`->` [_TypeNoBounds_])<sup>?</sup>
 >
 > _TypePathFnInputs_ :\
-> [_Type_] (`,` [_Type_])<sup>\*</sup> `,`<sup>?</sup>
+> &nbsp;&nbsp; [_Type_] (`,` [_Type_])<sup>\*</sup> `,`<sup>?</sup>
 
 r[paths.type.intro]
 Type paths are used within type definitions, trait bounds, type parameter bounds,

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -420,6 +420,7 @@ The wildcard pattern is always irrefutable.
 r[patterns.rest]
 ## Rest patterns
 
+r[patterns.rest.syntax]
 > **<sup>Syntax</sup>**\
 > _RestPattern_ :\
 > &nbsp;&nbsp; `..`

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -2,27 +2,27 @@ r[patterns]
 # Patterns
 
 r[patterns.syntax]
-> **<sup>Syntax</sup>**\
-> _Pattern_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `|`<sup>?</sup> _PatternNoTopAlt_  ( `|` _PatternNoTopAlt_ )<sup>\*</sup>
->
-> _PatternNoTopAlt_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; _PatternWithoutRange_\
-> &nbsp;&nbsp; | [_RangePattern_]
->
-> _PatternWithoutRange_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_LiteralPattern_]\
-> &nbsp;&nbsp; | [_IdentifierPattern_]\
-> &nbsp;&nbsp; | [_WildcardPattern_]\
-> &nbsp;&nbsp; | [_RestPattern_]\
-> &nbsp;&nbsp; | [_ReferencePattern_]\
-> &nbsp;&nbsp; | [_StructPattern_]\
-> &nbsp;&nbsp; | [_TupleStructPattern_]\
-> &nbsp;&nbsp; | [_TuplePattern_]\
-> &nbsp;&nbsp; | [_GroupedPattern_]\
-> &nbsp;&nbsp; | [_SlicePattern_]\
-> &nbsp;&nbsp; | [_PathPattern_]\
-> &nbsp;&nbsp; | [_MacroInvocation_]
+```grammar,patterns
+Pattern -> `|`? PatternNoTopAlt  ( `|` PatternNoTopAlt )*
+
+PatternNoTopAlt ->
+      PatternWithoutRange
+    | RangePattern
+
+PatternWithoutRange ->
+      LiteralPattern
+    | IdentifierPattern
+    | WildcardPattern
+    | RestPattern
+    | ReferencePattern
+    | StructPattern
+    | TupleStructPattern
+    | TuplePattern
+    | GroupedPattern
+    | SlicePattern
+    | PathPattern
+    | MacroInvocation
+```
 
 r[patterns.intro]
 Patterns are used to match values against structures and to, optionally, bind variables to values inside these structures.
@@ -138,30 +138,20 @@ r[patterns.literal]
 ## Literal patterns
 
 r[patterns.literal.syntax]
-> **<sup>Syntax</sup>**\
-> _LiteralPattern_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `true` | `false`\
-> &nbsp;&nbsp; | [CHAR_LITERAL]\
-> &nbsp;&nbsp; | [BYTE_LITERAL]\
-> &nbsp;&nbsp; | [STRING_LITERAL]\
-> &nbsp;&nbsp; | [RAW_STRING_LITERAL]\
-> &nbsp;&nbsp; | [BYTE_STRING_LITERAL]\
-> &nbsp;&nbsp; | [RAW_BYTE_STRING_LITERAL]\
-> &nbsp;&nbsp; | [C_STRING_LITERAL]\
-> &nbsp;&nbsp; | [RAW_C_STRING_LITERAL]\
-> &nbsp;&nbsp; | `-`<sup>?</sup> [INTEGER_LITERAL]\
-> &nbsp;&nbsp; | `-`<sup>?</sup> [FLOAT_LITERAL]
-
-[CHAR_LITERAL]: tokens.md#character-literals
-[BYTE_LITERAL]: tokens.md#byte-literals
-[STRING_LITERAL]: tokens.md#string-literals
-[RAW_STRING_LITERAL]: tokens.md#raw-string-literals
-[BYTE_STRING_LITERAL]: tokens.md#byte-string-literals
-[RAW_BYTE_STRING_LITERAL]: tokens.md#raw-byte-string-literals
-[C_STRING_LITERAL]: tokens.md#c-string-literals
-[RAW_C_STRING_LITERAL]: tokens.md#raw-c-string-literals
-[INTEGER_LITERAL]: tokens.md#integer-literals
-[FLOAT_LITERAL]: tokens.md#floating-point-literals
+```grammar,patterns
+LiteralPattern ->
+      `true` | `false`
+    | CHAR_LITERAL
+    | BYTE_LITERAL
+    | STRING_LITERAL
+    | RAW_STRING_LITERAL
+    | BYTE_STRING_LITERAL
+    | RAW_BYTE_STRING_LITERAL
+    | C_STRING_LITERAL
+    | RAW_C_STRING_LITERAL
+    | `-`? INTEGER_LITERAL
+    | `-`? FLOAT_LITERAL
+```
 
 r[patterns.literal.intro]
 _Literal patterns_ match exactly the same value as what is created by the literal.
@@ -190,9 +180,9 @@ r[patterns.ident]
 ## Identifier patterns
 
 r[patterns.ident.syntax]
-> **<sup>Syntax</sup>**\
-> _IdentifierPattern_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `ref`<sup>?</sup> `mut`<sup>?</sup> [IDENTIFIER] (`@` [_PatternNoTopAlt_] ) <sup>?</sup>
+```grammar,patterns
+IdentifierPattern -> `ref`? `mut`? IDENTIFIER (`@` PatternNoTopAlt ) ?
+```
 
 r[patterns.ident.intro]
 Identifier patterns bind the value they match to a variable in the [value namespace].
@@ -372,9 +362,9 @@ r[patterns.wildcard]
 ## Wildcard pattern
 
 r[patterns.wildcard.syntax]
-> **<sup>Syntax</sup>**\
-> _WildcardPattern_ :\
-> &nbsp;&nbsp; `_`
+```grammar,patterns
+WildcardPattern -> `_`
+```
 
 r[patterns.wildcard.intro]
 The _wildcard pattern_ (an underscore symbol) matches any value.
@@ -421,9 +411,9 @@ r[patterns.rest]
 ## Rest patterns
 
 r[patterns.rest.syntax]
-> **<sup>Syntax</sup>**\
-> _RestPattern_ :\
-> &nbsp;&nbsp; `..`
+```grammar,patterns
+RestPattern -> `..`
+```
 
 r[patterns.rest.intro]
 The _rest pattern_ (the `..` token) acts as a variable-length pattern which matches zero or more elements that haven't been matched already before and after.
@@ -479,41 +469,42 @@ r[patterns.range]
 ## Range patterns
 
 r[patterns.range.syntax]
-> **<sup>Syntax</sup>**\
-> _RangePattern_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; _RangeExclusivePattern_\
-> &nbsp;&nbsp; | _RangeInclusivePattern_\
-> &nbsp;&nbsp; | _RangeFromPattern_\
-> &nbsp;&nbsp; | _RangeToExclusivePattern_\
-> &nbsp;&nbsp; | _RangeToInclusivePattern_\
-> &nbsp;&nbsp; | _ObsoleteRangePattern_[^obsolete-range-edition]
->
-> _RangeExclusivePattern_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; _RangePatternBound_ `..` _RangePatternBound_
->
-> _RangeInclusivePattern_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; _RangePatternBound_ `..=` _RangePatternBound_
->
-> _RangeFromPattern_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; _RangePatternBound_ `..`
->
-> _RangeToExclusivePattern_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `..` _RangePatternBound_
->
-> _RangeToInclusivePattern_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `..=` _RangePatternBound_
->
-> _ObsoleteRangePattern_ :\
-> &nbsp;&nbsp; _RangePatternBound_ `...` _RangePatternBound_
->
-> _RangePatternBound_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [CHAR_LITERAL]\
-> &nbsp;&nbsp; | [BYTE_LITERAL]\
-> &nbsp;&nbsp; | `-`<sup>?</sup> [INTEGER_LITERAL]\
-> &nbsp;&nbsp; | `-`<sup>?</sup> [FLOAT_LITERAL]\
-> &nbsp;&nbsp; | [_PathExpression_]
->
-> [^obsolete-range-edition]: The _ObsoleteRangePattern_ syntax has been removed in the 2021 edition.
+```grammar,patterns
+RangePattern ->
+      RangeExclusivePattern
+    | RangeInclusivePattern
+    | RangeFromPattern
+    | RangeToExclusivePattern
+    | RangeToInclusivePattern
+    | ObsoleteRangePattern[^obsolete-range-edition]
+
+RangeExclusivePattern ->
+      RangePatternBound `..` RangePatternBound
+
+RangeInclusivePattern ->
+      RangePatternBound `..=` RangePatternBound
+
+RangeFromPattern ->
+      RangePatternBound `..`
+
+RangeToExclusivePattern ->
+      `..` RangePatternBound
+
+RangeToInclusivePattern ->
+      `..=` RangePatternBound
+
+ObsoleteRangePattern ->
+    RangePatternBound `...` RangePatternBound
+
+RangePatternBound ->
+      CHAR_LITERAL
+    | BYTE_LITERAL
+    | `-`? INTEGER_LITERAL
+    | `-`? FLOAT_LITERAL
+    | PathExpression
+```
+
+[^obsolete-range-edition]: The _ObsoleteRangePattern_ syntax has been removed in the 2021 edition.
 
 r[patterns.range.intro]
 *Range patterns* match scalar values within the range defined by their bounds.
@@ -679,9 +670,9 @@ r[patterns.ref]
 ## Reference patterns
 
 r[patterns.ref.syntax]
-> **<sup>Syntax</sup>**\
-> _ReferencePattern_ :\
-> &nbsp;&nbsp; (`&`|`&&`) `mut`<sup>?</sup> [_PatternWithoutRange_]
+```grammar,patterns
+ReferencePattern -> (`&`|`&&`) `mut`? PatternWithoutRange
+```
 
 r[patterns.ref.intro]
 Reference patterns dereference the pointers that are being matched and, thus, borrow them.
@@ -710,32 +701,29 @@ r[patterns.struct]
 ## Struct patterns
 
 r[patterns.struct.syntax]
-> **<sup>Syntax</sup>**\
-> _StructPattern_ :\
-> &nbsp;&nbsp; [_PathInExpression_] `{`\
-> &nbsp;&nbsp; &nbsp;&nbsp; _StructPatternElements_ <sup>?</sup>\
-> &nbsp;&nbsp; `}`
->
-> _StructPatternElements_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; _StructPatternFields_ (`,` | `,` _StructPatternEtCetera_)<sup>?</sup>\
-> &nbsp;&nbsp; | _StructPatternEtCetera_
->
-> _StructPatternFields_ :\
-> &nbsp;&nbsp; _StructPatternField_ (`,` _StructPatternField_) <sup>\*</sup>
->
-> _StructPatternField_ :\
-> &nbsp;&nbsp; [_OuterAttribute_] <sup>\*</sup>\
-> &nbsp;&nbsp; (\
-> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; [TUPLE_INDEX] `:` [_Pattern_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | [IDENTIFIER] `:` [_Pattern_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | `ref`<sup>?</sup> `mut`<sup>?</sup> [IDENTIFIER]\
-> &nbsp;&nbsp; )
->
-> _StructPatternEtCetera_ :\
-> &nbsp;&nbsp; `..`
+```grammar,patterns
+StructPattern ->
+    PathInExpression `{`
+        StructPatternElements ?
+    `}`
 
-[_OuterAttribute_]: attributes.md
-[TUPLE_INDEX]: tokens.md#tuple-index
+StructPatternElements ->
+      StructPatternFields (`,` | `,` StructPatternEtCetera)?
+    | StructPatternEtCetera
+
+StructPatternFields ->
+    StructPatternField (`,` StructPatternField)*
+
+StructPatternField ->
+    OuterAttribute*
+    (
+        TUPLE_INDEX `:` Pattern
+      | IDENTIFIER `:` Pattern
+      | `ref`? `mut`? IDENTIFIER
+    )
+
+StructPatternEtCetera -> `..`
+```
 
 r[patterns.struct.intro]
 Struct patterns match struct, enum, and union values that match all criteria defined by its subpatterns.
@@ -828,12 +816,11 @@ r[patterns.tuple-struct]
 ## Tuple struct patterns
 
 r[patterns.tuple-struct.syntax]
-> **<sup>Syntax</sup>**\
-> _TupleStructPattern_ :\
-> &nbsp;&nbsp; [_PathInExpression_] `(` _TupleStructItems_<sup>?</sup> `)`
->
-> _TupleStructItems_ :\
-> &nbsp;&nbsp; [_Pattern_]&nbsp;( `,` [_Pattern_] )<sup>\*</sup> `,`<sup>?</sup>
+```grammar,patterns
+TupleStructPattern -> PathInExpression `(` TupleStructItems? `)`
+
+TupleStructItems -> Pattern ( `,` Pattern )* `,`?
+```
 
 r[patterns.tuple-struct.intro]
 Tuple struct patterns match tuple struct and enum values that match all criteria defined by its subpatterns.
@@ -846,21 +833,21 @@ r[patterns.tuple]
 ## Tuple patterns
 
 r[patterns.tuple.syntax]
-> **<sup>Syntax</sup>**\
-> _TuplePattern_ :\
-> &nbsp;&nbsp; `(` _TuplePatternItems_<sup>?</sup> `)`
->
-> _TuplePatternItems_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_Pattern_] `,`\
-> &nbsp;&nbsp; | [_RestPattern_]\
-> &nbsp;&nbsp; | [_Pattern_]&nbsp;(`,` [_Pattern_])<sup>+</sup> `,`<sup>?</sup>
+```grammar,patterns
+TuplePattern -> `(` TuplePatternItems? `)`
+
+TuplePatternItems ->
+      Pattern `,`
+    | RestPattern
+    | Pattern (`,` Pattern)+ `,`?
+```
 
 r[patterns.tuple.intro]
 Tuple patterns match tuple values that match all criteria defined by its subpatterns.
 They are also used to [destructure](#destructuring) a tuple.
 
 r[patterns.tuple.rest-syntax]
-The form `(..)` with a single [_RestPattern_] is a special form that does not require a comma, and matches a tuple of any size.
+The form `(..)` with a single [RestPattern] is a special form that does not require a comma, and matches a tuple of any size.
 
 r[patterns.tuple.refutable]
 The tuple pattern is refutable when one of its subpatterns is refutable.
@@ -879,9 +866,9 @@ r[patterns.paren]
 ## Grouped patterns
 
 r[patterns.paren.syntax]
-> **<sup>Syntax</sup>**\
-> _GroupedPattern_ :\
-> &nbsp;&nbsp; `(` [_Pattern_] `)`
+```grammar,patterns
+GroupedPattern -> `(` Pattern `)`
+```
 
 r[patterns.paren.intro]
 Enclosing a pattern in parentheses can be used to explicitly control the precedence of compound patterns.
@@ -899,12 +886,11 @@ r[patterns.slice]
 ## Slice patterns
 
 r[patterns.slice.syntax]
-> **<sup>Syntax</sup>**\
-> _SlicePattern_ :\
-> &nbsp;&nbsp; `[` _SlicePatternItems_<sup>?</sup> `]`
->
-> _SlicePatternItems_ :\
-> &nbsp;&nbsp; [_Pattern_] \(`,` [_Pattern_])<sup>\*</sup> `,`<sup>?</sup>
+```grammar,patterns
+SlicePattern -> `[` SlicePatternItems? `]`
+
+SlicePatternItems -> Pattern (`,` Pattern)* `,`?
+```
 
 r[patterns.slice.intro]
 Slice patterns can match both arrays of fixed size and slices of dynamic size.
@@ -941,9 +927,9 @@ r[patterns.path]
 ## Path patterns
 
 r[patterns.path.syntax]
-> **<sup>Syntax</sup>**\
-> _PathPattern_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_PathExpression_]
+```grammar,patterns
+PathPattern -> PathExpression
+```
 
 r[patterns.path.intro]
 _Path patterns_ are patterns that refer either to constant values or
@@ -1057,29 +1043,7 @@ This allows us to reserve syntactic space for a possible future type ascription 
 For example, `x @ A(..) | B(..)` will result in an error that `x` is not bound in all patterns.
 `&A(x) | B(x)` will result in a type mismatch between `x` in the different subpatterns.
 
-[_GroupedPattern_]: #grouped-patterns
-[_IdentifierPattern_]: #identifier-patterns
-[_LiteralPattern_]: #literal-patterns
-[_MacroInvocation_]: macros.md#macro-invocation
-[_ObsoleteRangePattern_]: #range-patterns
-[_PathInExpression_]: paths.md#paths-in-expressions
-[_PathExpression_]: expressions/path-expr.md
-[_PathPattern_]: #path-patterns
-[_Pattern_]: #patterns
-[_PatternNoTopAlt_]: #patterns
-[_PatternWithoutRange_]: #patterns
-[_QualifiedPathInExpression_]: paths.md#qualified-paths
-[_RangePattern_]: #range-patterns
-[_ReferencePattern_]: #reference-patterns
-[_RestPattern_]: #rest-patterns
-[_SlicePattern_]: #slice-patterns
-[_StructPattern_]: #struct-patterns
-[_TuplePattern_]: #tuple-patterns
-[_TupleStructPattern_]: #tuple-struct-patterns
-[_WildcardPattern_]: #wildcard-pattern
-
 [`Copy`]: special-types-and-traits.md#copy
-[IDENTIFIER]: identifiers.md
 [constant]: items/constant-items.md
 [enums]: items/enumerations.md
 [literals]: expressions/literal-expr.md

--- a/src/runtime.md
+++ b/src/runtime.md
@@ -17,7 +17,7 @@ The *`windows_subsystem` attribute* may be applied at the crate level to set
 the [subsystem] when linking on a Windows target.
 
 r[runtime.windows_subsystem.syntax]
-It uses the [_MetaNameValueStr_] syntax to specify the subsystem with a value of either
+It uses the [MetaNameValueStr] syntax to specify the subsystem with a value of either
 `console` or `windows`.
 
 r[runtime.windows_subsystem.ignored]
@@ -36,7 +36,6 @@ display a console window on startup. It will run detached from any existing cons
 #![windows_subsystem = "windows"]
 ```
 
-[_MetaNameValueStr_]: attributes.md#meta-item-attribute-syntax
 [`GlobalAlloc`]: alloc::alloc::GlobalAlloc
 [crate types]: linkage.md
 [static item]: items/static-items.md

--- a/src/statements.md
+++ b/src/statements.md
@@ -2,13 +2,14 @@ r[statement]
 # Statements
 
 r[statement.syntax]
-> **<sup>Syntax</sup>**\
-> _Statement_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `;`\
-> &nbsp;&nbsp; | [_Item_]\
-> &nbsp;&nbsp; | [_LetStatement_]\
-> &nbsp;&nbsp; | [_ExpressionStatement_]\
-> &nbsp;&nbsp; | [_MacroInvocationSemi_]
+```grammar,statements
+Statement ->
+      `;`
+    | Item
+    | LetStatement
+    | ExpressionStatement
+    | MacroInvocationSemi
+```
 
 r[statement.intro]
 A *statement* is a component of a [block], which is in turn a component of an outer [expression] or [function].
@@ -56,14 +57,14 @@ r[statement.let]
 ### `let` statements
 
 r[statement.let.syntax]
-> **<sup>Syntax</sup>**\
-> _LetStatement_ :\
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> `let` [_PatternNoTopAlt_]
->     ( `:` [_Type_] )<sup>?</sup> (`=` [_Expression_] [†](#let-else-restriction)
->     ( `else` [_BlockExpression_]) <sup>?</sup> ) <sup>?</sup> `;`
->
-> <span id="let-else-restriction">† When an `else` block is specified, the
-> _Expression_ must not be a [_LazyBooleanExpression_], or end with a `}`.</span>
+```grammar,statements
+LetStatement ->
+    OuterAttribute* `let` PatternNoTopAlt ( `:` Type )?
+    (
+          `=` Expression
+        | `=` Expression _except [LazyBooleanExpression] or end with a `}`_ `else` BlockExpression
+    )? `;`
+```
 
 r[statement.let.intro]
 A *`let` statement* introduces a new set of [variables], given by a [pattern].
@@ -98,10 +99,11 @@ r[statement.expr]
 ## Expression statements
 
 r[statement.expr.syntax]
-> **<sup>Syntax</sup>**\
-> _ExpressionStatement_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_ExpressionWithoutBlock_][expression] `;`\
-> &nbsp;&nbsp; | [_ExpressionWithBlock_][expression] `;`<sup>?</sup>
+```grammar,statements
+ExpressionStatement ->
+      ExpressionWithoutBlock `;`
+    | ExpressionWithBlock `;`?
+```
 
 r[statement.expr.intro]
 An *expression statement* is one that evaluates an [expression] and ignores its result.
@@ -113,7 +115,7 @@ This can cause an ambiguity between it being parsed as a standalone statement an
 in this case, it is parsed as a statement.
 
 r[statement.expr.constraint-block]
-The type of [_ExpressionWithBlock_][expression] expressions when used as statements must be the unit type.
+The type of [ExpressionWithBlock] expressions when used as statements must be the unit type.
 
 ```rust
 # let mut v = vec![1, 2, 3];
@@ -163,13 +165,3 @@ The attributes that have meaning on a statement are [`cfg`], and [the lint check
 [the lint check attributes]: attributes/diagnostics.md#lint-check-attributes
 [pattern]: patterns.md
 [scope]: names/scopes.md
-[_BlockExpression_]: expressions/block-expr.md
-[_ExpressionStatement_]: #expression-statements
-[_Expression_]: expressions.md
-[_Item_]: items.md
-[_LazyBooleanExpression_]: expressions/operator-expr.md#lazy-boolean-operators
-[_LetStatement_]: #let-statements
-[_MacroInvocationSemi_]: macros.md#macro-invocation
-[_OuterAttribute_]: attributes.md
-[_PatternNoTopAlt_]: patterns.md
-[_Type_]: types.md

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -157,7 +157,7 @@ r[lex.token.literal.str.syntax]
 > **<sup>Lexer</sup>**\
 > STRING_LITERAL :\
 > &nbsp;&nbsp; `"` (\
-> &nbsp;&nbsp; &nbsp;&nbsp; ~\[`"` `\` _IsolatedCR_]\
+> &nbsp;&nbsp; &nbsp;&nbsp; ~\[`"` `\` CR]\
 > &nbsp;&nbsp; &nbsp;&nbsp; | QUOTE_ESCAPE\
 > &nbsp;&nbsp; &nbsp;&nbsp; | ASCII_ESCAPE\
 > &nbsp;&nbsp; &nbsp;&nbsp; | UNICODE_ESCAPE\
@@ -220,7 +220,7 @@ r[lex.token.literal.str-raw.syntax]
 > &nbsp;&nbsp; `r` RAW_STRING_CONTENT SUFFIX<sup>?</sup>
 >
 > RAW_STRING_CONTENT :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `"` ( ~ _IsolatedCR_ )<sup>* (non-greedy)</sup> `"`\
+> &nbsp;&nbsp; &nbsp;&nbsp; `"` ( ~ CR )<sup>* (non-greedy)</sup> `"`\
 > &nbsp;&nbsp; | `#` RAW_STRING_CONTENT `#`
 
 r[lex.token.literal.str-raw.intro]
@@ -285,7 +285,7 @@ r[lex.token.str-byte.syntax]
 > &nbsp;&nbsp; `b"` ( ASCII_FOR_STRING | BYTE_ESCAPE | STRING_CONTINUE )<sup>\*</sup> `"` SUFFIX<sup>?</sup>
 >
 > ASCII_FOR_STRING :\
-> &nbsp;&nbsp; _any ASCII (i.e 0x00 to 0x7F), except_ `"`, `\` _and IsolatedCR_
+> &nbsp;&nbsp; _any ASCII (i.e 0x00 to 0x7F) except_ `"`, `\`, _or CR_
 
 r[lex.token.str-byte.intro]
 A non-raw _byte string literal_ is a sequence of ASCII characters and _escapes_,
@@ -337,7 +337,7 @@ r[lex.token.str-byte-raw.syntax]
 > &nbsp;&nbsp; | `#` RAW_BYTE_STRING_CONTENT `#`
 >
 > ASCII_FOR_RAW :\
-> &nbsp;&nbsp; _any ASCII (i.e. 0x00 to 0x7F) except IsolatedCR_
+> &nbsp;&nbsp; _any ASCII (i.e. 0x00 to 0x7F) except CR_
 
 r[lex.token.str-byte-raw.intro]
 Raw byte string literals do not process any escapes. They start with the
@@ -377,7 +377,7 @@ r[lex.token.str-c.syntax]
 > **<sup>Lexer</sup>**\
 > C_STRING_LITERAL :\
 > &nbsp;&nbsp; `c"` (\
-> &nbsp;&nbsp; &nbsp;&nbsp; ~\[`"` `\` _IsolatedCR_ _NUL_]\
+> &nbsp;&nbsp; &nbsp;&nbsp; ~\[`"` `\` CR _NUL_]\
 > &nbsp;&nbsp; &nbsp;&nbsp; | BYTE_ESCAPE _except `\0` or `\x00`_\
 > &nbsp;&nbsp; &nbsp;&nbsp; | UNICODE_ESCAPE _except `\u{0}`, `\u{00}`, …, `\u{000000}`_\
 > &nbsp;&nbsp; &nbsp;&nbsp; | STRING_CONTINUE\
@@ -453,7 +453,7 @@ r[lex.token.str-c-raw.syntax]
 > &nbsp;&nbsp; `cr` RAW_C_STRING_CONTENT SUFFIX<sup>?</sup>
 >
 > RAW_C_STRING_CONTENT :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `"` ( ~ _IsolatedCR_ _NUL_ )<sup>* (non-greedy)</sup> `"`\
+> &nbsp;&nbsp; &nbsp;&nbsp; `"` ( ~\[CR NUL] )<sup>* (non-greedy)</sup> `"`\
 > &nbsp;&nbsp; | `#` RAW_C_STRING_CONTENT `#`
 
 r[lex.token.str-c-raw.intro]

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -2,23 +2,24 @@ r[lex.token]
 # Tokens
 
 r[lex.token.syntax]
-> **<sup>Lexer</sup>**\
-> Token :\
-> &nbsp;&nbsp; &nbsp;&nbsp; IDENTIFIER_OR_KEYWORD\
-> &nbsp;&nbsp; | RAW_IDENTIFIER\
-> &nbsp;&nbsp; | CHAR_LITERAL\
-> &nbsp;&nbsp; | STRING_LITERAL\
-> &nbsp;&nbsp; | RAW_STRING_LITERAL\
-> &nbsp;&nbsp; | BYTE_LITERAL\
-> &nbsp;&nbsp; | BYTE_STRING_LITERAL\
-> &nbsp;&nbsp; | RAW_BYTE_STRING_LITERAL\
-> &nbsp;&nbsp; | C_STRING_LITERAL\
-> &nbsp;&nbsp; | RAW_C_STRING_LITERAL\
-> &nbsp;&nbsp; | INTEGER_LITERAL\
-> &nbsp;&nbsp; | FLOAT_LITERAL\
-> &nbsp;&nbsp; | LIFETIME_TOKEN\
-> &nbsp;&nbsp; | PUNCTUATION\
-> &nbsp;&nbsp; | RESERVED_TOKEN
+```grammar,lexer
+Token ->
+      IDENTIFIER_OR_KEYWORD
+    | RAW_IDENTIFIER
+    | CHAR_LITERAL
+    | STRING_LITERAL
+    | RAW_STRING_LITERAL
+    | BYTE_LITERAL
+    | BYTE_STRING_LITERAL
+    | RAW_BYTE_STRING_LITERAL
+    | C_STRING_LITERAL
+    | RAW_C_STRING_LITERAL
+    | INTEGER_LITERAL
+    | FLOAT_LITERAL
+    | LIFETIME_TOKEN
+    | PUNCTUATION
+    | RESERVED_TOKEN
+```
 
 r[lex.token.intro]
 Tokens are primitive productions in the grammar defined by regular
@@ -116,9 +117,11 @@ r[lex.token.literal.literal.suffix.intro]
 A suffix is a sequence of characters following the primary part of a literal (without intervening whitespace), of the same form as a non-raw identifier or keyword.
 
 r[lex.token.literal.suffix.syntax]
-> **<sup>Lexer</sup>**\
-> SUFFIX : IDENTIFIER_OR_KEYWORD\
-> SUFFIX_NO_E : SUFFIX <sub>_not beginning with `e` or `E`_</sub>
+```grammar,lexer
+SUFFIX -> IDENTIFIER_OR_KEYWORD
+
+SUFFIX_NO_E -> SUFFIX _not beginning with `e` or `E`_
+```
 
 r[lex.token.literal.suffix.validity]
 Any kind of literal (string, integer, etc) with any suffix is valid as a token.
@@ -150,19 +153,21 @@ r[lex.token.literal.char]
 #### Character literals
 
 r[lex.token.literal.char.syntax]
-> **<sup>Lexer</sup>**\
-> CHAR_LITERAL :\
-> &nbsp;&nbsp; `'` ( ~\[`'` `\` LF CR TAB] | QUOTE_ESCAPE | ASCII_ESCAPE | UNICODE_ESCAPE ) `'` SUFFIX<sup>?</sup>
->
-> QUOTE_ESCAPE :\
-> &nbsp;&nbsp; `\'` | `\"`
->
-> ASCII_ESCAPE :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `\x` OCT_DIGIT HEX_DIGIT\
-> &nbsp;&nbsp; | `\n` | `\r` | `\t` | `\\` | `\0`
->
-> UNICODE_ESCAPE :\
-> &nbsp;&nbsp; `\u{` ( HEX_DIGIT `_`<sup>\*</sup> )<sup>1..6</sup> `}`
+```grammar,lexer
+CHAR_LITERAL ->
+    `'`
+        ( ~[`'` `\` LF CR TAB] | QUOTE_ESCAPE | ASCII_ESCAPE | UNICODE_ESCAPE )
+    `'` SUFFIX?
+
+QUOTE_ESCAPE -> `\'` | `\"`
+
+ASCII_ESCAPE ->
+      `\x` OCT_DIGIT HEX_DIGIT
+    | `\n` | `\r` | `\t` | `\\` | `\0`
+
+UNICODE_ESCAPE ->
+    `\u{` ( HEX_DIGIT `_`* ){1..6} `}`
+```
 
 r[lex.token.literal.char.intro]
 A _character literal_ is a single Unicode character enclosed within two
@@ -173,18 +178,18 @@ r[lex.token.literal.str]
 #### String literals
 
 r[lex.token.literal.str.syntax]
-> **<sup>Lexer</sup>**\
-> STRING_LITERAL :\
-> &nbsp;&nbsp; `"` (\
-> &nbsp;&nbsp; &nbsp;&nbsp; ~\[`"` `\` CR]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | QUOTE_ESCAPE\
-> &nbsp;&nbsp; &nbsp;&nbsp; | ASCII_ESCAPE\
-> &nbsp;&nbsp; &nbsp;&nbsp; | UNICODE_ESCAPE\
-> &nbsp;&nbsp; &nbsp;&nbsp; | STRING_CONTINUE\
-> &nbsp;&nbsp; )<sup>\*</sup> `"` SUFFIX<sup>?</sup>
->
-> STRING_CONTINUE :\
-> &nbsp;&nbsp; `\` LF
+```grammar,lexer
+STRING_LITERAL ->
+    `"` (
+        ~[`"` `\` CR]
+      | QUOTE_ESCAPE
+      | ASCII_ESCAPE
+      | UNICODE_ESCAPE
+      | STRING_CONTINUE
+    )* `"` SUFFIX?
+
+STRING_CONTINUE -> `\` LF
+```
 
 r[lex.token.literal.str.intro]
 A _string literal_ is a sequence of any Unicode characters enclosed within two
@@ -234,13 +239,13 @@ r[lex.token.literal.str-raw]
 #### Raw string literals
 
 r[lex.token.literal.str-raw.syntax]
-> **<sup>Lexer</sup>**\
-> RAW_STRING_LITERAL :\
-> &nbsp;&nbsp; `r` RAW_STRING_CONTENT SUFFIX<sup>?</sup>
->
-> RAW_STRING_CONTENT :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `"` ( ~ CR )<sup>* (non-greedy)</sup> `"`\
-> &nbsp;&nbsp; | `#` RAW_STRING_CONTENT `#`
+```grammar,lexer
+RAW_STRING_LITERAL -> `r` RAW_STRING_CONTENT SUFFIX?
+
+RAW_STRING_CONTENT ->
+      `"` ( ~CR )*? `"`
+    | `#` RAW_STRING_CONTENT `#`
+```
 
 r[lex.token.literal.str-raw.intro]
 Raw string literals do not process any escapes. They start with the character
@@ -276,16 +281,17 @@ r[lex.token.byte]
 #### Byte literals
 
 r[lex.token.byte.syntax]
-> **<sup>Lexer</sup>**\
-> BYTE_LITERAL :\
-> &nbsp;&nbsp; `b'` ( ASCII_FOR_CHAR | BYTE_ESCAPE )  `'` SUFFIX<sup>?</sup>
->
-> ASCII_FOR_CHAR :\
-> &nbsp;&nbsp; \<any ASCII (i.e. 0x00 to 0x7F) except `'`, `\`, LF, CR, or TAB\>
->
-> BYTE_ESCAPE :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `\x` HEX_DIGIT HEX_DIGIT\
-> &nbsp;&nbsp; | `\n` | `\r` | `\t` | `\\` | `\0` | `\'` | `\"`
+```grammar,lexer
+BYTE_LITERAL ->
+    `b'` ( ASCII_FOR_CHAR | BYTE_ESCAPE )  `'` SUFFIX?
+
+ASCII_FOR_CHAR ->
+    <any ASCII (i.e. 0x00 to 0x7F) except `'`, `\`, LF, CR, or TAB>
+
+BYTE_ESCAPE ->
+      `\x` HEX_DIGIT HEX_DIGIT
+    | `\n` | `\r` | `\t` | `\\` | `\0` | `\'` | `\"`
+```
 
 r[lex.token.byte.intro]
 A _byte literal_ is a single ASCII character (in the `U+0000` to `U+007F`
@@ -299,12 +305,13 @@ r[lex.token.str-byte]
 #### Byte string literals
 
 r[lex.token.str-byte.syntax]
-> **<sup>Lexer</sup>**\
-> BYTE_STRING_LITERAL :\
-> &nbsp;&nbsp; `b"` ( ASCII_FOR_STRING | BYTE_ESCAPE | STRING_CONTINUE )<sup>\*</sup> `"` SUFFIX<sup>?</sup>
->
-> ASCII_FOR_STRING :\
-> &nbsp;&nbsp; \<any ASCII (i.e 0x00 to 0x7F) except `"`, `\`, or CR\>
+```grammar,lexer
+BYTE_STRING_LITERAL ->
+    `b"` ( ASCII_FOR_STRING | BYTE_ESCAPE | STRING_CONTINUE )* `"` SUFFIX?
+
+ASCII_FOR_STRING ->
+    <any ASCII (i.e 0x00 to 0x7F) except `"`, `\`, or CR>
+```
 
 r[lex.token.str-byte.intro]
 A non-raw _byte string literal_ is a sequence of ASCII characters and _escapes_,
@@ -347,16 +354,17 @@ r[lex.token.str-byte-raw]
 #### Raw byte string literals
 
 r[lex.token.str-byte-raw.syntax]
-> **<sup>Lexer</sup>**\
-> RAW_BYTE_STRING_LITERAL :\
-> &nbsp;&nbsp; `br` RAW_BYTE_STRING_CONTENT SUFFIX<sup>?</sup>
->
-> RAW_BYTE_STRING_CONTENT :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `"` ASCII_FOR_RAW<sup>* (non-greedy)</sup> `"`\
-> &nbsp;&nbsp; | `#` RAW_BYTE_STRING_CONTENT `#`
->
-> ASCII_FOR_RAW :\
-> &nbsp;&nbsp; \<any ASCII (i.e. 0x00 to 0x7F) except CR\>
+```grammar,lexer
+RAW_BYTE_STRING_LITERAL ->
+    `br` RAW_BYTE_STRING_CONTENT SUFFIX?
+
+RAW_BYTE_STRING_CONTENT ->
+      `"` ASCII_FOR_RAW*? `"`
+    | `#` RAW_BYTE_STRING_CONTENT `#`
+
+ASCII_FOR_RAW ->
+    <any ASCII (i.e. 0x00 to 0x7F) except CR>
+```
 
 r[lex.token.str-byte-raw.intro]
 Raw byte string literals do not process any escapes. They start with the
@@ -393,14 +401,16 @@ r[lex.token.str-c]
 #### C string literals
 
 r[lex.token.str-c.syntax]
-> **<sup>Lexer</sup>**\
-> C_STRING_LITERAL :\
-> &nbsp;&nbsp; `c"` (\
-> &nbsp;&nbsp; &nbsp;&nbsp; ~\[`"` `\` CR _NUL_]\
-> &nbsp;&nbsp; &nbsp;&nbsp; | BYTE_ESCAPE _except `\0` or `\x00`_\
-> &nbsp;&nbsp; &nbsp;&nbsp; | UNICODE_ESCAPE _except `\u{0}`, `\u{00}`, …, `\u{000000}`_\
-> &nbsp;&nbsp; &nbsp;&nbsp; | STRING_CONTINUE\
-> &nbsp;&nbsp; )<sup>\*</sup> `"` SUFFIX<sup>?</sup>
+```grammar,lexer
+C_STRING_LITERAL ->
+    `c"` (
+        ~[`"` `\` CR NUL]
+      | BYTE_ESCAPE _except `\0` or `\x00`_
+      | UNICODE_ESCAPE _except `\u{0}`, `\u{00}`, …, `\u{000000}`_
+      | STRING_CONTINUE
+    )* `"` SUFFIX?
+
+```
 
 r[lex.token.str-c.intro]
 A _C string literal_ is a sequence of Unicode characters and _escapes_,
@@ -467,13 +477,14 @@ r[lex.token.str-c-raw]
 #### Raw C string literals
 
 r[lex.token.str-c-raw.syntax]
-> **<sup>Lexer</sup>**\
-> RAW_C_STRING_LITERAL :\
-> &nbsp;&nbsp; `cr` RAW_C_STRING_CONTENT SUFFIX<sup>?</sup>
->
-> RAW_C_STRING_CONTENT :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `"` ( ~\[CR NUL] )<sup>* (non-greedy)</sup> `"`\
-> &nbsp;&nbsp; | `#` RAW_C_STRING_CONTENT `#`
+```grammar,lexer
+RAW_C_STRING_LITERAL ->
+    `cr` RAW_C_STRING_CONTENT SUFFIX?
+
+RAW_C_STRING_CONTENT ->
+      `"` ( ~[CR NUL] )*? `"`
+    | `#` RAW_C_STRING_CONTENT `#`
+```
 
 r[lex.token.str-c-raw.intro]
 Raw C string literals do not process any escapes. They start with the
@@ -517,30 +528,26 @@ r[lex.token.literal.int]
 #### Integer literals
 
 r[lex.token.literal.int.syntax]
-> **<sup>Lexer</sup>**\
-> INTEGER_LITERAL :\
-> &nbsp;&nbsp; ( DEC_LITERAL | BIN_LITERAL | OCT_LITERAL | HEX_LITERAL )
->              SUFFIX_NO_E<sup>?</sup>
->
-> DEC_LITERAL :\
-> &nbsp;&nbsp; DEC_DIGIT (DEC_DIGIT|`_`)<sup>\*</sup>
->
-> BIN_LITERAL :\
-> &nbsp;&nbsp; `0b` (BIN_DIGIT|`_`)<sup>\*</sup> BIN_DIGIT (BIN_DIGIT|`_`)<sup>\*</sup>
->
-> OCT_LITERAL :\
-> &nbsp;&nbsp; `0o` (OCT_DIGIT|`_`)<sup>\*</sup> OCT_DIGIT (OCT_DIGIT|`_`)<sup>\*</sup>
->
-> HEX_LITERAL :\
-> &nbsp;&nbsp; `0x` (HEX_DIGIT|`_`)<sup>\*</sup> HEX_DIGIT (HEX_DIGIT|`_`)<sup>\*</sup>
->
-> BIN_DIGIT : \[`0`-`1`]
->
-> OCT_DIGIT : \[`0`-`7`]
->
-> DEC_DIGIT : \[`0`-`9`]
->
-> HEX_DIGIT : \[`0`-`9` `a`-`f` `A`-`F`]
+```grammar,lexer
+INTEGER_LITERAL ->
+    ( DEC_LITERAL | BIN_LITERAL | OCT_LITERAL | HEX_LITERAL ) SUFFIX_NO_E?
+
+DEC_LITERAL -> DEC_DIGIT (DEC_DIGIT|`_`)*
+
+BIN_LITERAL -> `0b` (BIN_DIGIT|`_`)* BIN_DIGIT (BIN_DIGIT|`_`)*
+
+OCT_LITERAL -> `0o` (OCT_DIGIT|`_`)* OCT_DIGIT (OCT_DIGIT|`_`)*
+
+HEX_LITERAL -> `0x` (HEX_DIGIT|`_`)* HEX_DIGIT (HEX_DIGIT|`_`)*
+
+BIN_DIGIT -> [`0`-`1`]
+
+OCT_DIGIT -> [`0`-`7`]
+
+DEC_DIGIT -> [`0`-`9`]
+
+HEX_DIGIT -> [`0`-`9` `a`-`f` `A`-`F`]
+```
 
 r[lex.token.literal.int.kind]
 An _integer literal_ has one of four forms:
@@ -618,9 +625,9 @@ r[lex.token.literal.int.tuple-field]
 #### Tuple index
 
 r[lex.token.literal.int.tuple-field.syntax]
-> **<sup>Lexer</sup>**\
-> TUPLE_INDEX: \
-> &nbsp;&nbsp; INTEGER_LITERAL
+```grammar,lexer
+TUPLE_INDEX -> INTEGER_LITERAL
+```
 
 r[lex.token.literal.int.tuple-field.intro]
 A tuple index is used to refer to the fields of [tuples], [tuple structs], and
@@ -648,17 +655,15 @@ r[lex.token.literal.float]
 #### Floating-point literals
 
 r[lex.token.literal.float.syntax]
-> **<sup>Lexer</sup>**\
-> FLOAT_LITERAL :\
-> &nbsp;&nbsp; &nbsp;&nbsp; DEC_LITERAL `.`
->   _not immediately followed by `.`, `_` or an XID_Start character_\
-> &nbsp;&nbsp; | DEC_LITERAL `.` DEC_LITERAL SUFFIX_NO_E<sup>?</sup>\
-> &nbsp;&nbsp; | DEC_LITERAL (`.` DEC_LITERAL)<sup>?</sup> FLOAT_EXPONENT SUFFIX<sup>?</sup>
->
-> FLOAT_EXPONENT :\
-> &nbsp;&nbsp; (`e`|`E`) (`+`|`-`)<sup>?</sup>
->               (DEC_DIGIT|`_`)<sup>\*</sup> DEC_DIGIT (DEC_DIGIT|`_`)<sup>\*</sup>
->
+```grammar,lexer
+FLOAT_LITERAL ->
+      DEC_LITERAL `.` _not immediately followed by `.`, `_` or an XID_Start character_
+    | DEC_LITERAL `.` DEC_LITERAL SUFFIX_NO_E?
+    | DEC_LITERAL (`.` DEC_LITERAL)? FLOAT_EXPONENT SUFFIX?
+
+FLOAT_EXPONENT ->
+    (`e`|`E`) (`+`|`-`)? (DEC_DIGIT|`_`)* DEC_DIGIT (DEC_DIGIT|`_`)*
+```
 
 r[lex.token.literal.float.form]
 A _floating-point literal_ has one of two forms:
@@ -705,17 +710,18 @@ r[lex.token.literal.reserved]
 #### Reserved forms similar to number literals
 
 r[lex.token.literal.reserved.syntax]
-> **<sup>Lexer</sup>**\
-> RESERVED_NUMBER :\
-> &nbsp;&nbsp; &nbsp;&nbsp; BIN_LITERAL \[`2`-`9`&ZeroWidthSpace;]\
-> &nbsp;&nbsp; | OCT_LITERAL \[`8`-`9`&ZeroWidthSpace;]\
-> &nbsp;&nbsp; | ( BIN_LITERAL | OCT_LITERAL | HEX_LITERAL ) `.` \
-> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; _not immediately followed by `.`, `_` or an XID_Start character_\
-> &nbsp;&nbsp; | ( BIN_LITERAL | OCT_LITERAL ) (`e`|`E`)\
-> &nbsp;&nbsp; | `0b` `_`<sup>\*</sup> \<end of input or not BIN_DIGIT\>\
-> &nbsp;&nbsp; | `0o` `_`<sup>\*</sup> \<end of input or not OCT_DIGIT\>\
-> &nbsp;&nbsp; | `0x` `_`<sup>\*</sup> \<end of input or not HEX_DIGIT\>\
-> &nbsp;&nbsp; | DEC_LITERAL ( . DEC_LITERAL)<sup>?</sup> (`e`|`E`) (`+`|`-`)<sup>?</sup> \<end of input or not DEC_DIGIT\>
+```grammar,lexer
+RESERVED_NUMBER ->
+      BIN_LITERAL [`2`-`9`]
+    | OCT_LITERAL [`8`-`9`]
+    | ( BIN_LITERAL | OCT_LITERAL | HEX_LITERAL ) `.` _not immediately followed by `.`, `_` or an XID_Start character_
+    | ( BIN_LITERAL | OCT_LITERAL ) (`e`|`E`)
+    | `0b` `_`* <end of input or not BIN_DIGIT>
+    | `0o` `_`* <end of input or not OCT_DIGIT>
+    | `0x` `_`* <end of input or not HEX_DIGIT>
+    | DEC_LITERAL ( `.` DEC_LITERAL )? (`e` | `E`) (`+` | `-`)? <end of input or not DEC_DIGIT>
+
+```
 
 r[lex.token.literal.reserved.intro]
 The following lexical forms similar to number literals are _reserved forms_.
@@ -755,25 +761,21 @@ r[lex.token.life]
 ## Lifetimes and loop labels
 
 r[lex.token.life.syntax]
-> **<sup>Lexer</sup>**\
-> LIFETIME_TOKEN :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `'` [IDENTIFIER_OR_KEYWORD][identifier]
->   _not immediately followed by `'`_\
-> &nbsp;&nbsp; | `'_`
->   _not immediately followed by `'`_\
-> &nbsp;&nbsp; | RAW_LIFETIME
->
-> LIFETIME_OR_LABEL :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `'` [NON_KEYWORD_IDENTIFIER][identifier]
->   _not immediately followed by `'`_\
-> &nbsp;&nbsp; | RAW_LIFETIME
->
-> RAW_LIFETIME :\
-> &nbsp;&nbsp; `'r#` [IDENTIFIER_OR_KEYWORD][identifier] <sub>*except `crate`, `self`, `super`, `Self`*</sub>
->   _not immediately followed by `'`_
->
-> RESERVED_RAW_LIFETIME : `'r#_`
->   _not immediately followed by `'`_
+```grammar,lexer
+LIFETIME_TOKEN ->
+      `'` IDENTIFIER_OR_KEYWORD _not immediately followed by `'`_
+    | `'_` _not immediately followed by `'`_
+    | RAW_LIFETIME
+
+LIFETIME_OR_LABEL ->
+      `'` NON_KEYWORD_IDENTIFIER _not immediately followed by `'`_
+    | RAW_LIFETIME
+
+RAW_LIFETIME ->
+    `'r#` IDENTIFIER_OR_KEYWORD _except `crate`, `self`, `super`, `Self` and not immediately followed by `'`_
+
+RESERVED_RAW_LIFETIME -> `'r#_` _not immediately followed by `'`_
+```
 
 r[lex.token.life.intro]
 Lifetime parameters and [loop labels] use LIFETIME_OR_LABEL tokens. Any
@@ -797,62 +799,62 @@ r[lex.token.punct]
 ## Punctuation
 
 r[lex.token.punct.syntax]
-> **<sup>Lexer</sup>**\
-> Token :\
-> PUNCTUATION :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `=`\
-> &nbsp;&nbsp; | `<`\
-> &nbsp;&nbsp; | `<=`\
-> &nbsp;&nbsp; | `==`\
-> &nbsp;&nbsp; | `!=`\
-> &nbsp;&nbsp; | `>=`\
-> &nbsp;&nbsp; | `>`\
-> &nbsp;&nbsp; | `&&`\
-> &nbsp;&nbsp; | `||`\
-> &nbsp;&nbsp; | `!`\
-> &nbsp;&nbsp; | `~`\
-> &nbsp;&nbsp; | `+`\
-> &nbsp;&nbsp; | `-`\
-> &nbsp;&nbsp; | `*`\
-> &nbsp;&nbsp; | `/`\
-> &nbsp;&nbsp; | `%`\
-> &nbsp;&nbsp; | `^`\
-> &nbsp;&nbsp; | `&`\
-> &nbsp;&nbsp; | `|`\
-> &nbsp;&nbsp; | `<<`\
-> &nbsp;&nbsp; | `>>`\
-> &nbsp;&nbsp; | `+=`\
-> &nbsp;&nbsp; | `-=`\
-> &nbsp;&nbsp; | `*=`\
-> &nbsp;&nbsp; | `/=`\
-> &nbsp;&nbsp; | `%=`\
-> &nbsp;&nbsp; | `^=`\
-> &nbsp;&nbsp; | `&=`\
-> &nbsp;&nbsp; | `|=`\
-> &nbsp;&nbsp; | `<<=`\
-> &nbsp;&nbsp; | `>>=`\
-> &nbsp;&nbsp; | `@`\
-> &nbsp;&nbsp; | `.`\
-> &nbsp;&nbsp; | `..`\
-> &nbsp;&nbsp; | `...`\
-> &nbsp;&nbsp; | `..=`\
-> &nbsp;&nbsp; | `,`\
-> &nbsp;&nbsp; | `;`\
-> &nbsp;&nbsp; | `:`\
-> &nbsp;&nbsp; | `::`\
-> &nbsp;&nbsp; | `->`\
-> &nbsp;&nbsp; | `<-`\
-> &nbsp;&nbsp; | `=>`\
-> &nbsp;&nbsp; | `#`\
-> &nbsp;&nbsp; | `$`\
-> &nbsp;&nbsp; | `?`\
-> &nbsp;&nbsp; | `_`\
-> &nbsp;&nbsp; | `{`\
-> &nbsp;&nbsp; | `}`\
-> &nbsp;&nbsp; | `[`\
-> &nbsp;&nbsp; | `]`\
-> &nbsp;&nbsp; | `(`\
-> &nbsp;&nbsp; | `)`
+```grammar,lexer
+PUNCTUATION ->
+      `=`
+    | `<`
+    | `<=`
+    | `==`
+    | `!=`
+    | `>=`
+    | `>`
+    | `&&`
+    | `||`
+    | `!`
+    | `~`
+    | `+`
+    | `-`
+    | `*`
+    | `/`
+    | `%`
+    | `^`
+    | `&`
+    | `|`
+    | `<<`
+    | `>>`
+    | `+=`
+    | `-=`
+    | `*=`
+    | `/=`
+    | `%=`
+    | `^=`
+    | `&=`
+    | `|=`
+    | `<<=`
+    | `>>=`
+    | `@`
+    | `.`
+    | `..`
+    | `...`
+    | `..=`
+    | `,`
+    | `;`
+    | `:`
+    | `::`
+    | `->`
+    | `<-`
+    | `=>`
+    | `#`
+    | `$`
+    | `?`
+    | `_`
+    | `{`
+    | `}`
+    | `[`
+    | `]`
+    | `(`
+    | `)`
+```
 
 r[lex.token.punct.intro]
 Punctuation symbol tokens are listed here for completeness. Their individual
@@ -928,28 +930,36 @@ r[lex.token.reserved.intro]
 Several token forms are reserved for future use. It is an error for the source input to match one of these forms.
 
 r[lex.token.reserved.syntax]
-
-> **<sup>Lexer</sup>**\
-> RESERVED_TOKEN :\
-> &nbsp;&nbsp; &nbsp;&nbsp; RESERVED_GUARDED_STRING_LITERAL\
-> &nbsp;&nbsp; | RESERVED_NUMBER\
-> &nbsp;&nbsp; | RESERVED_POUNDS\
-> &nbsp;&nbsp; | RESERVED_RAW_IDENTIFIER\
-> &nbsp;&nbsp; | RESERVED_RAW_LIFETIME\
-> &nbsp;&nbsp; | RESERVED_TOKEN_DOUBLE_QUOTE\
-> &nbsp;&nbsp; | RESERVED_TOKEN_LIFETIME\
-> &nbsp;&nbsp; | RESERVED_TOKEN_POUND\
-> &nbsp;&nbsp; | RESERVED_TOKEN_SINGLE_QUOTE
+```grammar,lexer
+RESERVED_TOKEN ->
+      RESERVED_GUARDED_STRING_LITERAL
+    | RESERVED_NUMBER
+    | RESERVED_POUNDS
+    | RESERVED_RAW_IDENTIFIER
+    | RESERVED_RAW_LIFETIME
+    | RESERVED_TOKEN_DOUBLE_QUOTE
+    | RESERVED_TOKEN_LIFETIME
+    | RESERVED_TOKEN_POUND
+    | RESERVED_TOKEN_SINGLE_QUOTE
+```
 
 r[lex.token.reserved-prefix]
 ## Reserved prefixes
 
 r[lex.token.reserved-prefix.syntax]
-> **<sup>Lexer 2021+</sup>**\
-> RESERVED_TOKEN_DOUBLE_QUOTE : ( IDENTIFIER_OR_KEYWORD <sub>_except `b` or `c` or `r` or `br` or `cr`_</sub> | `_` ) `"`\
-> RESERVED_TOKEN_SINGLE_QUOTE : ( IDENTIFIER_OR_KEYWORD <sub>_except `b`_</sub> | `_` ) `'`\
-> RESERVED_TOKEN_POUND : ( IDENTIFIER_OR_KEYWORD <sub>_except `r` or `br` or `cr`_</sub> | `_` ) `#`\
-> RESERVED_TOKEN_LIFETIME : `'` ( IDENTIFIER_OR_KEYWORD <sub>_except `r`_</sub> | `_` ) `#`
+```grammar,lexer
+RESERVED_TOKEN_DOUBLE_QUOTE ->
+    ( IDENTIFIER_OR_KEYWORD _except `b` or `c` or `r` or `br` or `cr`_ | `_` ) `"`
+
+RESERVED_TOKEN_SINGLE_QUOTE ->
+    ( IDENTIFIER_OR_KEYWORD _except `b`_ | `_` ) `'`
+
+RESERVED_TOKEN_POUND ->
+    ( IDENTIFIER_OR_KEYWORD _except `r` or `br` or `cr`_ | `_` ) `#`
+
+RESERVED_TOKEN_LIFETIME ->
+    `'` ( IDENTIFIER_OR_KEYWORD _except `r`_ | `_` ) `#`
+```
 
 r[lex.token.reserved-prefix.intro]
 Some lexical forms known as _reserved prefixes_ are reserved for future use.
@@ -995,9 +1005,11 @@ r[lex.token.reserved-guards]
 ## Reserved guards
 
 r[lex.token.reserved-guards.syntax]
-> **<sup>Lexer 2024+</sup>**\
-> RESERVED_GUARDED_STRING_LITERAL : `#`<sup>+</sup> [STRING_LITERAL]\
-> RESERVED_POUNDS : `#`<sup>2..</sup>
+```grammar,lexer
+RESERVED_GUARDED_STRING_LITERAL -> `#`+ STRING_LITERAL
+
+RESERVED_POUNDS -> `#`{2..}
+```
 
 r[lex.token.reserved-guards.intro]
 The reserved guards are syntax reserved for future use, and will generate a compile error if used.
@@ -1015,7 +1027,6 @@ r[lex.token.reserved-guards.edition2024]
 [Inferred types]: types/inferred.md
 [Range patterns]: patterns.md#range-patterns
 [Reference patterns]: patterns.md#reference-patterns
-[STRING_LITERAL]: tokens.md#string-literals
 [Subpattern binding]: patterns.md#identifier-patterns
 [Wildcard patterns]: patterns.md#wildcard-pattern
 [arith]: expressions/operator-expr.md#arithmetic-and-logical-binary-operators

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -685,6 +685,7 @@ Examples of floating-point literals which are not accepted as literal expression
 r[lex.token.literal.reserved]
 #### Reserved forms similar to number literals
 
+r[lex.token.literal.reserved.syntax]
 > **<sup>Lexer</sup>**\
 > RESERVED_NUMBER :\
 > &nbsp;&nbsp; &nbsp;&nbsp; BIN_LITERAL \[`2`-`9`&ZeroWidthSpace;]\

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -165,7 +165,7 @@ r[lex.token.literal.str.syntax]
 > &nbsp;&nbsp; )<sup>\*</sup> `"` SUFFIX<sup>?</sup>
 >
 > STRING_CONTINUE :\
-> &nbsp;&nbsp; `\` _followed by_ LF
+> &nbsp;&nbsp; `\` LF
 
 r[lex.token.literal.str.intro]
 A _string literal_ is a sequence of any Unicode characters enclosed within two

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -750,7 +750,7 @@ r[lex.token.life.syntax]
 > &nbsp;&nbsp; | RAW_LIFETIME
 >
 > RAW_LIFETIME :\
-> &nbsp;&nbsp; `'r#` [IDENTIFIER_OR_KEYWORD][identifier] <sub>*Except `crate`, `self`, `super`, `Self`*</sub>
+> &nbsp;&nbsp; `'r#` [IDENTIFIER_OR_KEYWORD][identifier] <sub>*except `crate`, `self`, `super`, `Self`*</sub>
 >   _(not immediately followed by `'`)_
 >
 > RESERVED_RAW_LIFETIME : `'r#_`
@@ -849,10 +849,10 @@ r[lex.token.reserved-prefix]
 
 r[lex.token.reserved-prefix.syntax]
 > **<sup>Lexer 2021+</sup>**\
-> RESERVED_TOKEN_DOUBLE_QUOTE : ( IDENTIFIER_OR_KEYWORD <sub>_Except `b` or `c` or `r` or `br` or `cr`_</sub> | `_` ) `"`\
-> RESERVED_TOKEN_SINGLE_QUOTE : ( IDENTIFIER_OR_KEYWORD <sub>_Except `b`_</sub> | `_` ) `'`\
-> RESERVED_TOKEN_POUND : ( IDENTIFIER_OR_KEYWORD <sub>_Except `r` or `br` or `cr`_</sub> | `_` ) `#`\
-> RESERVED_TOKEN_LIFETIME : `'` (IDENTIFIER_OR_KEYWORD <sub>_Except `r`_</sub> | _) `#`
+> RESERVED_TOKEN_DOUBLE_QUOTE : ( IDENTIFIER_OR_KEYWORD <sub>_except `b` or `c` or `r` or `br` or `cr`_</sub> | `_` ) `"`\
+> RESERVED_TOKEN_SINGLE_QUOTE : ( IDENTIFIER_OR_KEYWORD <sub>_except `b`_</sub> | `_` ) `'`\
+> RESERVED_TOKEN_POUND : ( IDENTIFIER_OR_KEYWORD <sub>_except `r` or `br` or `cr`_</sub> | `_` ) `#`\
+> RESERVED_TOKEN_LIFETIME : `'` ( IDENTIFIER_OR_KEYWORD <sub>_except `r`_</sub> | `_` ) `#`
 
 r[lex.token.reserved-prefix.intro]
 Some lexical forms known as _reserved prefixes_ are reserved for future use.

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -262,7 +262,7 @@ r[lex.token.byte.syntax]
 > &nbsp;&nbsp; `b'` ( ASCII_FOR_CHAR | BYTE_ESCAPE )  `'` SUFFIX<sup>?</sup>
 >
 > ASCII_FOR_CHAR :\
-> &nbsp;&nbsp; _any ASCII (i.e. 0x00 to 0x7F) except_ `'`, `\`, LF, CR, or TAB
+> &nbsp;&nbsp; \<any ASCII (i.e. 0x00 to 0x7F) except `'`, `\`, LF, CR, or TAB\>
 >
 > BYTE_ESCAPE :\
 > &nbsp;&nbsp; &nbsp;&nbsp; `\x` HEX_DIGIT HEX_DIGIT\
@@ -285,7 +285,7 @@ r[lex.token.str-byte.syntax]
 > &nbsp;&nbsp; `b"` ( ASCII_FOR_STRING | BYTE_ESCAPE | STRING_CONTINUE )<sup>\*</sup> `"` SUFFIX<sup>?</sup>
 >
 > ASCII_FOR_STRING :\
-> &nbsp;&nbsp; _any ASCII (i.e 0x00 to 0x7F) except_ `"`, `\`, _or CR_
+> &nbsp;&nbsp; \<any ASCII (i.e 0x00 to 0x7F) except `"`, `\`, or CR\>
 
 r[lex.token.str-byte.intro]
 A non-raw _byte string literal_ is a sequence of ASCII characters and _escapes_,
@@ -337,7 +337,7 @@ r[lex.token.str-byte-raw.syntax]
 > &nbsp;&nbsp; | `#` RAW_BYTE_STRING_CONTENT `#`
 >
 > ASCII_FOR_RAW :\
-> &nbsp;&nbsp; _any ASCII (i.e. 0x00 to 0x7F) except CR_
+> &nbsp;&nbsp; \<any ASCII (i.e. 0x00 to 0x7F) except CR\>
 
 r[lex.token.str-byte-raw.intro]
 Raw byte string literals do not process any escapes. They start with the
@@ -693,10 +693,10 @@ r[lex.token.literal.reserved.syntax]
 > &nbsp;&nbsp; | ( BIN_LITERAL | OCT_LITERAL | HEX_LITERAL ) `.` \
 > &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; _(not immediately followed by `.`, `_` or an XID_Start character)_\
 > &nbsp;&nbsp; | ( BIN_LITERAL | OCT_LITERAL ) (`e`|`E`)\
-> &nbsp;&nbsp; | `0b` `_`<sup>\*</sup> _end of input or not BIN_DIGIT_\
-> &nbsp;&nbsp; | `0o` `_`<sup>\*</sup> _end of input or not OCT_DIGIT_\
-> &nbsp;&nbsp; | `0x` `_`<sup>\*</sup> _end of input or not HEX_DIGIT_\
-> &nbsp;&nbsp; | DEC_LITERAL ( . DEC_LITERAL)<sup>?</sup> (`e`|`E`) (`+`|`-`)<sup>?</sup> _end of input or not DEC_DIGIT_
+> &nbsp;&nbsp; | `0b` `_`<sup>\*</sup> \<end of input or not BIN_DIGIT\>\
+> &nbsp;&nbsp; | `0o` `_`<sup>\*</sup> \<end of input or not OCT_DIGIT\>\
+> &nbsp;&nbsp; | `0x` `_`<sup>\*</sup> \<end of input or not HEX_DIGIT\>\
+> &nbsp;&nbsp; | DEC_LITERAL ( . DEC_LITERAL)<sup>?</sup> (`e`|`E`) (`+`|`-`)<sup>?</sup> \<end of input or not DEC_DIGIT\>
 
 r[lex.token.literal.reserved.intro]
 The following lexical forms similar to number literals are _reserved forms_.

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -777,6 +777,64 @@ r[lex.token.life.raw.edition2021]
 r[lex.token.punct]
 ## Punctuation
 
+r[lex.token.punct.syntax]
+> **<sup>Lexer</sup>**\
+> Token :\
+> PUNCTUATION :\
+> &nbsp;&nbsp; &nbsp;&nbsp; `=`\
+> &nbsp;&nbsp; | `<`\
+> &nbsp;&nbsp; | `<=`\
+> &nbsp;&nbsp; | `==`\
+> &nbsp;&nbsp; | `!=`\
+> &nbsp;&nbsp; | `>=`\
+> &nbsp;&nbsp; | `>`\
+> &nbsp;&nbsp; | `&&`\
+> &nbsp;&nbsp; | `||`\
+> &nbsp;&nbsp; | `!`\
+> &nbsp;&nbsp; | `~`\
+> &nbsp;&nbsp; | `+`\
+> &nbsp;&nbsp; | `-`\
+> &nbsp;&nbsp; | `*`\
+> &nbsp;&nbsp; | `/`\
+> &nbsp;&nbsp; | `%`\
+> &nbsp;&nbsp; | `^`\
+> &nbsp;&nbsp; | `&`\
+> &nbsp;&nbsp; | `|`\
+> &nbsp;&nbsp; | `<<`\
+> &nbsp;&nbsp; | `>>`\
+> &nbsp;&nbsp; | `+=`\
+> &nbsp;&nbsp; | `-=`\
+> &nbsp;&nbsp; | `*=`\
+> &nbsp;&nbsp; | `/=`\
+> &nbsp;&nbsp; | `%=`\
+> &nbsp;&nbsp; | `^=`\
+> &nbsp;&nbsp; | `&=`\
+> &nbsp;&nbsp; | `|=`\
+> &nbsp;&nbsp; | `<<=`\
+> &nbsp;&nbsp; | `>>=`\
+> &nbsp;&nbsp; | `@`\
+> &nbsp;&nbsp; | `.`\
+> &nbsp;&nbsp; | `..`\
+> &nbsp;&nbsp; | `...`\
+> &nbsp;&nbsp; | `..=`\
+> &nbsp;&nbsp; | `,`\
+> &nbsp;&nbsp; | `;`\
+> &nbsp;&nbsp; | `:`\
+> &nbsp;&nbsp; | `::`\
+> &nbsp;&nbsp; | `->`\
+> &nbsp;&nbsp; | `<-`\
+> &nbsp;&nbsp; | `=>`\
+> &nbsp;&nbsp; | `#`\
+> &nbsp;&nbsp; | `$`\
+> &nbsp;&nbsp; | `?`\
+> &nbsp;&nbsp; | `_`\
+> &nbsp;&nbsp; | `{`\
+> &nbsp;&nbsp; | `}`\
+> &nbsp;&nbsp; | `[`\
+> &nbsp;&nbsp; | `]`\
+> &nbsp;&nbsp; | `(`\
+> &nbsp;&nbsp; | `)`
+
 r[lex.token.punct.intro]
 Punctuation symbol tokens are listed here for completeness. Their individual
 usages and meanings are defined in the linked pages.

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -133,7 +133,7 @@ r[lex.token.literal.char]
 r[lex.token.literal.char.syntax]
 > **<sup>Lexer</sup>**\
 > CHAR_LITERAL :\
-> &nbsp;&nbsp; `'` ( ~\[`'` `\` \\n \\r \\t] | QUOTE_ESCAPE | ASCII_ESCAPE | UNICODE_ESCAPE ) `'` SUFFIX<sup>?</sup>
+> &nbsp;&nbsp; `'` ( ~\[`'` `\` LF CR TAB] | QUOTE_ESCAPE | ASCII_ESCAPE | UNICODE_ESCAPE ) `'` SUFFIX<sup>?</sup>
 >
 > QUOTE_ESCAPE :\
 > &nbsp;&nbsp; `\'` | `\"`
@@ -165,7 +165,7 @@ r[lex.token.literal.str.syntax]
 > &nbsp;&nbsp; )<sup>\*</sup> `"` SUFFIX<sup>?</sup>
 >
 > STRING_CONTINUE :\
-> &nbsp;&nbsp; `\` _followed by_ \\n
+> &nbsp;&nbsp; `\` _followed by_ LF
 
 r[lex.token.literal.str.intro]
 A _string literal_ is a sequence of any Unicode characters enclosed within two
@@ -262,7 +262,7 @@ r[lex.token.byte.syntax]
 > &nbsp;&nbsp; `b'` ( ASCII_FOR_CHAR | BYTE_ESCAPE )  `'` SUFFIX<sup>?</sup>
 >
 > ASCII_FOR_CHAR :\
-> &nbsp;&nbsp; _any ASCII (i.e. 0x00 to 0x7F), except_ `'`, `\`, \\n, \\r or \\t
+> &nbsp;&nbsp; _any ASCII (i.e. 0x00 to 0x7F) except_ `'`, `\`, LF, CR, or TAB
 >
 > BYTE_ESCAPE :\
 > &nbsp;&nbsp; &nbsp;&nbsp; `\x` HEX_DIGIT HEX_DIGIT\

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -632,7 +632,7 @@ r[lex.token.literal.float.syntax]
 > **<sup>Lexer</sup>**\
 > FLOAT_LITERAL :\
 > &nbsp;&nbsp; &nbsp;&nbsp; DEC_LITERAL `.`
->   _(not immediately followed by `.`, `_` or an XID_Start character)_\
+>   _not immediately followed by `.`, `_` or an XID_Start character_\
 > &nbsp;&nbsp; | DEC_LITERAL `.` DEC_LITERAL SUFFIX_NO_E<sup>?</sup>\
 > &nbsp;&nbsp; | DEC_LITERAL (`.` DEC_LITERAL)<sup>?</sup> FLOAT_EXPONENT SUFFIX<sup>?</sup>
 >
@@ -691,7 +691,7 @@ r[lex.token.literal.reserved.syntax]
 > &nbsp;&nbsp; &nbsp;&nbsp; BIN_LITERAL \[`2`-`9`&ZeroWidthSpace;]\
 > &nbsp;&nbsp; | OCT_LITERAL \[`8`-`9`&ZeroWidthSpace;]\
 > &nbsp;&nbsp; | ( BIN_LITERAL | OCT_LITERAL | HEX_LITERAL ) `.` \
-> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; _(not immediately followed by `.`, `_` or an XID_Start character)_\
+> &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; _not immediately followed by `.`, `_` or an XID_Start character_\
 > &nbsp;&nbsp; | ( BIN_LITERAL | OCT_LITERAL ) (`e`|`E`)\
 > &nbsp;&nbsp; | `0b` `_`<sup>\*</sup> \<end of input or not BIN_DIGIT\>\
 > &nbsp;&nbsp; | `0o` `_`<sup>\*</sup> \<end of input or not OCT_DIGIT\>\
@@ -739,22 +739,22 @@ r[lex.token.life.syntax]
 > **<sup>Lexer</sup>**\
 > LIFETIME_TOKEN :\
 > &nbsp;&nbsp; &nbsp;&nbsp; `'` [IDENTIFIER_OR_KEYWORD][identifier]
->   _(not immediately followed by `'`)_\
+>   _not immediately followed by `'`_\
 > &nbsp;&nbsp; | `'_`
->   _(not immediately followed by `'`)_\
+>   _not immediately followed by `'`_\
 > &nbsp;&nbsp; | RAW_LIFETIME
 >
 > LIFETIME_OR_LABEL :\
 > &nbsp;&nbsp; &nbsp;&nbsp; `'` [NON_KEYWORD_IDENTIFIER][identifier]
->   _(not immediately followed by `'`)_\
+>   _not immediately followed by `'`_\
 > &nbsp;&nbsp; | RAW_LIFETIME
 >
 > RAW_LIFETIME :\
 > &nbsp;&nbsp; `'r#` [IDENTIFIER_OR_KEYWORD][identifier] <sub>*except `crate`, `self`, `super`, `Self`*</sub>
->   _(not immediately followed by `'`)_
+>   _not immediately followed by `'`_
 >
 > RESERVED_RAW_LIFETIME : `'r#_`
->   _(not immediately followed by `'`)_
+>   _not immediately followed by `'`_
 
 r[lex.token.life.intro]
 Lifetime parameters and [loop labels] use LIFETIME_OR_LABEL tokens. Any

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -1,6 +1,25 @@
 r[lex.token]
 # Tokens
 
+r[lex.token.syntax]
+> **<sup>Lexer</sup>**\
+> Token :\
+> &nbsp;&nbsp; &nbsp;&nbsp; IDENTIFIER_OR_KEYWORD\
+> &nbsp;&nbsp; | RAW_IDENTIFIER\
+> &nbsp;&nbsp; | CHAR_LITERAL\
+> &nbsp;&nbsp; | STRING_LITERAL\
+> &nbsp;&nbsp; | RAW_STRING_LITERAL\
+> &nbsp;&nbsp; | BYTE_LITERAL\
+> &nbsp;&nbsp; | BYTE_STRING_LITERAL\
+> &nbsp;&nbsp; | RAW_BYTE_STRING_LITERAL\
+> &nbsp;&nbsp; | C_STRING_LITERAL\
+> &nbsp;&nbsp; | RAW_C_STRING_LITERAL\
+> &nbsp;&nbsp; | INTEGER_LITERAL\
+> &nbsp;&nbsp; | FLOAT_LITERAL\
+> &nbsp;&nbsp; | LIFETIME_TOKEN\
+> &nbsp;&nbsp; | PUNCTUATION\
+> &nbsp;&nbsp; | RESERVED_TOKEN
+
 r[lex.token.intro]
 Tokens are primitive productions in the grammar defined by regular
 (non-recursive) languages.  Rust source input can be broken down

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -902,6 +902,26 @@ them are referred to as "token trees" in [macros].  The three types of brackets 
 | `[` `]` | Square brackets |
 | `(` `)` | Parentheses     |
 
+r[lex.token.reserved]
+## Reserved tokens
+
+r[lex.token.reserved.intro]
+Several token forms are reserved for future use. It is an error for the source input to match one of these forms.
+
+r[lex.token.reserved.syntax]
+
+> **<sup>Lexer</sup>**\
+> RESERVED_TOKEN :\
+> &nbsp;&nbsp; &nbsp;&nbsp; RESERVED_GUARDED_STRING_LITERAL\
+> &nbsp;&nbsp; | RESERVED_NUMBER\
+> &nbsp;&nbsp; | RESERVED_POUNDS\
+> &nbsp;&nbsp; | RESERVED_RAW_IDENTIFIER\
+> &nbsp;&nbsp; | RESERVED_RAW_LIFETIME\
+> &nbsp;&nbsp; | RESERVED_TOKEN_DOUBLE_QUOTE\
+> &nbsp;&nbsp; | RESERVED_TOKEN_LIFETIME\
+> &nbsp;&nbsp; | RESERVED_TOKEN_POUND\
+> &nbsp;&nbsp; | RESERVED_TOKEN_SINGLE_QUOTE
+
 r[lex.token.reserved-prefix]
 ## Reserved prefixes
 

--- a/src/trait-bounds.md
+++ b/src/trait-bounds.md
@@ -2,41 +2,33 @@ r[bound]
 # Trait and lifetime bounds
 
 r[bound.syntax]
-> **<sup>Syntax</sup>**\
-> _TypeParamBounds_ :\
-> &nbsp;&nbsp; _TypeParamBound_ ( `+` _TypeParamBound_ )<sup>\*</sup> `+`<sup>?</sup>
->
-> _TypeParamBound_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; _Lifetime_ | _TraitBound_ | _UseBound_
->
-> _TraitBound_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; ( `?` |
-> [_ForLifetimes_](#higher-ranked-trait-bounds) )<sup>?</sup> [_TypePath_]\
-> &nbsp;&nbsp; | `(` ( `?` |
-> [_ForLifetimes_](#higher-ranked-trait-bounds) )<sup>?</sup> [_TypePath_] `)`
->
-> _LifetimeBounds_ :\
-> &nbsp;&nbsp; ( _Lifetime_ `+` )<sup>\*</sup> _Lifetime_<sup>?</sup>
->
-> _Lifetime_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [LIFETIME_OR_LABEL]\
-> &nbsp;&nbsp; | `'static`\
-> &nbsp;&nbsp; | `'_`
->
-> _UseBound_ :\
-> &nbsp;&nbsp; `use` _UseBoundGenericArgs_
->
-> _UseBoundGenericArgs_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `<` `>` \
-> &nbsp;&nbsp; | `<` \
-> &nbsp;&nbsp; &nbsp;&nbsp; ( _UseBoundGenericArg_ `,`)<sup>\*</sup> \
-> &nbsp;&nbsp; &nbsp;&nbsp; _UseBoundGenericArg_ `,`<sup>?</sup> \
-> &nbsp;&nbsp; &nbsp;&nbsp; `>`
->
-> _UseBoundGenericArg_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; _Lifetime_ \
-> &nbsp;&nbsp; | [IDENTIFIER][] \
-> &nbsp;&nbsp; | `Self`
+```grammar,miscellaneous
+TypeParamBounds -> TypeParamBound ( `+` TypeParamBound )* `+`?
+
+TypeParamBound -> Lifetime | TraitBound | UseBound
+
+TraitBound ->
+      ( `?` | ForLifetimes )? TypePath
+    | `(` ( `?` | ForLifetimes )? TypePath `)`
+
+LifetimeBounds -> ( Lifetime `+` )* Lifetime?
+
+Lifetime ->
+      LIFETIME_OR_LABEL
+    | `'static`
+    | `'_`
+
+UseBound -> `use` UseBoundGenericArgs
+
+UseBoundGenericArgs ->
+      `<` `>`
+    | `<` ( UseBoundGenericArg `,`)* UseBoundGenericArg `,`? `>`
+
+UseBoundGenericArg ->
+      Lifetime
+    | IDENTIFIER
+    | `Self`
+```
 
 r[bound.intro]
 [Trait] and lifetime bounds provide a way for [generic items][generic] to
@@ -148,9 +140,9 @@ r[bound.higher-ranked]
 ## Higher-ranked trait bounds
 
 r[bound.higher-ranked.syntax]
-> **<sup>Syntax</sup>**\
-> _ForLifetimes_ :\
-> &nbsp;&nbsp; `for` [_GenericParams_]
+```grammar,miscellaneous
+ForLifetimes -> `for` GenericParams
+```
 
 r[bound.higher-ranked.intro]
 Trait bounds may be *higher ranked* over lifetimes. These bounds specify a bound
@@ -271,14 +263,6 @@ r[bound.use]
 ## Use bounds
 
 Certain bounds lists may include a `use<..>` bound to control which generic parameters are captured by the `impl Trait` [abstract return type].  See [precise capturing] for more details.
-
-[IDENTIFIER]: identifiers.html
-[LIFETIME_OR_LABEL]: tokens.md#lifetimes-and-loop-labels
-[_GenericParams_]: items/generics.md
-[_TypePath_]: paths.md#paths-in-types
-[`Clone`]: special-types-and-traits.md#clone
-[`Copy`]: special-types-and-traits.md#copy
-[`Sized`]: special-types-and-traits.md#sized
 
 [abstract return type]: types/impl-trait.md#abstract-return-types
 [arrays]: types/array.md

--- a/src/trait-bounds.md
+++ b/src/trait-bounds.md
@@ -148,6 +148,7 @@ r[bound.higher-ranked]
 ## Higher-ranked trait bounds
 
 r[bound.higher-ranked.syntax]
+> **<sup>Syntax</sup>**\
 > _ForLifetimes_ :\
 > &nbsp;&nbsp; `for` [_GenericParams_]
 

--- a/src/types.md
+++ b/src/types.md
@@ -103,6 +103,7 @@ r[type.name.parenthesized]
 ### Parenthesized types
 
 r[type.name.parenthesized.syntax]
+> **<sup>Syntax</sup>**\
 > _ParenthesizedType_ :\
 > &nbsp;&nbsp; `(` [_Type_] `)`
 

--- a/src/types.md
+++ b/src/types.md
@@ -45,27 +45,28 @@ r[type.name]
 ## Type expressions
 
 r[type.name.syntax]
-> **<sup>Syntax</sup>**\
-> _Type_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; _TypeNoBounds_\
-> &nbsp;&nbsp; | [_ImplTraitType_]\
-> &nbsp;&nbsp; | [_TraitObjectType_]
->
-> _TypeNoBounds_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; [_ParenthesizedType_]\
-> &nbsp;&nbsp; | [_ImplTraitTypeOneBound_]\
-> &nbsp;&nbsp; | [_TraitObjectTypeOneBound_]\
-> &nbsp;&nbsp; | [_TypePath_]\
-> &nbsp;&nbsp; | [_TupleType_]\
-> &nbsp;&nbsp; | [_NeverType_]\
-> &nbsp;&nbsp; | [_RawPointerType_]\
-> &nbsp;&nbsp; | [_ReferenceType_]\
-> &nbsp;&nbsp; | [_ArrayType_]\
-> &nbsp;&nbsp; | [_SliceType_]\
-> &nbsp;&nbsp; | [_InferredType_]\
-> &nbsp;&nbsp; | [_QualifiedPathInType_]\
-> &nbsp;&nbsp; | [_BareFunctionType_]\
-> &nbsp;&nbsp; | [_MacroInvocation_]
+```grammar,types
+Type ->
+      TypeNoBounds
+    | ImplTraitType
+    | TraitObjectType
+
+TypeNoBounds ->
+      ParenthesizedType
+    | ImplTraitTypeOneBound
+    | TraitObjectTypeOneBound
+    | TypePath
+    | TupleType
+    | NeverType
+    | RawPointerType
+    | ReferenceType
+    | ArrayType
+    | SliceType
+    | InferredType
+    | QualifiedPathInType
+    | BareFunctionType
+    | MacroInvocation
+```
 
 r[type.name.intro]
 A _type expression_ as defined in the _Type_ grammar rule above is the syntax
@@ -103,17 +104,17 @@ r[type.name.parenthesized]
 ### Parenthesized types
 
 r[type.name.parenthesized.syntax]
-> **<sup>Syntax</sup>**\
-> _ParenthesizedType_ :\
-> &nbsp;&nbsp; `(` [_Type_] `)`
+```grammar,types
+ParenthesizedType -> `(` Type `)`
+```
 
 r[type.name.parenthesized.intro]
 In some situations the combination of types may be ambiguous. Use parentheses
 around a type to avoid ambiguity. For example, the `+` operator for [type
 boundaries] within a [reference type] is unclear where the
 boundary applies, so the use of parentheses is required. Grammar rules that
-require this disambiguation use the [_TypeNoBounds_] rule instead of
-[_Type_].
+require this disambiguation use the [TypeNoBounds] rule instead of
+[Type][grammar-Type].
 
 ```rust
 # use std::any::Any;
@@ -148,25 +149,6 @@ enum List<T> {
 
 let a: List<i32> = List::Cons(7, Box::new(List::Cons(13, Box::new(List::Nil))));
 ```
-
-[_ArrayType_]: types/array.md
-[_BareFunctionType_]: types/function-pointer.md
-[_ImplTraitTypeOneBound_]: types/impl-trait.md
-[_ImplTraitType_]: types/impl-trait.md
-[_InferredType_]: types/inferred.md
-[_MacroInvocation_]: macros.md#macro-invocation
-[_NeverType_]: types/never.md
-[_ParenthesizedType_]: types.md#parenthesized-types
-[_QualifiedPathInType_]: paths.md#qualified-paths
-[_RawPointerType_]: types/pointer.md#raw-pointers-const-and-mut
-[_ReferenceType_]: types/pointer.md#shared-references-
-[_SliceType_]: types/slice.md
-[_TraitObjectTypeOneBound_]: types/trait-object.md
-[_TraitObjectType_]: types/trait-object.md
-[_TupleType_]: types/tuple.md#tuple-types
-[_TypeNoBounds_]: types.md#type-expressions
-[_TypePath_]: paths.md#paths-in-types
-[_Type_]: types.md#type-expressions
 
 [Array]: types/array.md
 [Boolean]: types/boolean.md

--- a/src/types/array.md
+++ b/src/types/array.md
@@ -2,9 +2,9 @@ r[type.array]
 # Array types
 
 r[type.array.syntax]
-> **<sup>Syntax</sup>**\
-> _ArrayType_ :\
-> &nbsp;&nbsp; `[` [_Type_] `;` [_Expression_] `]`
+```grammar,types
+ArrayType -> `[` Type `;` Expression `]`
+```
 
 r[type.array.intro]
 An array is a fixed-size sequence of `N` elements of type `T`. The array type
@@ -30,7 +30,5 @@ always bounds-checked in safe methods and operators.
 > [!NOTE]
 > The [`Vec<T>`] standard library type provides a heap-allocated resizable array type.
 
-[_Expression_]: ../expressions.md
-[_Type_]: ../types.md#type-expressions
 [`usize`]: numeric.md#machine-dependent-integer-types
 [constant expression]: ../const_eval.md#constant-expressions

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -203,7 +203,7 @@ c();
 ```
 
 This also includes destructuring of tuples, structs, and enums.
-Fields matched with the [_RestPattern_] or [_StructPatternEtCetera_] are also not considered as read, and thus those fields will not be captured.
+Fields matched with the [RestPattern] or [StructPatternEtCetera] are also not considered as read, and thus those fields will not be captured.
 The following illustrates some of these:
 
 ```rust
@@ -262,8 +262,6 @@ let c = || {
 };
 ```
 
-[_RestPattern_]: ../patterns.md#rest-patterns
-[_StructPatternEtCetera_]: ../patterns.md#struct-patterns
 [wildcard pattern]: ../patterns.md#wildcard-pattern
 
 r[type.closure.capture.precision.move-dereference]

--- a/src/types/function-pointer.md
+++ b/src/types/function-pointer.md
@@ -2,28 +2,27 @@ r[type.fn-pointer]
 # Function pointer types
 
 r[type.fn-pointer.syntax]
-> **<sup>Syntax</sup>**\
-> _BareFunctionType_ :\
-> &nbsp;&nbsp; [_ForLifetimes_]<sup>?</sup> _FunctionTypeQualifiers_ `fn`\
-> &nbsp;&nbsp; &nbsp;&nbsp;  `(` _FunctionParametersMaybeNamedVariadic_<sup>?</sup> `)` _BareFunctionReturnType_<sup>?</sup>
->
-> _FunctionTypeQualifiers_:\
-> &nbsp;&nbsp; `unsafe`<sup>?</sup> (`extern` [_Abi_]<sup>?</sup>)<sup>?</sup>
->
-> _BareFunctionReturnType_:\
-> &nbsp;&nbsp; `->` [_TypeNoBounds_]
->
-> _FunctionParametersMaybeNamedVariadic_ :\
-> &nbsp;&nbsp; _MaybeNamedFunctionParameters_ | _MaybeNamedFunctionParametersVariadic_
->
-> _MaybeNamedFunctionParameters_ :\
-> &nbsp;&nbsp; _MaybeNamedParam_ ( `,` _MaybeNamedParam_ )<sup>\*</sup> `,`<sup>?</sup>
->
-> _MaybeNamedParam_ :\
-> &nbsp;&nbsp; [_OuterAttribute_]<sup>\*</sup> ( ( [IDENTIFIER] | `_` ) `:` )<sup>?</sup> [_Type_]
->
-> _MaybeNamedFunctionParametersVariadic_ :\
-> &nbsp;&nbsp; ( _MaybeNamedParam_ `,` )<sup>\*</sup> _MaybeNamedParam_ `,` [_OuterAttribute_]<sup>\*</sup> `...`
+```grammar,types
+BareFunctionType ->
+    ForLifetimes? FunctionTypeQualifiers `fn`
+       `(` FunctionParametersMaybeNamedVariadic? `)` BareFunctionReturnType?
+
+FunctionTypeQualifiers -> `unsafe`? (`extern` Abi?)?
+
+BareFunctionReturnType -> `->` TypeNoBounds
+
+FunctionParametersMaybeNamedVariadic ->
+    MaybeNamedFunctionParameters | MaybeNamedFunctionParametersVariadic
+
+MaybeNamedFunctionParameters ->
+    MaybeNamedParam ( `,` MaybeNamedParam )* `,`?
+
+MaybeNamedParam ->
+    OuterAttribute* ( ( IDENTIFIER | `_` ) `:` )? Type
+
+MaybeNamedFunctionParametersVariadic ->
+    ( MaybeNamedParam `,` )* MaybeNamedParam `,` OuterAttribute* `...`
+```
 
 r[type.fn-pointer.intro]
 Function pointer types, written using the `fn` keyword, refer to a function
@@ -62,12 +61,6 @@ r[type.fn-pointer.attributes]
 Attributes on function pointer parameters follow the same rules and
 restrictions as [regular function parameters].
 
-[IDENTIFIER]: ../identifiers.md
-[_Abi_]: ../items/functions.md
-[_ForLifetimes_]: ../trait-bounds.md#higher-ranked-trait-bounds
-[_TypeNoBounds_]: ../types.md#type-expressions
-[_Type_]: ../types.md#type-expressions
-[_OuterAttribute_]: ../attributes.md
 [`extern`]: ../items/external-blocks.md
 [closures]: closure.md
 [extern function]: ../items/functions.md#extern-function-qualifier

--- a/src/types/impl-trait.md
+++ b/src/types/impl-trait.md
@@ -2,10 +2,11 @@ r[type.impl-trait]
 # Impl trait
 
 r[type.impl-trait.syntax]
-> **<sup>Syntax</sup>**\
-> _ImplTraitType_ : `impl` [_TypeParamBounds_]
->
-> _ImplTraitTypeOneBound_ : `impl` [_TraitBound_]
+```grammar,types
+ImplTraitType -> `impl` TypeParamBounds
+
+ImplTraitTypeOneBound -> `impl` TraitBound
+```
 
 r[type.impl-trait.intro]
 `impl Trait` provides ways to specify unnamed but concrete types that
@@ -49,10 +50,10 @@ fn with_impl_trait(arg: impl Trait) {
 ```
 
 r[type.impl-trait.param.generic]
-That is, `impl Trait` in argument position is syntactic sugar for a generic type parameter like `<T: Trait>`, except that the type is anonymous and doesn't appear in the [_GenericParams_] list.
+That is, `impl Trait` in argument position is syntactic sugar for a generic type parameter like `<T: Trait>`, except that the type is anonymous and doesn't appear in the [GenericParams] list.
 
 > [!NOTE]
-> For function parameters, generic type parameters and `impl Trait` are not exactly equivalent. With a generic parameter such as `<T: Trait>`, the caller has the option to explicitly specify the generic argument for `T` at the call site using [_GenericArgs_], for example, `foo::<usize>(1)`. Changing a parameter from either one to the other can constitute a breaking change for the callers of a function, since this changes the number of generic arguments.
+> For function parameters, generic type parameters and `impl Trait` are not exactly equivalent. With a generic parameter such as `<T: Trait>`, the caller has the option to explicitly specify the generic argument for `T` at the call site using [GenericArgs], for example, `foo::<usize>(1)`. Changing a parameter from either one to the other can constitute a breaking change for the callers of a function, since this changes the number of generic arguments.
 
 r[type.impl-trait.return]
 ## Abstract return types
@@ -181,10 +182,6 @@ r[type.impl-trait.constraint]
 `impl Trait` can only appear as a parameter or return type of a non-`extern` function.
 It cannot be the type of a `let` binding, field type, or appear inside a type alias.
 
-[_GenericArgs_]: ../paths.md#paths-in-expressions
-[_GenericParams_]: ../items/generics.md
-[_TraitBound_]: ../trait-bounds.md
-[_TypeParamBounds_]: ../trait-bounds.md
 [`use<..>` bound]: ../trait-bounds.md#use-bounds
 [closures]: closure.md
 [trait object]: trait-object.md

--- a/src/types/inferred.md
+++ b/src/types/inferred.md
@@ -2,8 +2,9 @@ r[type.inferred]
 # Inferred type
 
 r[type.inferred.syntax]
-> **<sup>Syntax</sup>**\
-> _InferredType_ : `_`
+```grammar,types
+InferredType -> `_`
+```
 
 r[type.inferred.intro]
 The inferred type asks the compiler to infer the type if possible based on the

--- a/src/types/never.md
+++ b/src/types/never.md
@@ -2,8 +2,9 @@ r[type.never]
 # Never type
 
 r[type.never.syntax]
-> **<sup>Syntax</sup>**\
-> _NeverType_ : `!`
+```grammar,types
+NeverType -> `!`
+```
 
 r[type.never.intro]
 The never type `!` is a type with no values, representing the result of

--- a/src/types/pointer.md
+++ b/src/types/pointer.md
@@ -9,9 +9,9 @@ r[type.pointer.reference]
 ## References (`&` and `&mut`)
 
 r[type.pointer.reference.syntax]
-> **<sup>Syntax</sup>**\
-> _ReferenceType_ :\
-> &nbsp;&nbsp; `&` [_Lifetime_]<sup>?</sup> `mut`<sup>?</sup> [_TypeNoBounds_]
+```grammar,types
+ReferenceType -> `&` Lifetime? `mut`? TypeNoBounds
+```
 
 r[type.pointer.reference.shared]
 ### Shared references (`&`)
@@ -44,9 +44,9 @@ r[type.pointer.raw]
 ## Raw pointers (`*const` and `*mut`)
 
 r[type.pointer.raw.syntax]
-> **<sup>Syntax</sup>**\
-> _RawPointerType_ :\
-> &nbsp;&nbsp; `*` ( `mut` | `const` ) [_TypeNoBounds_]
+```grammar,types
+RawPointerType -> `*` ( `mut` | `const` ) TypeNoBounds
+```
 
 r[type.pointer.raw.intro]
 Raw pointers are pointers without safety or liveness guarantees.
@@ -89,8 +89,6 @@ the inverse direction (transmuting from an integer or array of integers to `P`) 
 However, the pointer produced via such a transmutation may not be dereferenced (not even if `T` has size zero).
 
 [Interior mutability]: ../interior-mutability.md
-[_Lifetime_]: ../trait-bounds.md
-[_TypeNoBounds_]: ../types.md#type-expressions
 [`unsafe` operation]: ../unsafety.md
 [dynamically sized types]: ../dynamically-sized-types.md
 [temporary value]: ../expressions.md#temporaries

--- a/src/types/slice.md
+++ b/src/types/slice.md
@@ -2,9 +2,9 @@ r[type.slice]
 # Slice types
 
 r[type.slice.syntax]
-> **<sup>Syntax</sup>**\
-> _SliceType_ :\
-> &nbsp;&nbsp; `[` [_Type_] `]`
+```grammar,types
+SliceType -> `[` Type `]`
+```
 
 r[type.slice.intro]
 A slice is a [dynamically sized type] representing a 'view' into a sequence of
@@ -32,5 +32,4 @@ r[type.slice.safe]
 All elements of slices are always initialized, and access to a slice is always
 bounds-checked in safe methods and operators.
 
-[_Type_]: ../types.md#type-expressions
 [dynamically sized type]: ../dynamically-sized-types.md

--- a/src/types/trait-object.md
+++ b/src/types/trait-object.md
@@ -2,12 +2,11 @@ r[type.trait-object]
 # Trait objects
 
 r[type.trait-object.syntax]
-> **<sup>Syntax</sup>**\
-> _TraitObjectType_ :\
-> &nbsp;&nbsp; `dyn`<sup>?</sup> [_TypeParamBounds_]
->
-> _TraitObjectTypeOneBound_ :\
-> &nbsp;&nbsp; `dyn`<sup>?</sup> [_TraitBound_]
+```grammar,types
+TraitObjectType -> `dyn`? TypeParamBounds
+
+TraitObjectTypeOneBound -> `dyn`? TraitBound
+```
 
 r[type.trait-object.intro]
 A *trait object* is an opaque value of another type that implements a set of
@@ -103,8 +102,6 @@ need to be expressed as part of the trait object. This lifetime is written as
 `Trait + 'a`. There are [defaults] that allow this lifetime to usually be
 inferred with a sensible choice.
 
-[_TraitBound_]: ../trait-bounds.md
-[_TypeParamBounds_]: ../trait-bounds.md
 [auto traits]: ../special-types-and-traits.md#auto-traits
 [defaults]: ../lifetime-elision.md#default-trait-object-lifetimes
 [dyn compatible]: ../items/traits.md#dyn-compatibility

--- a/src/types/tuple.md
+++ b/src/types/tuple.md
@@ -2,10 +2,11 @@ r[type.tuple]
 # Tuple types
 
 r[type.tuple.syntax]
-> **<sup>Syntax</sup>**\
-> _TupleType_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `(` `)`\
-> &nbsp;&nbsp; | `(` ( [_Type_] `,` )<sup>+</sup> [_Type_]<sup>?</sup> `)`
+```grammar,types
+TupleType ->
+      `(` `)`
+    | `(` ( Type `,` )+ Type? `)`
+```
 
 r[type.tuple.intro]
 *Tuple types* are a family of structural types[^1] for heterogeneous lists of other types.
@@ -51,7 +52,6 @@ Tuple fields can be accessed by either a [tuple index expression] or [pattern ma
 [^1]: Structural types are always equivalent if their internal types are equivalent.
       For a nominal version of tuples, see [tuple structs].
 
-[_Type_]: ../types.md#type-expressions
 [parenthesized type]: ../types.md#parenthesized-types
 [pattern matching]: ../patterns.md#tuple-patterns
 [tuple expression]: ../expressions/tuple-expr.md#tuple-expressions

--- a/src/visibility-and-privacy.md
+++ b/src/visibility-and-privacy.md
@@ -2,13 +2,14 @@ r[vis]
 # Visibility and Privacy
 
 r[vis.syntax]
-> **<sup>Syntax</sup>**\
-> _Visibility_ :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `pub`\
-> &nbsp;&nbsp; | `pub` `(` `crate` `)`\
-> &nbsp;&nbsp; | `pub` `(` `self` `)`\
-> &nbsp;&nbsp; | `pub` `(` `super` `)`\
-> &nbsp;&nbsp; | `pub` `(` `in` [_SimplePath_] `)`
+```grammar,items
+Visibility ->
+      `pub`
+    | `pub` `(` `crate` `)`
+    | `pub` `(` `self` `)`
+    | `pub` `(` `super` `)`
+    | `pub` `(` `in` SimplePath `)`
+```
 
 r[vis.intro]
 These two terms are often used interchangeably, and what they are attempting to
@@ -262,5 +263,3 @@ r[vis.reexports.private-item]
 When re-exporting a private item, it can be thought of as allowing the "privacy
 chain" being short-circuited through the reexport instead of passing through
 the namespace hierarchy as it normally would.
-
-[_SimplePath_]: paths.md#simple-paths

--- a/theme/reference.css
+++ b/theme/reference.css
@@ -551,3 +551,157 @@ main > .rule {
     z-index: 1000;
     padding: 1rem;
 }
+
+/* The box that contains the grammar. */
+.grammar-container {
+    font-family: var(--mono-font);
+    /* Enable absolute positioning for the target chevron. */
+    position: relative;
+    background-color: var(--quote-bg);
+    border-block-start: .1em solid var(--quote-border);
+    border-block-end: .1em solid var(--quote-border);
+    margin-top: 4px;
+    margin-bottom: 4px;
+    padding: 0 20px;
+}
+
+/* English words inside the grammar. */
+.grammar-text {
+    font-family: "Open Sans", sans-serif;
+}
+
+/* Places a box around literals to differentiate from other grammar punctuation like | and ( . */
+.grammar-literal {
+    font-family: var(--mono-font);
+    border-radius: 4px;
+    border: solid 1px var(--theme-popup-border);
+    font-weight: bold;
+    font-size: var(--code-font-size);
+    padding: 1px 4px;
+    color: var(--inline-code-color);
+}
+
+.light .grammar-literal {
+    background-color: #fafafa
+}
+.rust .grammar-literal {
+    background-color: #dedede
+}
+.coal .grammar-literal {
+    background-color: #1d1f21;
+}
+.navy .grammar-literal {
+    background-color: #1d1f21;
+}
+.ayu .grammar-literal {
+    background-color: #191f26
+}
+
+.grammar-production:target, .railroad-production:target {
+    scroll-margin-top: 50vh;
+}
+
+.railroad-production {
+    /* Enables absolute positioning of the target chevron. */
+    position: relative;
+}
+
+/* Adds an indicator to the targeted production name. */
+.grammar-production:target::before, .railroad-production:target::before {
+    content: "»";
+    position: absolute;
+    left: 3px;
+    font-size: 2rem;
+    font-weight: bolder;
+    /* For some reason, the vertical alignment is slightly off center. This helps
+       with that alignment. It was too difficult to try to fix that via
+       absolute positioning. */
+    line-height: 1;
+}
+
+/* Overrides the positioning of the chevron from the rule above. */
+.railroad-production:target::before {
+    left: -20px;
+    top: 8px;
+}
+
+/* The toggle button. */
+.grammar-toggle {
+    width: 120px;
+    padding: 5px 0px;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+/* This is used to toggle the hidden status of the railroad diagrams. */
+.grammar-hidden {
+    display: none;
+}
+
+:root {
+    --railroad-background-color: hsl(30, 20%, 95%);
+    --railroad-background-image: linear-gradient(to right, rgba(30, 30, 30, .05) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(30, 30, 30, .05) 1px, transparent 1px);
+    --railroad-path-stroke: black;
+    --railroad-rect-stroke: black;
+    --railroad-rect-fill: hsl(-290, 70%, 90%);
+}
+
+.coal, .navy, .ayu {
+    --railroad-background-color: hsl(230, 10%, 20%);
+    --railroad-background-image: linear-gradient(to right, rgba(150, 150, 150, .05) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(150, 150, 150, .05) 1px, transparent 1px);
+    --railroad-path-stroke: hsl(200, 10%, 60%);
+    --railroad-text-fill: hsl(230, 30%, 80%);
+    --railroad-rect-stroke: hsl(200, 10%, 50%);
+    --railroad-rect-fill: hsl(230, 20%, 20%);
+}
+
+svg.railroad {
+    background-color: var(--railroad-background-color);
+    background-size: 15px 15px;
+    background-image: var(--railroad-background-image);
+}
+
+svg.railroad rect.railroad_canvas {
+    stroke-width: 0px;
+    fill: none;
+}
+
+svg.railroad path {
+    stroke-width: 3px;
+    stroke: var(--railroad-path-stroke);
+    fill: none;
+}
+
+svg.railroad .debug {
+    stroke-width: 1px;
+    stroke: red;
+}
+
+svg.railroad text {
+    font: 14px monospace;
+    text-anchor: middle;
+    fill: var(--railroad-text-fill);
+}
+
+svg.railroad .nonterminal text {
+    font-weight: bold;
+}
+
+svg.railroad text.comment {
+    font: italic 12px monospace;
+}
+
+svg.railroad rect {
+    stroke-width: 3px;
+    stroke: var(--railroad-rect-stroke);
+    fill: var(--railroad-rect-fill);
+}
+
+svg.railroad g.labeledbox>rect {
+    stroke-width: 1px;
+    stroke: grey;
+    stroke-dasharray: 5px;
+    fill: rgba(90, 90, 150, .1);
+}

--- a/theme/reference.css
+++ b/theme/reference.css
@@ -705,3 +705,7 @@ svg.railroad g.labeledbox>rect {
     stroke-dasharray: 5px;
     fill: rgba(90, 90, 150, .1);
 }
+
+svg.railroad g.exceptbox > rect {
+    fill:rgba(245, 160, 125, .1);
+}

--- a/theme/reference.css
+++ b/theme/reference.css
@@ -626,7 +626,7 @@ main > .rule {
 }
 
 /* The toggle button. */
-.grammar-toggle {
+.grammar-toggle-railroad {
     width: 120px;
     padding: 5px 0px;
     border-radius: 5px;

--- a/theme/reference.js
+++ b/theme/reference.js
@@ -22,3 +22,52 @@ function spec_toggle_tests(rule_id) {
         el.classList.remove('popup-hidden');
     }
 }
+
+function toggle_grammar() {
+    const grammarRailroad = get_railroad();
+    set_railroad(!grammarRailroad);
+    update_railroad();
+}
+
+function get_railroad() {
+    let grammarRailroad = null;
+    try {
+        grammarRailroad = localStorage.getItem('grammar-railroad');
+    } catch (e) {
+        // Ignore error.
+    }
+    grammarRailroad = grammarRailroad === 'true' ? true : false;
+    return grammarRailroad;
+}
+
+function set_railroad(newValue) {
+    try {
+        localStorage.setItem('grammar-railroad', newValue);
+    } catch (e) {
+        // Ignore error.
+    }
+}
+
+function update_railroad() {
+    const grammarRailroad = get_railroad();
+    const railroads = document.querySelectorAll('.grammar-railroad');
+    railroads.forEach(element => {
+        if (grammarRailroad) {
+            element.classList.remove('grammar-hidden');
+        } else {
+            element.classList.add('grammar-hidden');
+        }
+    });
+    const buttons = document.querySelectorAll('.grammar-toggle');
+    buttons.forEach(button => {
+        if (grammarRailroad) {
+            button.innerText = "Hide Railroad";
+        } else {
+            button.innerText = "Show Railroad";
+        }
+    });
+}
+
+(function railroad_onload() {
+    update_railroad();
+})();

--- a/theme/reference.js
+++ b/theme/reference.js
@@ -23,9 +23,14 @@ function spec_toggle_tests(rule_id) {
     }
 }
 
-function toggle_grammar() {
+function toggle_railroad() {
     const grammarRailroad = get_railroad();
     set_railroad(!grammarRailroad);
+    update_railroad();
+}
+
+function show_railroad() {
+    set_railroad(true);
     update_railroad();
 }
 
@@ -58,7 +63,7 @@ function update_railroad() {
             element.classList.add('grammar-hidden');
         }
     });
-    const buttons = document.querySelectorAll('.grammar-toggle');
+    const buttons = document.querySelectorAll('.grammar-toggle-railroad');
     buttons.forEach(button => {
         if (grammarRailroad) {
             button.innerText = "Hide Railroad";


### PR DESCRIPTION
This introduces a new grammar renderer. Instead of trying to write the grammar in markdown/html hybrid, this introduces a new syntax that is parsed by the mdbook-spec plugin. This grammar is then converted into markdown/html hybrid, and also to railroad diagrams.

There are a lot of changes here (and some can be split into separate PRs if desired). A general overview of what to see here:

- Grammar rules are now written inside a code block (instead of a blockquote). The syntax is pretty similar to the old syntax with various small changes. See the `docs/grammar.md` file for a complete description.
- There is now a summary chapter which shows the entire grammar all on one page.
- The grammar is parsed by `mdbook-spec/src/grammar/parser.rs` into an internal representation.
- The internal representation is converted to markdown in `mdbook-spec/src/grammar/render_markdown.rs`, and railroad diagrams in `mdbook-spec/src/grammar/render_railroad.rs`.
    - The railroad diagrams are generated using the [railroad crate](https://crates.io/crates/railroad).
    - There is a toggle button the show/hide the railroad diagrams. It uses localstorage to keep that state sticky.
- The basic definitions and driver in the mdbook plugin is in `mdbook-spec/src/grammar.rs`. There are several pieces here:
    - The internal representation.
    - Code to load the grammar from the code blocks inside the chapters.
    - Some validation.
    - Code that will replace the code block with the rendered output.
    - Code for handling the summary chapter.
- All nonterminals are now linked to the rule definition.
- The text may now link to grammar rules by just putting them in brackets like `[FunctionParameters]`. Link definitions are automatically added to every page.
- Some rules were added or changed to accommodate the new renderer. I think all changes are put into separate commits to help with reviewing.
- Various misc fixes, see the individual commits.

I'd like to thank @lukaslueg for creating the railroad library which made this possible.

Closes https://github.com/rust-lang/reference/issues/221
Closes https://github.com/rust-lang/reference/issues/398
Closes https://github.com/rust-lang/reference/issues/596
Closes https://github.com/rust-lang/reference/issues/1513
Closes https://github.com/rust-lang/reference/issues/1677
