### PR TITLE
Simplify GenericParams grammar

### DIFF
--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -3,9 +3,7 @@ r[items.generics]
 
 r[items.generics.syntax]
 ```grammar,items
-GenericParams ->
-      `<` `>`
-    | `<` (GenericParam `,`)* GenericParam `,`? `>`
+GenericParams -> `<` ( (GenericParam `,`)* GenericParam `,`? )? `>`
 
 GenericParam -> OuterAttribute* ( LifetimeParam | TypeParam | ConstParam )
 

--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -3,7 +3,7 @@ r[items.generics]
 
 r[items.generics.syntax]
 ```grammar,items
-GenericParams -> `<` ( (GenericParam `,`)* GenericParam `,`? )? `>`
+GenericParams -> `<` ( GenericParam (`,` GenericParam)* `,`? )? `>`
 
 GenericParam -> OuterAttribute* ( LifetimeParam | TypeParam | ConstParam )
 


### PR DESCRIPTION
When reading through the grammar, I found it surprising that GenericParams had
two separate alternatives, one for the empty case and one for the one-or-more
case. That seemed to obfuscate that GenericParams contains zero-or-more
GenericParam. This structure likely arose in order to express the optional
trailing comma correctly; however, it's possible to express that in another
way.

Rework `GenericParams` to have a single production that uses `?`, which then
deduplicates the surrounding `<` and `>`, and (in my opinion) simplifies the
handling of the trailing comma.