### PR TITLE
Enable `[canonicalize-issue-links]` and `[no-mentions]` in triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -7,6 +7,11 @@ allow-unauthenticated = [
 
 [shortcut]
 
+[no-mentions]
+
+[issue-links]
+check-commits = false
+
 [merge-conflicts]
 remove = []
 add = ["S-waiting-on-author"]


### PR DESCRIPTION
This PR enables two new triagebot feature `[canonicalize-issue-links]` and `[no-mentions]`.

Documentation at https://forge.rust-lang.org/triagebot/canonicalize-issue-links.html and https://forge.rust-lang.org/triagebot/no-mentions.html.