### PR TITLE
doc(modules): Remove module style recommendation

### DIFF
--- a/src/items/modules.md
+++ b/src/items/modules.md
@@ -81,9 +81,6 @@ contents in a file named `mod.rs` within that directory. The above example can
 alternately be expressed with `crate::util`'s contents in a file named
 `util/mod.rs`. It is not allowed to have both `util.rs` and `util/mod.rs`.
 
-> [!NOTE]
-> Prior to `rustc` 1.30, using `mod.rs` files was the way to load a module with nested children. It is encouraged to use the new naming convention as it is more consistent, and avoids having many files named `mod.rs` within a project.
-
 r[items.mod.outlined.path]
 ### The `path` attribute
 


### PR DESCRIPTION
I was having a conversation about Rust modules with one of my coworkers who is relatively new to Rust.
They mentioned that using `foo/mod.rs` is not recommended in the Rust reference which surprised me.  

Even in modern Rust, I still find the `foo/mod.rs` style much more common than using the "newer" style of adding `foo.rs` and adding a `foo/` directory.

I think its worth removing this recommendation  from the reference to make it unopinionated and avoid confusing newcomers.