### PR TITLE
Use extern "system" instead of "stdcall" in example

### DIFF
--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -103,9 +103,8 @@ standard C ABI on the specific platform. Other ABIs may be specified using an
 `abi` string, as shown here:
 
 ```rust
-# #[cfg(any(windows, target_arch = "x86"))]
 // Interface to the Windows API
-unsafe extern "stdcall" { }
+unsafe extern "system" { }
 ```
 
 r[items.extern.abi.standard]


### PR DESCRIPTION
`stdcall` is only correct for 32-bit Windows and may be a hard error on other platforms in the future. Whereas `system` is correct for all Windows targets.