### PR TITLE
Parse optionals and repeats without regexes

### DIFF
--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -232,7 +232,7 @@ r[items.generics.where]
 
 r[items.generics.where.syntax]
 ```grammar,items
-WhereClause -> `where` ( WhereClauseItem `,` )* WhereClauseItem ?
+WhereClause -> `where` ( WhereClauseItem `,` )* WhereClauseItem?
 
 WhereClauseItem ->
       LifetimeWhereClauseItem

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -181,7 +181,7 @@ r[patterns.ident]
 
 r[patterns.ident.syntax]
 ```grammar,patterns
-IdentifierPattern -> `ref`? `mut`? IDENTIFIER (`@` PatternNoTopAlt ) ?
+IdentifierPattern -> `ref`? `mut`? IDENTIFIER ( `@` PatternNoTopAlt )?
 ```
 
 r[patterns.ident.intro]
@@ -704,7 +704,7 @@ r[patterns.struct.syntax]
 ```grammar,patterns
 StructPattern ->
     PathInExpression `{`
-        StructPatternElements ?
+        StructPatternElements?
     `}`
 
 StructPatternElements ->


### PR DESCRIPTION
Rather than parsing optionals and repeats fully in the recursive descent style, we were using regular expressions to do part of the matching and parsing.  That's fine for what it is, but as we think about extending the grammar language surrounding repeats further, it might be more straightforward for this to be parsed in the more usual way.  So let's do that.  Doing this also results in better and more targeted errors when parsing malformed syntax.

We had been supporting a space between an expression and the optional and repeat sigils `?`, `*`, and `+` (but not between an expression and the `{a..b}` ranged repeat syntax).  In making this change, we drop this support and adjust the affected productions.  We were only using this in a handful of places, and the clarity of the productions seem the same or better by removing these spaces.

We verified that, setting aside the removal of these spaces, the rendered output of the Reference is byte identical before and after this change.

cc @ehuss