### PR TITLE
Fix naked em-dash

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -291,7 +291,7 @@ The following is an index of all built-in attributes.
 - Code generation
   - [`inline`] --- Hint to inline code.
   - [`cold`] --- Hint that a function is unlikely to be called.
-  - [`naked`] - Prevent the compiler from emitting a function prologue.
+  - [`naked`] --- Prevent the compiler from emitting a function prologue.
   - [`no_builtins`] --- Disables use of certain built-in functions.
   - [`target_feature`] --- Configure platform-specific code generation.
   - [`track_caller`] --- Pass the parent call location to `std::panic::Location::caller()`.


### PR DESCRIPTION
The `naked` attribute was not following the style of all the other attributes of using an em-dash here.