### PR TITLE
Document how closure capturing interacts with discriminant reads

### DIFF
--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -288,7 +288,11 @@ let c = || {
 r[type.closure.capture.precision.discriminants]
 ### Capturing for discriminant reads
 
-If pattern matching requires inspecting a discriminant, the relevant place will get captured by `ImmBorrow`.
+r[type.closure.capture.precision.discriminants.reads]
+If pattern matching reads a discriminant, the place containing that discriminant is captured by `ImmBorrow`.
+
+r[type.closure.capture.precision.discriminants.multiple-variant]
+Matching against a variant of an enum that has more than one variant reads the discriminant, capturing the place by `ImmBorrow`.
 
 ```rust
 enum Example {

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -354,14 +354,14 @@ c();
 ```
 
 r[type.closure.capture.precision.discriminants.range-patterns]
-Matching against a [range pattern][patterns.range] performs a read of the place being matched, causing the closure to borrow it by `ImmBorrow`. This is the case even if the range matches all possible values.
+Matching against a [range pattern][patterns.range] reads the place being matched, even if the range includes all possible values of the type, and captures the place by `ImmBorrow`.
 
-```rust,compile_fail,E0506
-let mut x = 7_u8;
+```rust,compile_fail,E0502
+let mut x = 0u8;
 let c = || {
-    let 0..=u8::MAX = x; // captures `x` by ImmBorrow
+    let 0..=u8::MAX = x; // Captures `x` by `ImmBorrow`.
 };
-x += 1; // ERROR: cannot assign to `x` because it is borrowed
+let _ = &mut x; // ERROR: Cannot borrow `x` as mutable.
 c();
 ```
 

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -338,9 +338,7 @@ c();
 ```
 
 r[type.closure.capture.precision.discriminants.non_exhaustive]
-If [the `#[non_exhaustive]` attribute][non_exhaustive] is applied to an enum defined in an external crate, it is considered to have multiple variants, even if only one variant is actually present.
-
-[non_exhaustive]: attributes.type-system.non_exhaustive
+If [`#[non_exhaustive]`][attributes.type-system.non_exhaustive] is applied to an enum defined in an external crate, the enum is treated as having multiple variants for the purpose of deciding whether a read occurs, even if it actually has only one variant.
 
 r[type.closure.capture.precision.discriminants.uninhabited-variant]
 Even if all other variants are uninhabited, the discriminant read still occurs.

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -186,9 +186,8 @@ If this were to capture `m`, then the closure would no longer outlive `'static`,
 r[type.closure.capture.precision.wildcard]
 ### Wildcard pattern bindings
 
-Closures only capture data that needs to be read.
-Binding a value with a [wildcard pattern] does not count as a read, and thus won't be captured.
-For example, the following closures will not capture `x`:
+r[type.closure.capture.precision.wildcard.reads]
+Closures only capture data that needs to be read. Binding a value with a [wildcard pattern] does not read the value, so the place is not captured.
 
 ```rust
 let x = String::from("hello");

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -340,22 +340,16 @@ c();
 r[type.closure.capture.precision.discriminants.non_exhaustive]
 If [`#[non_exhaustive]`][attributes.type-system.non_exhaustive] is applied to an enum defined in an external crate, the enum is treated as having multiple variants for the purpose of deciding whether a read occurs, even if it actually has only one variant.
 
-r[type.closure.capture.precision.discriminants.uninhabited-variant]
-Even if all other variants are uninhabited, the discriminant read still occurs.
+r[type.closure.capture.precision.discriminants.uninhabited-variants]
+Even if all variants but the one being matched against are uninhabited, making the pattern [irrefutable][patterns.refutable], the discriminant is still read if it otherwise would be.
 
-```rust,compile_fail,E0506
-enum Void {}
-
-enum Example {
-    A(i32),
-    B(Void),
-}
-
-let mut x = Example::A(42);
+```rust,compile_fail,E0502
+enum Empty {}
+let mut x = Ok::<_, Empty>(42);
 let c = || {
-    let Example::A(_) = x; // captures `x` by ImmBorrow
+    let Ok(_) = x; // Captures `x` by `ImmBorrow`.
 };
-x = Example::A(57); // ERROR: cannot assign to `x` because it is borrowed
+let _ = &mut x; // ERROR: Cannot borrow `x` as mutable.
 c();
 ```
 

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -205,6 +205,9 @@ c();
 r[type.closure.capture.precision.wildcard.destructuring]
 Destructuring tuples, structs, and single-variant enums does not, by itself, cause a read or the place to be captured.
 
+> [!NOTE]
+> Enums marked with [`#[non_exhaustive]`][attributes.type-system.non_exhaustive] from other crates are always treated as having multiple variants. See *[type.closure.capture.precision.discriminants.non_exhaustive]*.
+
 ```rust,no_run
 struct S; // A non-`Copy` type.
 

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -202,6 +202,7 @@ let c = || match x {  // x is not captured
 c();
 ```
 
+r[type.closure.capture.precision.wildcard.destructuring]
 Destructuring tuples, structs, and single-variant enums does not, by itself, cause a read or the place to be captured.
 
 ```rust,no_run

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -342,7 +342,7 @@ x = Example::A(57); // `x` can be modified while the closure is live
 c();
 ```
 
-r[type.closure.capture.precision.discriminants.non-exhaustive]
+r[type.closure.capture.precision.discriminants.non_exhaustive]
 If [the `#[non_exhaustive]` attribute][non_exhaustive] is applied to an enum defined in an external crate, it is considered to have multiple variants, even if only one variant is actually present.
 
 [non_exhaustive]: attributes.type-system.non_exhaustive

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -98,12 +98,10 @@ Async closures always capture all input arguments, regardless of whether or not 
 ## Capture precision
 
 r[type.closure.capture.precision.capture-path]
-A *capture path* is a sequence starting with a variable from the environment followed by zero or more place projections that were applied to that variable, as well as any [further projections performed by matching against patterns][pattern-wildcards].
-
-[pattern-wildcards]: type.closure.capture.precision.wildcard
+A *capture path* is a sequence starting with a variable from the environment followed by zero or more place projections from that variable.
 
 r[type.closure.capture.precision.place-projection]
-A *place projection* is a [field access], [tuple index], [dereference] (and automatic dereferences), or [array or slice index] expression applied to a variable.
+A *place projection* is a [field access], [tuple index], [dereference] (and automatic dereferences), [array or slice index] expression, or [pattern destructuring] applied to a variable.
 
 r[type.closure.capture.precision.intro]
 The closure borrows or moves the capture path, which may be truncated based on the rules described below.
@@ -126,6 +124,7 @@ Here the capture path is the local variable `s`, followed by a field access `.f1
 This closure captures an immutable borrow of `s.f1.1`.
 
 [field access]: ../expressions/field-expr.md
+[pattern destructuring]: patterns.destructure
 [tuple index]: ../expressions/tuple-expr.md#tuple-indexing-expressions
 [dereference]: ../expressions/operator-expr.md#the-dereference-operator
 [array or slice index]: ../expressions/array-expr.md#array-and-slice-indexing-expressions

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -247,6 +247,7 @@ x; // OK: `x` can be moved here.
 c();
 ```
 
+r[type.closure.capture.precision.wildcard.fields]
 Fields matched against [RestPattern] (`..`) or [StructPatternEtCetera] (also `..`) are not read, and those fields are not captured.
 
 ```rust

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -135,7 +135,7 @@ This closure captures an immutable borrow of `s.f1.1`.
 r[type.closure.capture.precision.shared-prefix]
 ### Shared prefix
 
-In the case where a capture path and one of the ancestor’s of that path are both captured by a closure, the ancestor path is captured with the highest capture mode among the two captures, `CaptureMode = max(AncestorCaptureMode, DescendantCaptureMode)`, using the strict weak ordering:
+In the case where a capture path and one of the ancestors of that path are both captured by a closure, the ancestor path is captured with the highest capture mode among the two captures, `CaptureMode = max(AncestorCaptureMode, DescendantCaptureMode)`, using the strict weak ordering:
 
 `ImmBorrow < UniqueImmBorrow < MutBorrow < ByValue`
 

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -282,7 +282,6 @@ c();
 
 r[type.closure.capture.precision.wildcard.array-slice]
 Partial captures of arrays and slices are not supported; the entire slice or array is always captured even if used with wildcard pattern matching, indexing, or sub-slicing.
-For example:
 
 ```rust,compile_fail,E0382
 #[derive(Debug)]

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -103,6 +103,9 @@ A *capture path* is a sequence starting with a variable from the environment fol
 r[type.closure.capture.precision.place-projection]
 A *place projection* is a [field access], [tuple index], [dereference] (and automatic dereferences), [array or slice index] expression, or [pattern destructuring] applied to a variable.
 
+> [!NOTE]
+> In `rustc`, pattern destructuring desugars into a series of dereferences and field or element accesses.
+
 r[type.closure.capture.precision.intro]
 The closure borrows or moves the capture path, which may be truncated based on the rules described below.
 

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -325,18 +325,15 @@ c();
 ```
 
 r[type.closure.capture.precision.discriminants.single-variant]
-Matching against the only variant of an enum does not constitute a discriminant read.
+Matching against the only variant of a single-variant enum does not read the discriminant and does not capture the place.
 
-```rust
-enum Example {
-    A(i32),
-}
-
-let mut x = Example::A(42);
+```rust,no_run
+enum E<T> { V(T) } // A single-variant enum.
+let x = E::V(());
 let c = || {
-    let Example::A(_) = x; // does not capture `x`
+    let E::V(_) = x; // Does not capture `x`.
 };
-x = Example::A(57); // `x` can be modified while the closure is live
+x; // OK: `x` can be moved here.
 c();
 ```
 

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -203,6 +203,46 @@ c();
 ```
 
 This also includes destructuring of tuples, structs, and single-variant enums.
+
+```rust,no_run
+struct S; // A non-`Copy` type.
+
+// Destructuring tuples does not cause a read or capture.
+let x = (S,);
+let c = || {
+    let (..) = x; // Does not capture `x`.
+};
+x; // OK: `x` can be moved here.
+c();
+
+// Destructuring unit structs does not cause a read or capture.
+let x = S;
+let c = || {
+    let S = x; // Does not capture `x`.
+};
+x; // OK: `x` can be moved here.
+c();
+
+// Destructuring structs does not cause a read or capture.
+struct W<T>(T);
+let x = W(S);
+let c = || {
+    let W(..) = x; // Does not capture `x`.
+};
+x; // OK: `x` can be moved here.
+c();
+
+// Destructuring single-variant enums does not cause a read
+// or capture.
+enum E<T> { V(T) }
+let x = E::V(S);
+let c = || {
+    let E::V(..) = x; // Does not capture `x`.
+};
+x; // OK: `x` can be moved here.
+c();
+```
+
 Fields matched with the [RestPattern] or [StructPatternEtCetera] are also not considered as read, and thus those fields will not be captured.
 The following illustrates some of these:
 

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -98,8 +98,7 @@ Async closures always capture all input arguments, regardless of whether or not 
 ## Capture precision
 
 r[type.closure.capture.precision.capture-path]
-A *capture path* is a sequence starting with a variable from the environment followed by zero or more place projections that were applied to that variable, as well as
-any [further projections performed by matching against patterns][pattern-wildcards].
+A *capture path* is a sequence starting with a variable from the environment followed by zero or more place projections that were applied to that variable, as well as any [further projections performed by matching against patterns][pattern-wildcards].
 
 [pattern-wildcards]: type.closure.capture.precision.wildcard
 
@@ -305,9 +304,7 @@ c();
 ```
 
 r[type.closure.capture.precision.discriminants.non-exhaustive]
-If [the `#[non_exhaustive]` attribute][non_exhaustive] is applied to an enum
-defined in an external crate, it is considered to have multiple variants,
-even if only one variant is actually present.
+If [the `#[non_exhaustive]` attribute][non_exhaustive] is applied to an enum defined in an external crate, it is considered to have multiple variants, even if only one variant is actually present.
 
 [non_exhaustive]: attributes.type-system.non_exhaustive
 
@@ -331,8 +328,7 @@ c();
 ```
 
 r[type.closure.capture.precision.discriminants.range-patterns]
-Matching against a [range pattern][patterns.range] constitutes a discriminant read, even if
-the range matches all possible values.
+Matching against a [range pattern][patterns.range] performs a read of the place being matched, causing the closure to borrow it by `ImmBorrow`. This is the case even if the range matches all possible values.
 
 ```rust,compile_fail,E0506
 let mut x = 7_u8;
@@ -344,11 +340,10 @@ c();
 ```
 
 r[type.closure.capture.precision.discriminants.slice-patterns]
-Matching against a [slice pattern][patterns.slice] constitutes a discriminant read if
-the slice pattern needs to inspect the length of the scrutinee.
+Matching against a [slice pattern][patterns.slice] performs a read if the slice pattern needs to inspect the length of the scrutinee. The read will cause the closure to borrow the relevant place by `ImmBorrow`.
 
 ```rust,compile_fail,E0506
-let mut x: &mut [i32] = &mut [1, 2, 3];
+let x: &mut [i32] = &mut [1, 2, 3];
 let c = || match x { // captures `*x` by ImmBorrow
     [_, _, _] => println!("three elements"),
     _ => println!("something else"),
@@ -357,7 +352,7 @@ x[0] += 1; // ERROR: cannot assign to `x[_]` because it is borrowed
 c();
 ```
 
-Thus, matching against an array doesn't constitute a discriminant read, as the length is fixed.
+As such, matching against an array doesn't itself cause any borrows, as the lengthh is fixed and doesn't need to be read.
 
 ```rust
 let mut x: [i32; 3] = [1, 2, 3];
@@ -368,10 +363,10 @@ x[0] += 1; // `x` can be modified while the closure is live
 c();
 ```
 
-Likewise, a slice pattern that matches slices of all possible lengths does not constitute a discriminant read.
+Likewise, a slice pattern that matches slices of all possible lengths does not constitute a read.
 
 ```rust
-let mut x: &mut [i32] = &mut [1, 2, 3];
+let x: &mut [i32] = &mut [1, 2, 3];
 let c = || match x { // does not capture `x`
     [..] => println!("always matches"),
 };

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -202,7 +202,7 @@ let c = || match x {  // x is not captured
 c();
 ```
 
-This also includes destructuring of tuples, structs, and single-variant enums.
+Destructuring tuples, structs, and single-variant enums does not, by itself, cause a read or the place to be captured.
 
 ```rust,no_run
 struct S; // A non-`Copy` type.

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -247,8 +247,7 @@ x; // OK: `x` can be moved here.
 c();
 ```
 
-Fields matched with the [RestPattern] or [StructPatternEtCetera] are also not considered as read, and thus those fields will not be captured.
-The following illustrates some of these:
+Fields matched against [RestPattern] (`..`) or [StructPatternEtCetera] (also `..`) are not read, and those fields are not captured.
 
 ```rust
 let x = (String::from("a"), String::from("b"));

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -353,7 +353,11 @@ let _ = &mut x; // ERROR: Cannot borrow `x` as mutable.
 c();
 ```
 
-r[type.closure.capture.precision.discriminants.range-patterns]
+
+r[type.closure.capture.precision.range-patterns]
+### Capturing and range patterns
+
+r[type.closure.capture.precision.range-patterns.reads]
 Matching against a [range pattern][patterns.range] reads the place being matched, even if the range includes all possible values of the type, and captures the place by `ImmBorrow`.
 
 ```rust,compile_fail,E0502
@@ -365,7 +369,10 @@ let _ = &mut x; // ERROR: Cannot borrow `x` as mutable.
 c();
 ```
 
-r[type.closure.capture.precision.discriminants.slice-patterns-slices]
+r[type.closure.capture.precision.slice-patterns]
+### Capturing and slice patterns
+
+r[type.closure.capture.precision.slice-patterns.slices]
 Matching a slice against a [slice pattern][patterns.slice] other than one with only a single [rest pattern][patterns.rest] (i.e. `[..]`) is treated as a read of the length from the slice and captures the slice by `ImmBorrow`.
 
 ```rust,compile_fail,E0502
@@ -392,7 +399,7 @@ let _ = &mut *x; // OK: `*x` can be borrow here.
 c();
 ```
 
-r[type.closure.capture.precision.discriminants.slice-patterns-arrays]
+r[type.closure.capture.precision.slice-patterns.arrays]
 As the length of an array is fixed by its type, matching an array against a slice pattern does not by itself capture the place.
 
 ```rust,no_run

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -340,7 +340,7 @@ c();
 ```
 
 r[type.closure.capture.precision.discriminants.slice-patterns]
-Matching against a [slice pattern][patterns.slice] performs a read if the slice pattern needs to inspect the length of the scrutinee. The read will cause the closure to borrow the relevant place by `ImmBorrow`.
+Matching against a [slice pattern][patterns.slice] that needs to inspect the length of the scrutinee performs a read of the pointer value in order to fetch the length. The read will cause the closure to borrow the relevant place by `ImmBorrow`.
 
 ```rust,compile_fail,E0506
 let x: &mut [i32] = &mut [1, 2, 3];
@@ -352,7 +352,7 @@ x[0] += 1; // ERROR: cannot assign to `x[_]` because it is borrowed
 c();
 ```
 
-As such, matching against an array doesn't itself cause any borrows, as the lengthh is fixed and doesn't need to be read.
+As such, matching against an array doesn't itself cause any borrows, as the lengthh is fixed and the pattern doesn't need to inspect it.
 
 ```rust
 let mut x: [i32; 3] = [1, 2, 3];

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -261,25 +261,6 @@ println!("{:?}", x.1);
 c();
 ```
 
-```rust
-struct Example {
-    f1: String,
-    f2: String,
-}
-
-let e = Example {
-    f1: String::from("first"),
-    f2: String::from("second"),
-};
-let c = || {
-    let Example { f2, .. } = e; // captures `e.f2` ByValue
-};
-// Field f2 cannot be accessed since it is moved into the closure.
-// Field f1 is still accessible.
-println!("{:?}", e.f1);
-c();
-```
-
 r[type.closure.capture.precision.wildcard.array-slice]
 Partial captures of arrays and slices are not supported; the entire slice or array is always captured even if used with wildcard pattern matching, indexing, or sub-slicing.
 


### PR DESCRIPTION
This is the behavior after the bugfixes in rust-lang/rust#138961. I have successfully ran `mdbook test` with `RUSTUP_TOOLCHAIN` pointed at a stage1 built on top of the aforementioned PR – until it's merged, the CI here will fail.