### PR TITLE
Compactify syntax diagrams

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -116,9 +116,7 @@ attributes]. It has the following grammar:
 r[attributes.meta.syntax]
 ```grammar,attributes
 MetaItem ->
-      SimplePath
-    | SimplePath `=` Expression
-    | SimplePath `(` MetaSeq? `)`
+      SimplePath ((`=` Expression) | (`(` MetaSeq? `)`))?
 
 MetaSeq ->
     MetaItemInner ( `,` MetaItemInner )* `,`?

--- a/src/attributes.md
+++ b/src/attributes.md
@@ -116,7 +116,10 @@ attributes]. It has the following grammar:
 r[attributes.meta.syntax]
 ```grammar,attributes
 MetaItem ->
-      SimplePath ((`=` Expression) | (`(` MetaSeq? `)`))?
+    SimplePath (
+        `=` Expression
+      | `(` MetaSeq? `)`
+    )?
 
 MetaSeq ->
     MetaItemInner ( `,` MetaItemInner )* `,`?

--- a/src/comments.md
+++ b/src/comments.md
@@ -4,8 +4,7 @@ r[comments]
 r[comments.syntax]
 ```grammar,lexer
 @root LINE_COMMENT ->
-      `//` (~[`/` `!` LF] | `//`) ~LF*
-    | `//`
+    `//` ( ( ~[`/` `!` LF] | `//` ) ~LF* )?
 
 BLOCK_COMMENT ->
       `/*`

--- a/src/expressions/array-expr.md
+++ b/src/expressions/array-expr.md
@@ -8,7 +8,10 @@ r[expr.array.syntax]
 ArrayExpression -> `[` ArrayElements? `]`
 
 ArrayElements ->
-      Expression (( `,` Expression )* `,`? | (`;` Expression ))
+    Expression (
+        ( `,` Expression )* `,`?
+      | `;` Expression
+    )
 ```
 
 r[expr.array.constructor]

--- a/src/expressions/array-expr.md
+++ b/src/expressions/array-expr.md
@@ -8,8 +8,7 @@ r[expr.array.syntax]
 ArrayExpression -> `[` ArrayElements? `]`
 
 ArrayElements ->
-      Expression ( `,` Expression )* `,`?
-    | Expression `;` Expression
+      Expression (( `,` Expression )* `,`? | (`;` Expression ))
 ```
 
 r[expr.array.constructor]

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -10,7 +10,7 @@ BlockExpression ->
     `}`
 
 Statements ->
-    Statement+ ExpressionWithoutBlock?
+      Statement+ ExpressionWithoutBlock?
     | ExpressionWithoutBlock
 ```
 

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -10,8 +10,7 @@ BlockExpression ->
     `}`
 
 Statements ->
-      Statement+
-    | Statement+ ExpressionWithoutBlock
+    Statement+ ExpressionWithoutBlock?
     | ExpressionWithoutBlock
 ```
 

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -58,7 +58,7 @@ r[expr.operator.borrow]
 r[expr.operator.borrow.syntax]
 ```grammar,expressions
 BorrowExpression ->
-    (`&`|`&&`) ( `mut` | (`raw` (`const` | `mut`))) Expression
+    (`&`|`&&`) ( `mut` | (`raw` (`const` | `mut`)))? Expression
 ```
 
 r[expr.operator.borrow.intro]

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -58,10 +58,7 @@ r[expr.operator.borrow]
 r[expr.operator.borrow.syntax]
 ```grammar,expressions
 BorrowExpression ->
-      (`&`|`&&`) Expression
-    | (`&`|`&&`) `mut` Expression
-    | (`&`|`&&`) `raw` `const` Expression
-    | (`&`|`&&`) `raw` `mut` Expression
+    (`&`|`&&`) ( `mut` | (`raw` (`const` | `mut`))) Expression
 ```
 
 r[expr.operator.borrow.intro]
@@ -291,16 +288,7 @@ r[expr.arith-logic]
 r[expr.arith-logic.syntax]
 ```grammar,expressions
 ArithmeticOrLogicalExpression ->
-      Expression `+` Expression
-    | Expression `-` Expression
-    | Expression `*` Expression
-    | Expression `/` Expression
-    | Expression `%` Expression
-    | Expression `&` Expression
-    | Expression `|` Expression
-    | Expression `^` Expression
-    | Expression `<<` Expression
-    | Expression `>>` Expression
+      Expression ( `+` | `-` | `*` | `/` | `%` | `&` | `|` | `^` | `<<` | `>>` ) Expression
 ```
 
 r[expr.arith-logic.intro]
@@ -354,12 +342,7 @@ r[expr.cmp]
 r[expr.cmp.syntax]
 ```grammar,expressions
 ComparisonExpression ->
-      Expression `==` Expression
-    | Expression `!=` Expression
-    | Expression `>` Expression
-    | Expression `<` Expression
-    | Expression `>=` Expression
-    | Expression `<=` Expression
+      Expression ( `==` | `!=` | `>` | `<` | `>=` | `<=` ) Expression
 ```
 
 r[expr.cmp.intro]
@@ -413,8 +396,7 @@ r[expr.bool-logic]
 r[expr.bool-logic.syntax]
 ```grammar,expressions
 LazyBooleanExpression ->
-      Expression `||` Expression
-    | Expression `&&` Expression
+      Expression (`||` | `&&`) Expression
 ```
 
 r[expr.bool-logic.intro]
@@ -809,16 +791,7 @@ r[expr.compound-assign]
 r[expr.compound-assign.syntax]
 ```grammar,expressions
 CompoundAssignmentExpression ->
-      Expression `+=` Expression
-    | Expression `-=` Expression
-    | Expression `*=` Expression
-    | Expression `/=` Expression
-    | Expression `%=` Expression
-    | Expression `&=` Expression
-    | Expression `|=` Expression
-    | Expression `^=` Expression
-    | Expression `<<=` Expression
-    | Expression `>>=` Expression
+      Expression (`+=` | `-=` | `*=` | `/=` | `%=` | `&=` | `|=` | `^=` | `<<=` | `>>=`) Expression
 ```
 
 r[expr.compound-assign.intro]

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -58,7 +58,9 @@ r[expr.operator.borrow]
 r[expr.operator.borrow.syntax]
 ```grammar,expressions
 BorrowExpression ->
-    (`&`|`&&`) ( `mut` | (`raw` (`const` | `mut`)))? Expression
+    ( `&` | `&&` )
+    ( `mut` | `raw` ( `const` | `mut` ) )?
+    Expression
 ```
 
 r[expr.operator.borrow.intro]
@@ -288,7 +290,9 @@ r[expr.arith-logic]
 r[expr.arith-logic.syntax]
 ```grammar,expressions
 ArithmeticOrLogicalExpression ->
-      Expression ( `+` | `-` | `*` | `/` | `%` | `&` | `|` | `^` | `<<` | `>>` ) Expression
+    Expression (
+        `+` | `-` | `*` | `/` | `%` | `&` | `|` | `^` | `<<` | `>>`
+    ) Expression
 ```
 
 r[expr.arith-logic.intro]
@@ -342,7 +346,9 @@ r[expr.cmp]
 r[expr.cmp.syntax]
 ```grammar,expressions
 ComparisonExpression ->
-      Expression ( `==` | `!=` | `>` | `<` | `>=` | `<=` ) Expression
+    Expression (
+        `==` | `!=` | `>` | `<` | `>=` | `<=`
+    ) Expression
 ```
 
 r[expr.cmp.intro]
@@ -396,7 +402,7 @@ r[expr.bool-logic]
 r[expr.bool-logic.syntax]
 ```grammar,expressions
 LazyBooleanExpression ->
-      Expression (`||` | `&&`) Expression
+    Expression (`||` | `&&`) Expression
 ```
 
 r[expr.bool-logic.intro]
@@ -791,7 +797,11 @@ r[expr.compound-assign]
 r[expr.compound-assign.syntax]
 ```grammar,expressions
 CompoundAssignmentExpression ->
-      Expression (`+=` | `-=` | `*=` | `/=` | `%=` | `&=` | `|=` | `^=` | `<<=` | `>>=`) Expression
+    Expression (
+        `+=` | `-=` | `*=` | `/=` | `%=`
+      | `&=` | `|=` | `^=`
+      | `<<=` | `>>=`
+    ) Expression
 ```
 
 r[expr.compound-assign.intro]

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -256,8 +256,7 @@ r[expr.negate]
 r[expr.negate.syntax]
 ```grammar,expressions
 NegationExpression ->
-      `-` Expression
-    | `!` Expression
+    ( `-` | `!`)  Expression
 ```
 
 r[expr.negate.intro]

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -73,20 +73,21 @@ AsmOption ->
     | `att_syntax`
     | `raw`
 
-RegOperand -> (ParamName `=`)?
-    (
-          ((DirSpec `(` RegSpec `)`)
-           | `const`
-          ) Expression
-        | DualDirSpec `(` RegSpec `)` DualDirSpecExpression
-        | `sym` PathExpression
-        | `label` `{` Statements? `}`
+RegOperand ->
+    (ParamName `=`)? (
+        (
+            DirSpec `(` RegSpec `)`
+          | `const`
+        ) Expression
+      | DualDirSpec `(` RegSpec `)` DualDirSpecExpression
+      | `sym` PathExpression
+      | `label` `{` Statements? `}`
     )
 
 ParamName -> IDENTIFIER_OR_KEYWORD | RAW_IDENTIFIER
 
 DualDirSpecExpression ->
-    Expression (`=>` Expression)?
+    Expression ( `=>` Expression )?
 
 RegSpec -> RegisterClass | ExplicitRegister
 

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -75,18 +75,18 @@ AsmOption ->
 
 RegOperand -> (ParamName `=`)?
     (
-          DirSpec `(` RegSpec `)` Expression
+          ((DirSpec `(` RegSpec `)`)
+           | `const`
+          ) Expression
         | DualDirSpec `(` RegSpec `)` DualDirSpecExpression
         | `sym` PathExpression
-        | `const` Expression
         | `label` `{` Statements? `}`
     )
 
 ParamName -> IDENTIFIER_OR_KEYWORD | RAW_IDENTIFIER
 
 DualDirSpecExpression ->
-      Expression
-    | Expression `=>` Expression
+    Expression (`=>` Expression)?
 
 RegSpec -> RegisterClass | ExplicitRegister
 

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -11,8 +11,8 @@ ExternBlock ->
 
 ExternalItem ->
     OuterAttribute* (
-      Visibility? (StaticItem | Function)
-      |  MacroInvocationSemi
+        Visibility? ( StaticItem | Function )
+      | MacroInvocationSemi
     )
 ```
 

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -11,9 +11,8 @@ ExternBlock ->
 
 ExternalItem ->
     OuterAttribute* (
-        MacroInvocationSemi
-      | Visibility? StaticItem
-      | Visibility? Function
+      Visibility? (StaticItem | Function)
+      |  MacroInvocationSemi
     )
 ```
 

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -21,7 +21,7 @@ FunctionParameters ->
 
 SelfParam -> OuterAttribute* ( ShorthandSelf | TypedSelf )
 
-ShorthandSelf -> (`&` Lifetime?)? `mut`? `self`
+ShorthandSelf -> ( `&` Lifetime? )? `mut`? `self`
 
 TypedSelf -> `mut`? `self` `:` Type
 

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -21,7 +21,7 @@ FunctionParameters ->
 
 SelfParam -> OuterAttribute* ( ShorthandSelf | TypedSelf )
 
-ShorthandSelf -> (`&` | `&` Lifetime)? `mut`? `self`
+ShorthandSelf -> (`&` Lifetime?)? `mut`? `self`
 
 TypedSelf -> `mut`? `self` `:` Type
 

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -16,14 +16,16 @@ ItemSafety -> `safe`[^extern-safe] | `unsafe`
 Abi -> STRING_LITERAL | RAW_STRING_LITERAL
 
 FunctionParameters ->
-      SelfParam `,`?
-    | (SelfParam `,`)? FunctionParam (`,` FunctionParam)* `,`?
+      SelfParam ( `,` FunctionParams? )?
+    | FunctionParams
 
 SelfParam -> OuterAttribute* ( ShorthandSelf | TypedSelf )
 
 ShorthandSelf -> ( `&` Lifetime? )? `mut`? `self`
 
 TypedSelf -> `mut`? `self` `:` Type
+
+FunctionParams -> FunctionParam ( `,` FunctionParam )* `,`?
 
 FunctionParam -> OuterAttribute* ( FunctionParamPattern | `...` | Type[^fn-param-2015] )
 

--- a/src/items/modules.md
+++ b/src/items/modules.md
@@ -4,11 +4,7 @@ r[items.mod]
 r[items.mod.syntax]
 ```grammar,items
 Module ->
-      `unsafe`? `mod` IDENTIFIER `;`
-    | `unsafe`? `mod` IDENTIFIER `{`
-        InnerAttribute*
-        Item*
-      `}`
+      `unsafe`? `mod` IDENTIFIER ( `;` | (`{` InnerAttribute* Item* `}` ))
 ```
 
 r[items.mod.intro]

--- a/src/items/modules.md
+++ b/src/items/modules.md
@@ -4,7 +4,10 @@ r[items.mod]
 r[items.mod.syntax]
 ```grammar,items
 Module ->
-      `unsafe`? `mod` IDENTIFIER ( `;` | (`{` InnerAttribute* Item* `}` ))
+    `unsafe`? `mod` IDENTIFIER (
+        `{` InnerAttribute* Item* `}`
+      | `;`
+    )
 ```
 
 r[items.mod.intro]

--- a/src/items/use-declarations.md
+++ b/src/items/use-declarations.md
@@ -6,8 +6,7 @@ r[items.use.syntax]
 UseDeclaration -> `use` UseTree `;`
 
 UseTree ->
-      (SimplePath? `::`)? `*`
-    | (SimplePath? `::`)? `{` (UseTree ( `,`  UseTree )* `,`?)? `}`
+      (SimplePath? `::`)? (`*` | (`{` (UseTree ( `,`  UseTree )* `,`?)? `}`))
     | SimplePath ( `as` ( IDENTIFIER | `_` ) )?
 ```
 

--- a/src/items/use-declarations.md
+++ b/src/items/use-declarations.md
@@ -6,7 +6,10 @@ r[items.use.syntax]
 UseDeclaration -> `use` UseTree `;`
 
 UseTree ->
-      (SimplePath? `::`)? (`*` | (`{` (UseTree ( `,`  UseTree )* `,`?)? `}`))
+      ( SimplePath? `::` )? (
+          `{` ( UseTree ( `,`  UseTree )* `,`? )? `}`
+        | `*`
+      )
     | SimplePath ( `as` ( IDENTIFIER | `_` ) )?
 ```
 

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -7,9 +7,10 @@ MacroRulesDefinition ->
     `macro_rules` `!` IDENTIFIER MacroRulesDef
 
 MacroRulesDef ->
-      `(` MacroRules `)` `;`
-    | `[` MacroRules `]` `;`
-    | `{` MacroRules `}`
+      (  (`(` MacroRules `)`)
+       | (`[` MacroRules `]`)
+      )`;`
+    |    (`{` MacroRules `}`)
 
 MacroRules ->
     MacroRule ( `;` MacroRule )* `;`?
@@ -25,8 +26,8 @@ MacroMatcher ->
 MacroMatch ->
       Token _except `$` and [delimiters][lex.token.delim]_
     | MacroMatcher
-    | `$` ( IDENTIFIER_OR_KEYWORD _except `crate`_ | RAW_IDENTIFIER | `_` ) `:` MacroFragSpec
-    | `$` `(` MacroMatch+ `)` MacroRepSep? MacroRepOp
+    | `$` ((( IDENTIFIER_OR_KEYWORD _except `crate`_ | RAW_IDENTIFIER | `_` ) `:` MacroFragSpec)
+           | (`(` MacroMatch+ `)` MacroRepSep? MacroRepOp))
 
 MacroFragSpec ->
       `block` | `expr` | `expr_2021` | `ident` | `item` | `lifetime` | `literal`

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -7,10 +7,11 @@ MacroRulesDefinition ->
     `macro_rules` `!` IDENTIFIER MacroRulesDef
 
 MacroRulesDef ->
-      (  (`(` MacroRules `)`)
-       | (`[` MacroRules `]`)
-      )`;`
-    |    (`{` MacroRules `}`)
+      (
+          `(` MacroRules `)`
+        | `[` MacroRules `]`
+      ) `;`
+    | `{` MacroRules `}`
 
 MacroRules ->
     MacroRule ( `;` MacroRule )* `;`?
@@ -26,8 +27,11 @@ MacroMatcher ->
 MacroMatch ->
       Token _except `$` and [delimiters][lex.token.delim]_
     | MacroMatcher
-    | `$` ((( IDENTIFIER_OR_KEYWORD _except `crate`_ | RAW_IDENTIFIER | `_` ) `:` MacroFragSpec)
-           | (`(` MacroMatch+ `)` MacroRepSep? MacroRepOp))
+    | `$` (
+          ( IDENTIFIER_OR_KEYWORD _except `crate`_ | RAW_IDENTIFIER | `_` )
+          `:` MacroFragSpec
+        | `(` MacroMatch+ `)` MacroRepSep? MacroRepOp
+      )
 
 MacroFragSpec ->
       `block` | `expr` | `expr_2021` | `ident` | `item` | `lifetime` | `literal`

--- a/src/macros.md
+++ b/src/macros.md
@@ -29,7 +29,13 @@ TokenTree ->
     Token _except [delimiters][lex.token.delim]_ | DelimTokenTree
 
 MacroInvocationSemi ->
-      SimplePath `!` ( ( ( `(` TokenTree* `)` ) | ( `[` TokenTree* `]` )) `;` | ( `{` TokenTree* `}` ))
+    SimplePath `!` (
+        (
+            `(` TokenTree* `)`
+          | `[` TokenTree* `]`
+        ) `;`
+      | `{` TokenTree* `}`
+    )
 ```
 
 r[macro.invocation.intro]

--- a/src/macros.md
+++ b/src/macros.md
@@ -29,9 +29,7 @@ TokenTree ->
     Token _except [delimiters][lex.token.delim]_ | DelimTokenTree
 
 MacroInvocationSemi ->
-      SimplePath `!` `(` TokenTree* `)` `;`
-    | SimplePath `!` `[` TokenTree* `]` `;`
-    | SimplePath `!` `{` TokenTree* `}`
+      SimplePath `!` ( ( ( `(` TokenTree* `)` ) | ( `[` TokenTree* `]` )) `;` | ( `{` TokenTree* `}` ))
 ```
 
 r[macro.invocation.intro]

--- a/src/paths.md
+++ b/src/paths.md
@@ -54,16 +54,14 @@ PathIdentSegment ->
     IDENTIFIER | `super` | `self` | `Self` | `crate` | `$crate`
 
 GenericArgs ->
-      `<` `>`
-    | `<` ( GenericArg `,` )* GenericArg `,`? `>`
+    `<` (( GenericArg `,` )* GenericArg `,`?)? `>`
 
 GenericArg ->
     Lifetime | Type | GenericArgsConst | GenericArgsBinding | GenericArgsBounds
 
 GenericArgsConst ->
       BlockExpression
-    | LiteralExpression
-    | `-` LiteralExpression
+    | `-`? LiteralExpression
     | SimplePathSegment
 
 GenericArgsBinding ->

--- a/src/paths.md
+++ b/src/paths.md
@@ -54,7 +54,7 @@ PathIdentSegment ->
     IDENTIFIER | `super` | `self` | `Self` | `crate` | `$crate`
 
 GenericArgs ->
-    `<` (( GenericArg `,` )* GenericArg `,`?)? `>`
+    `<` ( GenericArg ( `,` GenericArg )* `,`? )? `>`
 
 GenericArg ->
     Lifetime | Type | GenericArgsConst | GenericArgsBinding | GenericArgsBounds

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -149,8 +149,7 @@ LiteralPattern ->
     | RAW_BYTE_STRING_LITERAL
     | C_STRING_LITERAL
     | RAW_C_STRING_LITERAL
-    | `-`? INTEGER_LITERAL
-    | `-`? FLOAT_LITERAL
+    | `-`? (INTEGER_LITERAL | FLOAT_LITERAL)
 ```
 
 r[patterns.literal.intro]
@@ -499,8 +498,7 @@ ObsoleteRangePattern ->
 RangePatternBound ->
       CHAR_LITERAL
     | BYTE_LITERAL
-    | `-`? INTEGER_LITERAL
-    | `-`? FLOAT_LITERAL
+    | `-`? (INTEGER_LITERAL | FLOAT_LITERAL)
     | PathExpression
 ```
 
@@ -708,7 +706,7 @@ StructPattern ->
     `}`
 
 StructPatternElements ->
-      StructPatternFields (`,` | `,` StructPatternEtCetera)?
+      StructPatternFields (`,` StructPatternEtCetera?)?
     | StructPatternEtCetera
 
 StructPatternFields ->
@@ -717,8 +715,7 @@ StructPatternFields ->
 StructPatternField ->
     OuterAttribute*
     (
-        TUPLE_INDEX `:` Pattern
-      | IDENTIFIER `:` Pattern
+        (TUPLE_INDEX | IDENTIFIER) `:` Pattern
       | `ref`? `mut`? IDENTIFIER
     )
 
@@ -837,9 +834,8 @@ r[patterns.tuple.syntax]
 TuplePattern -> `(` TuplePatternItems? `)`
 
 TuplePatternItems ->
-      Pattern `,`
+      Pattern (`,` | (`,` Pattern)+ `,`?)
     | RestPattern
-    | Pattern (`,` Pattern)+ `,`?
 ```
 
 r[patterns.tuple.intro]

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -149,7 +149,7 @@ LiteralPattern ->
     | RAW_BYTE_STRING_LITERAL
     | C_STRING_LITERAL
     | RAW_C_STRING_LITERAL
-    | `-`? (INTEGER_LITERAL | FLOAT_LITERAL)
+    | `-`? ( INTEGER_LITERAL | FLOAT_LITERAL )
 ```
 
 r[patterns.literal.intro]
@@ -498,7 +498,7 @@ ObsoleteRangePattern ->
 RangePatternBound ->
       CHAR_LITERAL
     | BYTE_LITERAL
-    | `-`? (INTEGER_LITERAL | FLOAT_LITERAL)
+    | `-`? ( INTEGER_LITERAL | FLOAT_LITERAL )
     | PathExpression
 ```
 
@@ -706,7 +706,7 @@ StructPattern ->
     `}`
 
 StructPatternElements ->
-      StructPatternFields (`,` StructPatternEtCetera?)?
+      StructPatternFields ( `,` StructPatternEtCetera? )?
     | StructPatternEtCetera
 
 StructPatternFields ->
@@ -715,7 +715,7 @@ StructPatternFields ->
 StructPatternField ->
     OuterAttribute*
     (
-        (TUPLE_INDEX | IDENTIFIER) `:` Pattern
+        ( TUPLE_INDEX | IDENTIFIER ) `:` Pattern
       | `ref`? `mut`? IDENTIFIER
     )
 
@@ -834,7 +834,7 @@ r[patterns.tuple.syntax]
 TuplePattern -> `(` TuplePatternItems? `)`
 
 TuplePatternItems ->
-      Pattern (`,` | (`,` Pattern)+ `,`?)
+      Pattern ( `,` | ( `,` Pattern )+ `,`? )
     | RestPattern
 ```
 

--- a/src/statements.md
+++ b/src/statements.md
@@ -61,8 +61,11 @@ r[statement.let.syntax]
 LetStatement ->
     OuterAttribute* `let` PatternNoTopAlt ( `:` Type )?
     (
-          `=` Expression
-        | `=` Expression _except [LazyBooleanExpression] or end with a `}`_ `else` BlockExpression
+        `=` (
+            Expression _except [LazyBooleanExpression] or end with a `}`_
+            `else` BlockExpression
+          | Expression
+        )
     )? `;`
 ```
 

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -657,9 +657,11 @@ r[lex.token.literal.float]
 r[lex.token.literal.float.syntax]
 ```grammar,lexer
 FLOAT_LITERAL ->
-      DEC_LITERAL ((`.` _not immediately followed by `.`, `_` or an XID_Start character_ )
-                   | (`.` DEC_LITERAL SUFFIX_NO_E?)
-                   | ((`.` DEC_LITERAL)? FLOAT_EXPONENT SUFFIX?))
+    DEC_LITERAL (
+        `.` _not immediately followed by `.`, `_` or an XID_Start character_
+      | `.` DEC_LITERAL SUFFIX_NO_E?
+      | ( `.` DEC_LITERAL )? FLOAT_EXPONENT SUFFIX?
+    )
 
 FLOAT_EXPONENT ->
     (`e`|`E`) (`+`|`-`)? (DEC_DIGIT|`_`)* DEC_DIGIT (DEC_DIGIT|`_`)*

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -657,9 +657,9 @@ r[lex.token.literal.float]
 r[lex.token.literal.float.syntax]
 ```grammar,lexer
 FLOAT_LITERAL ->
-      DEC_LITERAL `.` _not immediately followed by `.`, `_` or an XID_Start character_
-    | DEC_LITERAL `.` DEC_LITERAL SUFFIX_NO_E?
-    | DEC_LITERAL (`.` DEC_LITERAL)? FLOAT_EXPONENT SUFFIX?
+      DEC_LITERAL ((`.` _not immediately followed by `.`, `_` or an XID_Start character_ )
+                   | (`.` DEC_LITERAL SUFFIX_NO_E?)
+                   | ((`.` DEC_LITERAL)? FLOAT_EXPONENT SUFFIX?))
 
 FLOAT_EXPONENT ->
     (`e`|`E`) (`+`|`-`)? (DEC_DIGIT|`_`)* DEC_DIGIT (DEC_DIGIT|`_`)*

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -659,8 +659,8 @@ r[lex.token.literal.float.syntax]
 FLOAT_LITERAL ->
     DEC_LITERAL (
         `.` _not immediately followed by `.`, `_` or an XID_Start character_
-      | `.` DEC_LITERAL SUFFIX_NO_E?
-      | ( `.` DEC_LITERAL )? FLOAT_EXPONENT SUFFIX?
+      | `.` DEC_LITERAL ( SUFFIX_NO_E? | FLOAT_EXPONENT SUFFIX? )
+      | FLOAT_EXPONENT SUFFIX?
     )
 
 FLOAT_EXPONENT ->
@@ -716,8 +716,11 @@ r[lex.token.literal.reserved.syntax]
 RESERVED_NUMBER ->
       BIN_LITERAL [`2`-`9`]
     | OCT_LITERAL [`8`-`9`]
-    | ( BIN_LITERAL | OCT_LITERAL | HEX_LITERAL ) `.` _not immediately followed by `.`, `_` or an XID_Start character_
-    | ( BIN_LITERAL | OCT_LITERAL ) (`e`|`E`)
+    | ( BIN_LITERAL | OCT_LITERAL ) (
+          `.` _not immediately followed by `.`, `_` or an XID_Start character_
+        | (`e`|`E`)
+      )
+    | HEX_LITERAL `.` _not immediately followed by `.`, `_` or an XID_Start character_
     | `0b` `_`* <end of input or not BIN_DIGIT>
     | `0o` `_`* <end of input or not OCT_DIGIT>
     | `0x` `_`* <end of input or not HEX_DIGIT>

--- a/src/trait-bounds.md
+++ b/src/trait-bounds.md
@@ -21,8 +21,7 @@ Lifetime ->
 UseBound -> `use` UseBoundGenericArgs
 
 UseBoundGenericArgs ->
-      `<` `>`
-    | `<` ( UseBoundGenericArg `,`)* UseBoundGenericArg `,`? `>`
+    `<` (( UseBoundGenericArg `,`)* UseBoundGenericArg `,`?)? `>`
 
 UseBoundGenericArg ->
       Lifetime

--- a/src/trait-bounds.md
+++ b/src/trait-bounds.md
@@ -21,7 +21,7 @@ Lifetime ->
 UseBound -> `use` UseBoundGenericArgs
 
 UseBoundGenericArgs ->
-    `<` (( UseBoundGenericArg `,`)* UseBoundGenericArg `,`?)? `>`
+    `<` ( UseBoundGenericArg ( `,` UseBoundGenericArg )*  `,`? )? `>`
 
 UseBoundGenericArg ->
       Lifetime

--- a/src/trait-bounds.md
+++ b/src/trait-bounds.md
@@ -7,9 +7,9 @@ TypeParamBounds -> TypeParamBound ( `+` TypeParamBound )* `+`?
 
 TypeParamBound -> Lifetime | TraitBound | UseBound
 
-TraitBound ->
-      ( `?` | ForLifetimes )? TypePath
-    | `(` ( `?` | ForLifetimes )? TypePath `)`
+TraitBound -> `(` TraitBoundNoParens `)` | TraitBoundNoParens
+
+TraitBoundNoParens ->  ( `?` | ForLifetimes )? TypePath
 
 LifetimeBounds -> ( Lifetime `+` )* Lifetime?
 

--- a/src/types/function-pointer.md
+++ b/src/types/function-pointer.md
@@ -21,7 +21,7 @@ MaybeNamedParam ->
     OuterAttribute* ( ( IDENTIFIER | `_` ) `:` )? Type
 
 MaybeNamedFunctionParametersVariadic ->
-    ( MaybeNamedParam `,` )* MaybeNamedParam `,` OuterAttribute* `...`
+    MaybeNamedParam ( `,` MaybeNamedParam )* `,` OuterAttribute* `...`
 ```
 
 r[type.fn-pointer.intro]

--- a/src/types/tuple.md
+++ b/src/types/tuple.md
@@ -4,7 +4,7 @@ r[type.tuple]
 r[type.tuple.syntax]
 ```grammar,types
 TupleType ->
-    `(` (( Type `,` )+ Type?)? `)`
+    `(` ( ( Type `,` )+ Type? )? `)`
 ```
 
 r[type.tuple.intro]

--- a/src/types/tuple.md
+++ b/src/types/tuple.md
@@ -4,8 +4,7 @@ r[type.tuple]
 r[type.tuple.syntax]
 ```grammar,types
 TupleType ->
-      `(` `)`
-    | `(` ( Type `,` )+ Type? `)`
+    `(` (( Type `,` )+ Type?)? `)`
 ```
 
 r[type.tuple.intro]

--- a/src/visibility-and-privacy.md
+++ b/src/visibility-and-privacy.md
@@ -4,7 +4,14 @@ r[vis]
 r[vis.syntax]
 ```grammar,items
 Visibility ->
-      `pub` ( `(` (`crate` | `self` | `super` | (`in` SimplePath))  `)` )?
+    `pub` (
+      `(` (
+          `crate`
+        | `self`
+        | `super`
+        | `in` SimplePath
+      ) `)`
+    )?
 ```
 
 r[vis.intro]

--- a/src/visibility-and-privacy.md
+++ b/src/visibility-and-privacy.md
@@ -4,11 +4,7 @@ r[vis]
 r[vis.syntax]
 ```grammar,items
 Visibility ->
-      `pub`
-    | `pub` `(` `crate` `)`
-    | `pub` `(` `self` `)`
-    | `pub` `(` `super` `)`
-    | `pub` `(` `in` SimplePath `)`
+      `pub` ( `(` (`crate` | `self` | `super` | (`in` SimplePath))  `)` )?
 ```
 
 r[vis.intro]


### PR DESCRIPTION
Fixes #1805 

This makes the grammar rules more compact by removing superfluous elements. It leads to much simpler syntax diagrams at the expense of more difficult to follow (nested) text representation. See #1805 for some examples.

I visually compared every before-and-after to make sure that the grammar rules represent the same syntax. Please give it firm look anyway. 