### PR TITLE
document that the `rustc` tool namespace is reserved

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -229,6 +229,7 @@ pub fn f() {}
 
 > [!NOTE]
 > `rustc` currently recognizes the tools "clippy", "rustfmt", "diagnostic", "miri" and "rust_analyzer".
+> Additionally, the `rustc` tool, and all tools starting with the literal string "rustc", are reserved for future extensions.
 
 r[attributes.builtin]
 ## Built-in attributes index


### PR DESCRIPTION
this section in the reference is not quite right; or at least is an incomplete summary. here is a more detailed explanation of what's currently implemented:

|Tool|Lints|Attributes|
|-|-|-|
|`clippy`|✅|✅|
|`rustfmt`|❌|✅|
|`miri`|❌|✅|
|`rust_analyzer`|❌|✅|
|`rustdoc`|✅|❌|
|`rustc`|✅ (with `-Z unstable-options`)|❌|
|`diagnostic`|❌|✅|

i'm not sure how to write that up, and it doesn't belong in the attributes section anyway, so i've just added this short snippet.

thanks to @BD103 for putting together the pretty markdown table.
cc https://github.com/rust-lang/rfcs/pull/3808