### PR TITLE
Explain why nested receivers are dyn-incompatible

### DIFF
--- a/src/items/traits.md
+++ b/src/items/traits.md
@@ -173,7 +173,7 @@ trait DynIncompatible {
     fn foo() {}  // ERROR: associated function without Sized
     fn returns(&self) -> Self; // ERROR: Self in return type
     fn typed<T>(&self, x: T) {} // ERROR: has generic type parameters
-    fn nested(self: Rc<Box<Self>>) {} // ERROR: nested receiver not yet supported
+    fn nested(self: Rc<Box<Self>>) {} // ERROR: nested receiver cannot be downcasted
 }
 
 struct S;


### PR DESCRIPTION
It's not true that they're not supported *yet* - fundamentally, it's not possible to downcast the inner pointer (i.e. removing its vtable) while it is stuck inside the outer pointer