### PR TITLE
Remove outdated comment about non-copy unions

### DIFF
--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -419,9 +419,6 @@ struct MyCFields { x: u32, y: u8 }
 struct MyDFields;
 ```
 
-> [!NOTE]
-> `union`s with non-`Copy` fields are unstable, see [55149].
-
 r[layout.repr.primitive]
 ### Primitive representations
 
@@ -495,9 +492,6 @@ struct MyVariantC { tag: MyEnumDiscriminant, x: u32, y: u8 }
 #[derive(Clone, Copy)]
 struct MyVariantD(MyEnumDiscriminant);
 ```
-
-> [!NOTE]
-> `union`s with non-`Copy` fields are unstable, see [55149].
 
 r[layout.repr.primitive-c]
 #### Combining primitive representations of enums with fields and `#[repr(C)]`
@@ -668,7 +662,6 @@ used with any other representation.
 [enumerations]: items/enumerations.md
 [zero-variant enums]: items/enumerations.md#zero-variant-enums
 [undefined behavior]: behavior-considered-undefined.md
-[55149]: https://github.com/rust-lang/rust/issues/55149
 [`PhantomData<T>`]: special-types-and-traits.md#phantomdatat
 [`Rust`]: #the-rust-representation
 [`C`]: #the-c-representation


### PR DESCRIPTION
I'm not sure when exactly this was removed, but non-copy union fields aren't allowed, and there is no nightly feature to allow them AFAIK.

This was discussed in the tracking issue https://github.com/rust-lang/rust/issues/55149 and various changes like https://github.com/rust-lang/rust/pull/97995 on what is allowed, but I did not dig down to find the exact change that closed the door.

The allowed field kinds are described in items.union.field-restrictions.

Also, in general the reference shouldn't be referring to unstable features.