### PR TITLE
Fix missing rule on destructors

### DIFF
--- a/src/destructors.md
+++ b/src/destructors.md
@@ -1,3 +1,4 @@
+r[destructors]
 # Destructors
 
 r[destructors.intro]


### PR DESCRIPTION
To stay consistent with the rest of the book, the chapter head gets a rule label.