### PR TITLE
Add missing attribute for statement macros

### DIFF
--- a/src/statements.md
+++ b/src/statements.md
@@ -8,7 +8,7 @@ Statement ->
     | Item
     | LetStatement
     | ExpressionStatement
-    | MacroInvocationSemi
+    | OuterAttribute* MacroInvocationSemi
 ```
 
 r[statement.intro]


### PR DESCRIPTION
This adds a missing OuterAttribute for macro invocations used in statement position. That is, something like the following is valid and compiles successfully.

```rust
macro_rules! m {
    () => {
        compile_error!("poof");
    };
}

fn main() {
    #[cfg(false)] m!();
}
```