### PR TITLE
associated-items.md: remove redundant word

### DIFF
--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -59,8 +59,8 @@ r[items.associated.fn.def]
 An *associated function definition* defines a function associated with another
 type. It is written the same as a [function item].
 
-An example of a common associated function is a `new` function that returns
-a value of the type the function is associated with.
+> [!NOTE]
+> A common example is an associated function named `new` that returns a value of the type with which it is associated.
 
 ```rust
 struct Struct {

--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -60,7 +60,7 @@ An *associated function definition* defines a function associated with another
 type. It is written the same as a [function item].
 
 An example of a common associated function is a `new` function that returns
-a value of the type the associated function is associated with.
+a value of the type the function is associated with.
 
 ```rust
 struct Struct {


### PR DESCRIPTION
The word does not improve precision, and makes the sentence a bit slower to parse.