### PR TITLE
triagebot: enable issue transfer

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -5,6 +5,8 @@ allow-unauthenticated = [
 
 [assign]
 
+[transfer]
+
 [shortcut]
 
 [no-mentions]


### PR DESCRIPTION
I believe it was already possible to transfer issues into the reference repo without this, but this will allow transferring issues both ways.

Issue transfer is still only available to members of teams and certain working groups.

https://forge.rust-lang.org/triagebot/transfer.html