### PR TITLE
remove the `safe` keyword from a c-variadic foreign function.

### DIFF
--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -176,7 +176,7 @@ identifier.
 
 ```rust
 unsafe extern "C" {
-    safe fn foo(...);
+    unsafe fn foo(...);
     unsafe fn bar(x: i32, ...);
     unsafe fn with_name(format: *const u8, args: ...);
 }


### PR DESCRIPTION
Calling a c-variadic function is never safe: passing an unexpected number of arguments, or arguments of an unexpected type, is UB.

As requested in https://github.com/rust-lang/rust/pull/141733#issuecomment-2935156116, cc @ehuss 