### PR TITLE
Fix recursive root-accessible grammar check

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -115,7 +115,7 @@ attributes]. It has the following grammar:
 
 r[attributes.meta.syntax]
 ```grammar,attributes
-MetaItem ->
+@root MetaItem ->
       SimplePath
     | SimplePath `=` Expression
     | SimplePath `(` MetaSeq? `)`

--- a/src/comments.md
+++ b/src/comments.md
@@ -30,7 +30,7 @@ OUTER_BLOCK_DOC ->
       ( BlockCommentOrDoc | ~[`*/` CR] )*
     `*/`
 
-BlockCommentOrDoc ->
+@root BlockCommentOrDoc ->
       BLOCK_COMMENT
     | OUTER_BLOCK_DOC
     | INNER_BLOCK_DOC


### PR DESCRIPTION
This fixes a bug in how the `@root` grammar validation was done. It was not properly handling recursive rules because when walking the tree it would find itself, and thus mark it as "used". What we really want is to only walk starting from the root set, and don't remove recursive definitions from the root set.