### PR TITLE
`if let` guards documentation

### DIFF
--- a/src/destructors.md
+++ b/src/destructors.md
@@ -126,6 +126,15 @@ r[destructors.scope.nesting.match-arm]
 * The parent of the expression after the `=>` in a `match` expression is the
   scope of the arm that it's in.
 
+r[destructors.scope.nesting.match-guard-pattern]
+* The parent of an `if let` guard pattern is the scope of the guard expression.
+
+r[destructors.scope.nesting.match-guard-bindings]
+* Variables bound by `if let` guard patterns have their drop scope determined by
+  guard success:
+  - On guard failure: dropped immediately after guard evaluation
+  - On guard success: scope extends to the end of the match arm body
+
 r[destructors.scope.nesting.match]
 * The parent of the arm scope is the scope of the `match` expression that it
   belongs to.
@@ -204,8 +213,8 @@ smallest scope that contains the expression and is one of the following:
 * A statement.
 * The body of an [`if`], [`while`] or [`loop`] expression.
 * The `else` block of an `if` expression.
-* The non-pattern matching condition expression of an `if` or `while` expression,
-  or a `match` guard.
+* The condition expression of an `if` or `while` expression.
+* A `match` guard expression, including `if let` guard patterns.
 * The body expression for a match arm.
 * Each operand of a [lazy boolean expression].
 * The pattern-matching condition(s) and consequent body of [`if`] ([destructors.scope.temporary.edition2024]).
@@ -413,6 +422,58 @@ Here are some examples where expressions don't have extended temporary scopes:
 let x = Some(&temp());         // ERROR
 let x = (&temp()).use_temp();  // ERROR
 # x;
+```
+
+r[destructors.scope.match-guards]
+### Match Guards and Pattern Binding
+
+r[destructors.scope.match-guards.basic]
+Match guard expressions create their own temporary scope. Variables bound within
+guard patterns have conditional drop scopes based on guard evaluation results.
+
+r[destructors.scope.match-guards.if-let]
+For `if let` guards specifically:
+
+1. **Guard pattern evaluation**: The `if let` pattern is evaluated within the
+   guard's temporary scope.
+2. **Conditional binding scope**:
+   - If the pattern matches, bound variables extend their scope to the match arm body
+   - If the pattern fails, bound variables are dropped immediately
+3. **Temporary cleanup**: Temporaries created during guard evaluation are dropped
+   when the guard scope ends, regardless of pattern match success.
+
+r[destructors.scope.match-guards.multiple]
+For multiple guards connected by `&&`:
+- Each guard maintains its own temporary scope
+- Failed guards drop their bindings before subsequent guard evaluation
+- Only successful guard bindings are available in the arm body
+- Guards are evaluated left-to-right with short-circuit semantics
+
+```rust
+# struct PrintOnDrop(&'static str);
+# impl Drop for PrintOnDrop {
+#     fn drop(&mut self) {
+#         println!("drop({})", self.0);
+#     }
+# }
+# fn expensive_operation(x: i32) -> Option<PrintOnDrop> {
+#     Some(PrintOnDrop("expensive result"))
+# }
+
+match Some(42) {
+    // Guard creates temporary scope for pattern evaluation
+    Some(x) if let Some(y) = expensive_operation(x) => {
+        // Both x (from main pattern) and y (from guard) are live
+        // y will be dropped at end of this arm
+        println!("Success case");
+    } // y dropped here
+    Some(x) => {
+        // If guard failed, y was already dropped during guard evaluation
+        // expensive_operation result was also dropped
+        println!("Guard failed case");
+    }
+    None => {}
+}
 ```
 
 r[destructors.forget]

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -9,15 +9,25 @@ MatchExpression ->
         MatchArms?
     `}`
 
-Scrutinee -> Expression _except [StructExpression]_
+Scrutinee ->
+    Expression _except_ [StructExpression]
 
 MatchArms ->
     ( MatchArm `=>` ( ExpressionWithoutBlock `,` | ExpressionWithBlock `,`? ) )*
     MatchArm `=>` Expression `,`?
 
-MatchArm -> OuterAttribute* Pattern MatchArmGuard?
+MatchArm ->
+    OuterAttribute* Pattern MatchArmGuard?
 
-MatchArmGuard -> `if` Expression
+MatchArmGuard ->
+    `if` MatchConditions
+
+MatchConditions ->
+    MatchCondition ( `&&` MatchCondition )*
+
+MatchCondition ->
+      OuterAttribute* `let` Pattern `=` Scrutinee
+    | Expression
 ```
 <!-- TODO: The exception above isn't accurate, see https://github.com/rust-lang/reference/issues/569 -->
 
@@ -149,6 +159,93 @@ This allows shared borrows to be used inside guards without moving out of the sc
 
 r[expr.match.guard.no-mutation]
 Moreover, by holding a shared reference while evaluating the guard, mutation inside guards is also prevented.
+
+r[expr.match.if.let.guard]
+## If Let Guards
+Match arms can include `if let` guards to allow conditional pattern matching within the guard clause.
+
+r[expr.match.if.let.guard.syntax]
+```rust,ignore
+match expression {
+    pattern if let subpattern = guard_expr => arm_body,
+    ...
+}
+```
+Here, `guard_expr` is evaluated and matched against `subpattern`. If the `if let` expression in the guard matches successfully, the arm's body is executed. Otherwise, pattern matching continues to the next arm.
+
+r[expr.match.if.let.guard.behavior]
+When the pattern matches successfully, the `if let` expression in the guard is evaluated:
+  * The guard proceeds if the inner pattern (`subpattern`) matches the result of `guard_expr`.
+  * Otherwise, the next arm is tested.
+
+```rust,ignore
+let value = Some(10);
+
+let msg = match value {
+    Some(x) if let Some(y) = Some(x - 1) => format!("Matched inner value: {}", y),
+    _ => "No match".to_string(),
+};
+```
+
+r[expr.match.if.let.guard.scope]
+* The `if let` guard may refer to variables bound by the outer match pattern.
+* New variables bound inside the `if let` guard (e.g., `y` in the example above) are available within the body of the match arm where the guard evaluates to `true`, but are not accessible in other arms or outside the match expression.
+
+```rust,ignore
+let opt = Some(42);
+
+match opt {
+    Some(x) if let Some(y) = Some(x + 1) => {
+        // Both `x` and `y` are available in this arm,
+        // since the pattern matched and the guard evaluated to true.
+        println!("x = {}, y = {}", x, y);
+    }
+    _ => {
+        // `y` is not available here --- it was only bound inside the guard above.
+        // Uncommenting the line below will cause a compile-time error:
+        // println!("{}", y); // error: cannot find value `y` in this scope
+    }
+}
+
+// Outside the match expression, neither `x` nor `y` are in scope.
+```
+
+* The outer pattern variables (`x`) follow the same borrowing behavior as in standard match guards (see below).
+
+r[expr.match.if.let.guard.drop]
+
+* Variables bound inside `if let` guards are dropped before evaluating subsequent match arms.
+
+* Temporaries created during guard evaluation follow standard drop semantics and are cleaned up appropriately.
+
+r[expr.match.if.let.guard.borrowing]
+Variables bound by the outer pattern follow the same borrowing rules as standard match guards:
+* A shared reference is taken to pattern variables before guard evaluation
+* Values are moved or copied only when the guard succeeds
+* Moving from outer pattern variables within the guard is restricted
+
+```rust,ignore
+fn take<T>(value: T) -> Option<T> { Some(value) }
+
+let val = Some(vec![1, 2, 3]);
+match val {
+    Some(v) if let Some(_) = take(v) => "moved", // ERROR: cannot move `v`
+    Some(v) if let Some(_) = take(v.clone()) => "cloned", // OK
+    _ => "none",
+}
+```
+> [!NOTE]
+> Multiple matches using the `|` operator can cause the pattern guard and the side effects it has to execute multiple times. For example:
+> ```rust,ignore
+> use std::cell::Cell;
+>
+> let i: Cell<i32> = Cell::new(0);
+> match 1 {
+>     1 | _ if let Some(_) = { i.set(i.get() + 1); Some(1) } => {}
+>     _ => {}
+> }
+> assert_eq!(i.get(), 2); // Guard is executed twice
+> ```
 
 r[expr.match.attributes]
 ## Attributes on match arms

--- a/src/names/scopes.md
+++ b/src/names/scopes.md
@@ -54,8 +54,8 @@ r[names.scopes.pattern-bindings.let-chains]
 * [`if let`] and [`while let`] bindings are valid in the following conditions as well as the consequent block.
 r[names.scopes.pattern-bindings.match-arm]
 * [`match` arms] bindings are within the [match guard] and the match arm expression.
-r[names.scopes.pattern-bindings.match-guard-if-let]
-* [`if let` guard] bindings are within the guard expression and the match arm expression if the guard succeeds.
+r[names.scopes.pattern-bindings.match-guard-let]
+* [`match` guard `let`] bindings are valid in the following guard conditions and the match arm expression if the guard succeeds.
 
 r[names.scopes.pattern-bindings.items]
 Local variable scopes do not extend into item declarations.
@@ -349,7 +349,7 @@ impl ImplExample {
 [`macro_use` prelude]: preludes.md#macro_use-prelude
 [`macro_use`]: ../macros-by-example.md#the-macro_use-attribute
 [`match` arms]: ../expressions/match-expr.md
-[`if let` guard]: ../expressions/match-expr.md#if-let-guards
+[`match` guard `let`]: expr.match.guard.let
 [`Self`]: ../paths.md#self-1
 [Associated consts]: ../items/associated-items.md#associated-constants
 [associated items]: ../items/associated-items.md

--- a/src/names/scopes.md
+++ b/src/names/scopes.md
@@ -54,6 +54,8 @@ r[names.scopes.pattern-bindings.let-chains]
 * [`if let`] and [`while let`] bindings are valid in the following conditions as well as the consequent block.
 r[names.scopes.pattern-bindings.match-arm]
 * [`match` arms] bindings are within the [match guard] and the match arm expression.
+r[names.scopes.pattern-bindings.match-guard-if-let]
+* [`if let` guard] bindings are within the guard expression and the match arm expression if the guard succeeds.
 
 r[names.scopes.pattern-bindings.items]
 Local variable scopes do not extend into item declarations.
@@ -347,6 +349,7 @@ impl ImplExample {
 [`macro_use` prelude]: preludes.md#macro_use-prelude
 [`macro_use`]: ../macros-by-example.md#the-macro_use-attribute
 [`match` arms]: ../expressions/match-expr.md
+[`if let` guard]: ../expressions/match-expr.md#if-let-guards
 [`Self`]: ../paths.md#self-1
 [Associated consts]: ../items/associated-items.md#associated-constants
 [associated items]: ../items/associated-items.md


### PR DESCRIPTION
It’s been a while since the original PR for `if let` guards was opened, so I decided to take the initiative and push it a bit closer to stabilization

This PR adds some documentation — I did my best to keep it consistent with the existing docs on `if` guards
There might still be some rough edges or small inaccuracies, so feel free to point them out

It’s also my first time contributing to the docs, so any feedback is appreciated!

Tracking issue rust-lang/rust#51114
Stabilization: https://github.com/rust-lang/rust/pull/141295

[rendered](https://github.com/rust-lang/reference/blob/19de488bde270f1e336eb7fca07336ef7b5353a5/src/expressions/match-expr.md#if-let-guards)