### PR TITLE
Remove StructExprTuple and StructExprUnit

### DIFF
--- a/src/expressions.md
+++ b/src/expressions.md
@@ -347,8 +347,8 @@ They are never allowed before:
 [Structs]:              expr.struct
 [Temporary values]:     #temporaries
 [tuple expressions]:    expressions/tuple-expr.md
-[Tuple structs]:        expr.struct.tuple
+[Tuple structs]:        items.struct.tuple
 [Tuples]:               expressions/tuple-expr.md
 [Underscores]:          expressions/underscore-expr.md
-[Unit structs]:         expr.struct.unit
+[Unit structs]:         items.struct.unit
 [Variables]:            variables.md

--- a/src/expressions/if-expr.md
+++ b/src/expressions/if-expr.md
@@ -6,7 +6,7 @@ r[expr.if]
 r[expr.if.syntax]
 ```grammar,expressions
 IfExpression ->
-    `if` Expression _except [StructExprStruct]_ BlockExpression
+    `if` Expression _except [StructExpression]_ BlockExpression
     (`else` ( BlockExpression | IfExpression | IfLetExpression ) )?
 ```
 <!-- TODO: The exception above isn't accurate, see https://github.com/rust-lang/reference/issues/569 -->

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -54,7 +54,7 @@ r[expr.loop.while]
 
 r[expr.loop.while.syntax]
 ```grammar,expressions
-PredicateLoopExpression -> `while` Expression _except [StructExprStruct]_ BlockExpression
+PredicateLoopExpression -> `while` Expression _except [StructExpression]_ BlockExpression
 ```
 <!-- TODO: The exception above isn't accurate, see https://github.com/rust-lang/reference/issues/569 -->
 
@@ -148,7 +148,7 @@ r[expr.loop.for]
 r[expr.loop.for.syntax]
 ```grammar,expressions
 IteratorLoopExpression ->
-    `for` Pattern `in` Expression _except [StructExprStruct]_ BlockExpression
+    `for` Pattern `in` Expression _except [StructExpression]_ BlockExpression
 ```
 <!-- TODO: The exception above isn't accurate, see https://github.com/rust-lang/reference/issues/569 -->
 

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -9,7 +9,7 @@ MatchExpression ->
         MatchArms?
     `}`
 
-Scrutinee -> Expression _except [StructExprStruct]_
+Scrutinee -> Expression _except [StructExpression]_
 
 MatchArms ->
     ( MatchArm `=>` ( ExpressionWithoutBlock `,` | ExpressionWithBlock `,`? ) )*


### PR DESCRIPTION
This removes the grammar rules StructExprTuple and StructExprUnit, and removes these as distinct expressions. Instead, a note block is used to let the reader know how the constructors can be accessed in the value namespace.

This stems back to the beginning of this documentation, which presumably was presenting these as distinct kinds of expressions just as a simplification or to match what people's mental models might be. However, they are not distinct expressions, and I think it is misleading to pretend that they are.

Closes https://github.com/rust-lang/reference/issues/1802