### PR TITLE
attributes/codegen: update aarch64 features

### DIFF
--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -227,51 +227,51 @@ Reference Manual], or elsewhere on [developer.arm.com].
 > - `paca` and `pacg`, which LLVM currently implements as one feature.
 
 Feature        | Implicitly Enables | Feature Name
----------------|--------------------|-------------------
-`aes`          | `neon`         | FEAT_AES & FEAT_PMULL --- Advanced <abbr title="Single Instruction Multiple Data">SIMD</abbr> AES & PMULL instructions
-`bf16`         |                | FEAT_BF16 --- BFloat16 instructions
-`bti`          |                | FEAT_BTI --- Branch Target Identification
-`crc`          |                | FEAT_CRC --- CRC32 checksum instructions
-`dit`          |                | FEAT_DIT --- Data Independent Timing instructions
-`dotprod`      |                | FEAT_DotProd --- Advanced SIMD Int8 dot product instructions
-`dpb`          |                | FEAT_DPB --- Data cache clean to point of persistence
-`dpb2`         |                | FEAT_DPB2 --- Data cache clean to point of deep persistence
-`f32mm`        | `sve`          | FEAT_F32MM --- SVE single-precision FP matrix multiply instruction
-`f64mm`        | `sve`          | FEAT_F64MM --- SVE double-precision FP matrix multiply instruction
-`fcma`         | `neon`         | FEAT_FCMA --- Floating point complex number support
-`fhm`          | `fp16`         | FEAT_FHM --- Half-precision FP FMLAL instructions
-`flagm`        |                | FEAT_FlagM --- Conditional flag manipulation
-`fp16`         | `neon`         | FEAT_FP16 --- Half-precision FP data processing
-`frintts`      |                | FEAT_FRINTTS --- Floating-point to int helper instructions
-`i8mm`         |                | FEAT_I8MM --- Int8 Matrix Multiplication
-`jsconv`       | `neon`         | FEAT_JSCVT --- JavaScript conversion instruction
-`lse`          |                | FEAT_LSE --- Large System Extension
-`lor`          |                | FEAT_LOR --- Limited Ordering Regions extension
-`mte`          |                | FEAT_MTE & FEAT_MTE2 --- Memory Tagging Extension
-`neon`         |                | FEAT_FP & FEAT_AdvSIMD --- Floating Point and Advanced SIMD extension
-`pan`          |                | FEAT_PAN --- Privileged Access-Never extension
-`paca`         |                | FEAT_PAuth --- Pointer Authentication (address authentication)
-`pacg`         |                | FEAT_PAuth --- Pointer Authentication (generic authentication)
-`pmuv3`        |                | FEAT_PMUv3 --- Performance Monitors extension (v3)
-`rand`         |                | FEAT_RNG --- Random Number Generator
-`ras`          |                | FEAT_RAS & FEAT_RASv1p1 --- Reliability, Availability and Serviceability extension
-`rcpc`         |                | FEAT_LRCPC --- Release consistent Processor Consistent
-`rcpc2`        | `rcpc`         | FEAT_LRCPC2 --- RcPc with immediate offsets
-`rdm`          |                | FEAT_RDM --- Rounding Double Multiply accumulate
-`sb`           |                | FEAT_SB --- Speculation Barrier
-`sha2`         | `neon`         | FEAT_SHA1 & FEAT_SHA256 --- Advanced SIMD SHA instructions
-`sha3`         | `sha2`         | FEAT_SHA512 & FEAT_SHA3 --- Advanced SIMD SHA instructions
-`sm4`          | `neon`         | FEAT_SM3 & FEAT_SM4 --- Advanced SIMD SM3/4 instructions
-`spe`          |                | FEAT_SPE --- Statistical Profiling Extension
-`ssbs`         |                | FEAT_SSBS & FEAT_SSBS2 --- Speculative Store Bypass Safe
-`sve`          | `fp16`         | FEAT_SVE --- Scalable Vector Extension
-`sve2`         | `sve`          | FEAT_SVE2 --- Scalable Vector Extension 2
-`sve2-aes`     | `sve2`, `aes`  | FEAT_SVE_AES --- SVE AES instructions
-`sve2-sm4`     | `sve2`, `sm4`  | FEAT_SVE_SM4 --- SVE SM4 instructions
-`sve2-sha3`    | `sve2`, `sha3` | FEAT_SVE_SHA3 --- SVE SHA3 instructions
-`sve2-bitperm` | `sve2`         | FEAT_SVE_BitPerm --- SVE Bit Permute
-`tme`          |                | FEAT_TME --- Transactional Memory Extension
-`vh`           |                | FEAT_VHE --- Virtualization Host Extensions
+-------        | ------------------ | ------------
+`aes`          | `neon`             | FEAT_AES & FEAT_PMULL --- Advanced <abbr title="Single Instruction Multiple Data">SIMD</abbr> AES & PMULL instructions
+`bf16`         |                    | FEAT_BF16 --- BFloat16 instructions
+`bti`          |                    | FEAT_BTI --- Branch Target Identification
+`crc`          |                    | FEAT_CRC --- CRC32 checksum instructions
+`dit`          |                    | FEAT_DIT  --- Data Independent Timing instructions
+`dotprod`      | `neon`             | FEAT_DotProd --- Advanced SIMD Int8 dot product instructions
+`dpb`          |                    | FEAT_DPB --- Data cache clean to point of persistence
+`dpb2`         | `dpb`              | FEAT_DPB2 --- Data cache clean to point of deep persistence
+`f32mm`        | `sve`              | FEAT_F32MM --- SVE single-precision FP matrix multiply instruction
+`f64mm`        | `sve`              | FEAT_F64MM --- SVE double-precision FP matrix multiply instruction
+`fcma`         | `neon`             | FEAT_FCMA --- Floating point complex number support
+`fhm`          | `fp16`             | FEAT_FHM --- Half-precision FP FMLAL instructions
+`flagm`        |                    | FEAT_FLAGM --- Conditional flag manipulation
+`fp16`         | `neon`             | FEAT_FP16 --- Half-precision FP data processing
+`frintts`      |                    | FEAT_FRINTTS --- Floating-point to int helper instructions
+`i8mm`         |                    | FEAT_I8MM --- Int8 Matrix Multiplication
+`jsconv`       | `neon`             | FEAT_JSCVT --- JavaScript conversion instruction
+`lor`          |                    | FEAT_LOR --- Limited Ordering Regions extension
+`lse`          |                    | FEAT_LSE --- Large System Extensions
+`mte`          |                    | FEAT_MTE & FEAT_MTE2 --- Memory Tagging Extension
+`neon`         |                    | FEAT_AdvSimd & FEAT_FP --- Floating Point and Advanced SIMD extension
+`paca`         |                    | FEAT_PAUTH --- Pointer Authentication (address authentication)
+`pacg`         |                    | FEAT_PAUTH --- Pointer Authentication (generic authentication)
+`pan`          |                    | FEAT_PAN --- Privileged Access-Never extension
+`pmuv3`        |                    | FEAT_PMUv3 --- Performance Monitors extension (v3)
+`rand`         |                    | FEAT_RNG --- Random Number Generator
+`ras`          |                    | FEAT_RAS & FEAT_RASv1p1 --- Reliability, Availability and Serviceability extension
+`rcpc`         |                    | FEAT_LRCPC --- Release consistent Processor Consistent
+`rcpc2`        | `rcpc`             | FEAT_LRCPC2 --- RcPc with immediate offsets
+`rdm`          | `neon`             | FEAT_RDM --- Rounding Double Multiply accumulate
+`sb`           |                    | FEAT_SB --- Speculation Barrier
+`sha2`         | `neon`             | FEAT_SHA1 & FEAT_SHA256 --- Advanced SIMD SHA instructions
+`sha3`         | `sha2`             | FEAT_SHA512 & FEAT_SHA3 --- Advanced SIMD SHA instructions
+`sm4`          | `neon`             | FEAT_SM3 & FEAT_SM4 --- Advanced SIMD SM3/4 instructions
+`spe`          |                    | FEAT_SPE --- Statistical Profiling Extension
+`ssbs`         |                    | FEAT_SSBS & FEAT_SSBS2 --- Speculative Store Bypass Safe
+`sve`          | `neon`             | FEAT_SVE --- Scalable Vector Extension
+`sve2`         | `sve`              | FEAT_SVE2 --- Scalable Vector Extension 2
+`sve2-aes`     | `sve2`, `aes`      | FEAT_SVE_AES & FEAT_SVE_PMULL128 --- SVE AES instructions
+`sve2-bitperm` | `sve2`             | FEAT_SVE2_BitPerm --- SVE Bit Permute
+`sve2-sha3`    | `sve2`, `sha3`     | FEAT_SVE2_SHA3 --- SVE SHA3 instructions
+`sve2-sm4`     | `sve2`, `sm4`      | FEAT_SVE2_SM4 --- SVE SM4 instructions
+`tme`          |                    | FEAT_TME --- Transactional Memory Extension
+`vh`           |                    | FEAT_VHE --- Virtualization Host Extensions
 
 r[attributes.codegen.target_feature.riscv]
 #### `riscv32` or `riscv64`


### PR DESCRIPTION
Supercedes #1546.

Update `attributes/codegen.md` to match [aarch64 CPU features known to rustc](https://github.com/rust-lang/rust/blob/afa859f8121bf2985362a2c8414dc71a825ccf2d/compiler/rustc_target/src/target_features.rs#L179-L373).