### PR TITLE
Relabel grammarRailroad-Button

### DIFF
--- a/src/notation.md
+++ b/src/notation.md
@@ -40,11 +40,11 @@ When such a string in `monospace` font occurs inside the grammar,
 it is an implicit reference to a single member of such a string table
 production. See [tokens] for more information.
 
-## Railroad visualizations
+## Grammar visualizations
 
-Below each grammar block is a button to toggle the display of a [railroad diagram]. A square element is a non-terminal rule, and a rounded rectangle is a terminal.
+Below each grammar block is a button to toggle the display of a [syntax diagram]. A square element is a non-terminal rule, and a rounded rectangle is a terminal.
 
-[railroad diagram]: https://en.wikipedia.org/wiki/Syntax_diagram
+[syntax diagram]: https://en.wikipedia.org/wiki/Syntax_diagram
 
 ## Common productions
 

--- a/theme/reference.css
+++ b/theme/reference.css
@@ -627,7 +627,7 @@ main > .rule {
 
 /* The toggle button. */
 .grammar-toggle-railroad {
-    width: 120px;
+    width: 160px;
     padding: 5px 0px;
     border-radius: 5px;
     cursor: pointer;

--- a/theme/reference.js
+++ b/theme/reference.js
@@ -66,9 +66,9 @@ function update_railroad() {
     const buttons = document.querySelectorAll('.grammar-toggle-railroad');
     buttons.forEach(button => {
         if (grammarRailroad) {
-            button.innerText = "Hide Railroad";
+            button.innerText = "Hide syntax diagram";
         } else {
-            button.innerText = "Show Railroad";
+            button.innerText = "Show syntax diagram";
         }
     });
 }


### PR DESCRIPTION
I suggest to relabel the button, and use the term "syntax diagram" instead of "railroad". The term "railroad" has no meaning to most readers.

---

On a different topic: Some of the diagrams can be simplified quite a bit. See the example below, which somewhat makes the written grammar more compact, but is to the benefit of the visual representation. Would you like a PR?


```diff
diff --git a/src/visibility-and-privacy.md b/src/visibility-and-privacy.md
index 847d469..e5469be 100644
--- a/src/visibility-and-privacy.md
+++ b/src/visibility-and-privacy.md
@@ -4,11 +4,7 @@ r[vis]
 r[vis.syntax]
 ```grammar,items
 Visibility ->
-      `pub`
-    | `pub` `(` `crate` `)`
-    | `pub` `(` `self` `)`
-    | `pub` `(` `super` `)`
-    | `pub` `(` `in` SimplePath `)`
+      `pub` ( `(` (`crate` | `self` | `super` | (`in` SimplePath))  `)` )?
```

<img width="445" alt="a" src="https://github.com/user-attachments/assets/77a14b6a-34bf-4b38-b425-a1e7e4fe535e" />
<img width="454" alt="b" src="https://github.com/user-attachments/assets/2c1f83e9-a567-4e35-846f-13dcec705d9b" />
