### PR TITLE
Align pattern destructuring with rest of patterns documentation

### DIFF
--- a/src/patterns.md
+++ b/src/patterns.md
@@ -92,8 +92,8 @@ Patterns can be used to *destructure* [structs], [enums], and [tuples].
 Destructuring breaks up a value into its component pieces.
 The syntax used is almost the same as when creating such values.
 
-r[patterns.destructure.placeholder]
-In a pattern whose [scrutinee] expression has a `struct`, `enum` or `tuple` type, a placeholder (`_`) stands in for a *single* data field, whereas a wildcard `..`  stands in for *all* the remaining fields of a particular variant.
+r[patterns.destructure.wildcard]
+In a pattern whose [scrutinee] expression has a `struct`, `enum` or `tuple` type, a [wildcard pattern](#wildcard-pattern) (`_`) stands in for a *single* data field, whereas an [et cetera](#grammar-StructPatternEtCetera) or [rest pattern](#rest-patterns) (`..`) stands in for *all* the remaining fields of a particular variant.
 
 r[patterns.destructure.named-field-shorthand]
 When destructuring a data structure with named (but not numbered) fields, it is allowed to write `fieldname` as a shorthand for `fieldname: fieldname`.


### PR DESCRIPTION
See rust-lang/reference#1845.

Fix the inconsistent use of "wildcard" and "placeholder" in [`patterns.destructure.placeholder`].

Instead of using "placeholder", `_` is now referred to as a wildcard pattern, and `..` is now referred to as an et cetera or rest pattern instead of "wildcard".

Moreover, add links to the respective sections/statements to all updated references.

I didn't update the `r[patterns.destructure.placeholder]` part, as I imagine doing so would break (external) links to that part of the reference. I can update the commit if this reference should be updated as well.

[`patterns.destructure.placeholder`]: https://github.com/rust-lang/reference/blob/a24e6e9380a28e9b836777cf94ec5b2f03ba4e47/src/patterns.md#L96

Closes: rust-lang/reference#1845