### PR TITLE
&str and &[u8] have the same layout

### DIFF
--- a/src/dynamically-sized-types.md
+++ b/src/dynamically-sized-types.md
@@ -2,11 +2,7 @@ r[dynamic-sized]
 # Dynamically Sized Types
 
 r[dynamic-sized.intro]
-Most types have a fixed size that is known at compile time and implement the
-trait [`Sized`][sized]. A type with a size that is known only at run-time is
-called a _dynamically sized type_ (_DST_) or, informally, an unsized type.
-[Slices], [trait objects], and [str] are three examples of <abbr title="dynamically sized
-types">DSTs</abbr>.
+Most types have a fixed size that is known at compile time and implement the trait [`Sized`][sized]. A type with a size that is known only at run-time is called a _dynamically sized type_ (_DST_) or, informally, an unsized type.  [Slices], [trait objects], and [str] are examples of <abbr title="dynamically sized types">DSTs</abbr>.
 
 r[dynamic-sized.restriction]
 Such types can only be used in certain cases:
@@ -14,7 +10,7 @@ Such types can only be used in certain cases:
 r[dynamic-sized.pointer-types]
 * [Pointer types] to <abbr title="dynamically sized types">DSTs</abbr> are
   sized but have twice the size of pointers to sized types
-    * Pointers to slices and `str` also store the number of elements of the slice.
+    * Pointers to slices and `str` also store the number of elements.
     * Pointers to trait objects also store a pointer to a vtable.
 
 r[dynamic-sized.question-sized]

--- a/src/dynamically-sized-types.md
+++ b/src/dynamically-sized-types.md
@@ -5,7 +5,7 @@ r[dynamic-sized.intro]
 Most types have a fixed size that is known at compile time and implement the
 trait [`Sized`][sized]. A type with a size that is known only at run-time is
 called a _dynamically sized type_ (_DST_) or, informally, an unsized type.
-[Slices] and [trait objects] are two examples of <abbr title="dynamically sized
+[Slices], [trait objects], and [str] are three examples of <abbr title="dynamically sized
 types">DSTs</abbr>.
 
 r[dynamic-sized.restriction]
@@ -14,7 +14,7 @@ Such types can only be used in certain cases:
 r[dynamic-sized.pointer-types]
 * [Pointer types] to <abbr title="dynamically sized types">DSTs</abbr> are
   sized but have twice the size of pointers to sized types
-    * Pointers to slices also store the number of elements of the slice.
+    * Pointers to slices and `str` also store the number of elements of the slice.
     * Pointers to trait objects also store a pointer to a vtable.
 
 r[dynamic-sized.question-sized]
@@ -38,6 +38,7 @@ r[dynamic-sized.struct-field]
 
 [sized]: special-types-and-traits.md#sized
 [Slices]: types/slice.md
+[str]: types/textual.md
 [trait objects]: types/trait-object.md
 [Pointer types]: types/pointer.md
 [Variables]: variables.md

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -110,6 +110,7 @@ r[layout.str]
 ## `str` Layout
 
 String slices are a UTF-8 representation of characters that have the same layout as slices of type `[u8]`.
+A reference `&str` has the same layout as a reference `&[u8]`.
 
 r[layout.tuple]
 ## Tuple Layout

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -109,8 +109,7 @@ Slices have the same layout as the section of the array they slice.
 r[layout.str]
 ## `str` Layout
 
-String slices are a UTF-8 representation of characters that have the same layout as slices of type `[u8]`.
-A reference `&str` has the same layout as a reference `&[u8]`.
+String slices are a UTF-8 representation of characters that have the same layout as slices of type `[u8]`. A reference `&str` has the same layout as a reference `&[u8]`.
 
 r[layout.tuple]
 ## Tuple Layout

--- a/src/types/textual.md
+++ b/src/types/textual.md
@@ -23,7 +23,8 @@ is valid UTF-8. Calling a `str` method with a non-UTF-8 buffer can cause
 
 r[type.text.str-unsized]
 Since `str` is a [dynamically sized type], it can only be instantiated through a
-pointer type, such as `&str`.
+pointer type, such as `&str`. The layout of `&str` is the same as the layout of
+`&[u8]`.
 
 r[type.text.layout]
 ## Layout and bit validity


### PR DESCRIPTION
Currently, `str` and `[u8]` are promised to have the same layout, but `&str` and `&[u8]` are **not** promised to have the same layout. The std currently assumes that they *are* promised to have the same layout (https://doc.rust-lang.org/src/core/str/converts.rs.html#172), so this change would have no impact beyond codifying what is already in practice. This PR defines `&str` and `&[u8]` to have the same layout, though what that layout is continues to be unspecified.

There are some further steps here that I didn't take:

1. Every rule about slices should probably also apply to `str`. I have added `str` in several places in the reference where it otherwise refered to slices, but likely the definition of a slice should also simply include `str`. This is a bigger conversation and frankly unimportant if...
2. Some version of https://github.com/rust-lang/rust/pull/107939 ever getts stabilized. In that case, all of this doesn't matter and `str` would be removed from the reference. This seems to me to be obviously the better choice.

In any case, this PR represents a fairly incrementalist approach.

Thanks for the insight of those on the Zulip thread [here](https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/Layout.20of.20Fat.20Pointer.20to.20Slice.2Fstr/near/522912141)