### PR TITLE
Add doc for keylocker target features

### DIFF
--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -217,6 +217,7 @@ Feature     | Implicitly Enables | Description
 `fma`       | `avx`    | [FMA3] --- Three-operand fused multiply-add
 `fxsr`      |          | [`fxsave`] and [`fxrstor`] --- Save and restore x87 FPU, MMX Technology, and SSE State
 `gfni`      | `sse2`   | [GFNI] --- Galois Field New Instructions
+`kl`        | `sse2`   | [KEYLOCKER] --- Intel Key Locker Instructions
 `lzcnt`     |          | [`lzcnt`] --- Leading zeros count
 `movbe`     |          | [`movbe`] --- Move data after swapping bytes
 `pclmulqdq` | `sse2`   | [`pclmulqdq`] --- Packed carry-less multiplication quadword
@@ -232,6 +233,7 @@ Feature     | Implicitly Enables | Description
 `ssse3`     | `sse3`   | [SSSE3] --- Supplemental Streaming SIMD Extensions 3
 `vaes`      | `avx2`, `aes`     | [VAES] --- Vector AES Instructions
 `vpclmulqdq`| `avx`, `pclmulqdq`| [VPCLMULQDQ] --- Vector Carry-less multiplication of Quadwords
+`widekl`    | `kl`     | [KEYLOCKER_WIDE] --- Intel Wide Keylocker Instructions
 `xsave`     |          | [`xsave`] --- Save processor extended states
 `xsavec`    |          | [`xsavec`] --- Save processor extended states with compaction
 `xsaveopt`  |          | [`xsaveopt`] --- Save processor extended states optimized
@@ -270,6 +272,8 @@ Feature     | Implicitly Enables | Description
 [`fxsave`]: https://www.felixcloutier.com/x86/fxsave
 [`fxrstor`]: https://www.felixcloutier.com/x86/fxrstor
 [GFNI]: https://en.wikipedia.org/wiki/AVX-512#GFNI
+[KEYLOCKER]: https://en.wikipedia.org/wiki/List_of_x86_cryptographic_instructions#Intel_Key_Locker_instructions
+[KEYLOCKER_WIDE]: https://en.wikipedia.org/wiki/List_of_x86_cryptographic_instructions#Intel_Key_Locker_instructions
 [`lzcnt`]: https://www.felixcloutier.com/x86/lzcnt
 [`movbe`]: https://www.felixcloutier.com/x86/movbe
 [`pclmulqdq`]: https://www.felixcloutier.com/x86/pclmulqdq


### PR DESCRIPTION
Adds some docs for the target features `kl` and `widekl`, in lieu of the stabilization PR at rust-lang/rust#140766 and rust-lang/stdarch#1795.

Also, please lmk if anyone finds a better link for them, the wikipedia page is not _too_ good.

@rustbot label S-waiting-on-stabilization