### PR TITLE
Fix smart punctuation inside grammar terminals

### DIFF
--- a/mdbook-spec/src/grammar/render_markdown.rs
+++ b/mdbook-spec/src/grammar/render_markdown.rs
@@ -223,6 +223,7 @@ impl Characters {
 
 /// Escapes characters that markdown would otherwise interpret.
 fn markdown_escape(s: &str) -> Cow<'_, str> {
-    static ESC_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"[\\`_*\[\](){}'"]"#).unwrap());
+    static ESC_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r#"[\\`_*\[\](){}'".-]"#).unwrap());
     ESC_RE.replace_all(s, r"\$0")
 }


### PR DESCRIPTION
Smart punctuation was converting `...` to `…`. This fixes it so that it will be escaped to avoid the conversion. This normally doesn't happen inside a backtick code block, but since we are using spans for terminals, pulldown-cmark is accidentally picking them up.

This also includes hyphen to handle en-dash and em-dash, though we don't have those.

Fixes https://github.com/rust-lang/reference/issues/1867