### PR TITLE
fix: swap places for 2 words in associated-items.md sentence.

### DIFF
--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -24,7 +24,7 @@ Specifically, there are [associated functions] (including methods), [associated 
 [associated constants]: #associated-constants
 
 r[items.associated.related]
-Associated items are useful when the associated item logically is related to the
+Associated items are useful when the associated item is logically related to the
 associating item. For example, the `is_some` method on `Option` is intrinsically
 related to Options, so should be associated.
 


### PR DESCRIPTION
The sentence is still a mouthful. But this fixes a grammatical mistake.

Here is the nightly version of the doc https://doc.rust-lang.org/nightly/reference/items/associated-items.html#r-items.associated.related