### PR TITLE
const_eval: we allow references to statics and promoteds

### DIFF
--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -83,8 +83,9 @@ r[const-eval.const-expr.builtin-arith-logic]
 r[const-eval.const-expr.borrows]
 * All forms of [borrow]s, including raw borrows, with one limitation:
   mutable borrows and shared borrows to values with interior mutability
-  are only allowed to refer to *transient* places. A place is *transient*
+  are only allowed to refer to *transient* places or to *static* places. A place is *transient*
   if its lifetime is strictly contained inside the current [const context].
+  A place is *static* if it is a `static` item or a [promoted expression].
 
 r[const-eval.const-expr.deref]
 * The [dereference operator] except for raw pointers.
@@ -195,6 +196,7 @@ of whether you are building on a `64` bit or a `32` bit system.
 [overflow]:             expressions/operator-expr.md#overflow
 [paths]:                expressions/path-expr.md
 [patterns]:             patterns.md
+[promoted expression]:  destructors.md#constant-promotion
 [range expressions]:    expressions/range-expr.md
 [slice]:                types/slice.md
 [statics]:              items/static-items.md


### PR DESCRIPTION
The docs currently seem to imply that we would reject these, but we do not:
```rust
use std::sync::Mutex;

static S: Mutex<i32> = Mutex::new(0);
const _: () = {
  let _ref = &S;
};

const _: () = {
    // The lifetime shows that this is not transient.
    let _mutref: &'static [i32] = &mut [];
};
```

Arguably, the second example with a promoted is a bit of a stretch. It's also a bit unclear what "are only allowed to refer" means, i.e. what exactly gets checked when exactly.

What *actually* happens is that we allow mutable and interior mutable borrows when
- the place is transient
- or the place is indirect, i.e. based on a deref expression

We allow the 2nd point because that means the new borrow is pointing to something that was already borrowed before, so we already checked transience at that point. But also, the internal representation of a static item as an expression is a deref, so this also allows `&INTERIOR_MUTABLE_STATIC` or `&mut MUT_STATIC`, and something similar happens with promoteds.

Should we mention the point about indirect places? It makes the description more algorithmic, which seems like a good thing, if that's the style you are going for. Basically, the question is, when this clause talks about "places", does it mean places expressions or evaluated places? Is it talking about a static property of the source code, or a dynamic property of the runtime data? If it is the former, indirect places have to be mentioned, if it is the latter, then not.