### PR TITLE
Add a note that `!` can only be coerced to sized types

### DIFF
--- a/src/type-coercions.md
+++ b/src/type-coercions.md
@@ -187,7 +187,7 @@ r[coerce.types.closure]
 * Non capturing closures to `fn` pointers
 
 r[coerce.types.never]
-* `!` to any `T`
+* `!` to any `T` which is `Sized`
 
 ### Unsized Coercions
 


### PR DESCRIPTION
This commit is dated 2025-02-02, I accidentally found it while looking for something else lol.