### PR TITLE
Make linked rules are clicked, highlight the color

### DIFF
--- a/theme/reference.css
+++ b/theme/reference.css
@@ -389,6 +389,11 @@ main > .rule {
     padding-right: 5px;
 }
 
+/* Make it bolder/easier to read when selected. */
+.rule:target .rule-link {
+    color: var(--fg) !important;
+}
+
 /* Dodge » from headings */
 /* Note: Some rules have a .tests-popup in the way, so that's why this selects
          either with or without. */


### PR DESCRIPTION
The current grey color has a low contrast with the background. This changes it so that when selected it uses the foreground color so that it is clearer which rule is currently linked to.

Before:
<img width="339" alt="image" src="https://github.com/user-attachments/assets/de8a3c6b-8413-4b9f-8817-532459920e38" />

After:
<img width="338" alt="image" src="https://github.com/user-attachments/assets/7be4ce8e-d87e-4545-a0cf-0d46fac6c1e9" />
