### PR TITLE
add a warning about using `safe` on extern c-variadic functions

### DIFF
--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -179,12 +179,14 @@ unsafe extern "C" {
     unsafe fn foo(...);
     unsafe fn bar(x: i32, ...);
     unsafe fn with_name(format: *const u8, args: ...);
+    // SAFETY: This function guarantees it will not access
+    // variadic arguments.
     safe fn ignores_variadic_arguments(x: i32, ...);
 }
 ```
 
 > [!WARNING]
-> `safe` should only be used in cases where the function does not look at the variadic arguments at all. Passing an unexpected number of arguments or arguments of an unexpected type to a variadic function is [undefined behavior][undefined].
+> The `safe` qualifier should not be used on a function in an `extern` block unless that function guarantees that it will not access the variadic arguments at all. Passing an unexpected number of arguments or arguments of unexpected type to a variadic function may lead to [undefined behavior][undefined].
 
 r[items.extern.attributes]
 ## Attributes on extern blocks

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -179,8 +179,12 @@ unsafe extern "C" {
     unsafe fn foo(...);
     unsafe fn bar(x: i32, ...);
     unsafe fn with_name(format: *const u8, args: ...);
+    safe fn ignores_variadic_arguments(x: i32, ...);
 }
 ```
+
+> [!WARNING]
+> `safe` should only be used in cases where the function does not look at the variadic arguments at all. Passing an unexpected number of arguments or arguments of an unexpected type to a variadic function is [undefined behavior][undefined].
 
 r[items.extern.attributes]
 ## Attributes on extern blocks


### PR DESCRIPTION
edit: the lang team found an edge case. 

An extern c-variadic function can be marked as safe when it does not look at its arguments at all. That is not very useful, but technically allowed. 

So, I've now added a warning with this information to the section on extern c-variadic functions.

