### PR TITLE
fix (expr): add never-type note to expressions.

### DIFF
--- a/src/expressions.md
+++ b/src/expressions.md
@@ -46,10 +46,13 @@ ExpressionWithBlock ->
 ```
 
 r[expr.intro]
-An expression may have two roles: it always produces a *value*, and it may have *effects* (otherwise known as "side effects").
+An expression may have two roles: it produces a *value*, and it may have *effects* (otherwise known as "side effects").
 
 r[expr.evaluation]
 An expression *evaluates to* a value, and has effects during *evaluation*.
+
+> [!NOTE]
+> Some expressions _do not_ produce a value; however, they are exceptions rather than the rule. Examples that do not produce a value are: [`return`][expr.return], [`continue`][expr.loop.continue], [`break`][expr.loop.break] and [`loop`][expr.loop.infinite]. They do have a type, the [never type][Never Type] denoted `!`.
 
 r[expr.operands]
 Many expressions contain sub-expressions, called the *operands* of the expression.
@@ -333,6 +336,7 @@ They are never allowed before:
 [match]:                expressions/match-expr.md
 [method-call]:          expressions/method-call-expr.md
 [Mutable `static` items]: items/static-items.md#mutable-statics
+[Never type]:           types/never.html
 [Outer attributes]:     attributes.md
 [paths]:                expressions/path-expr.md
 [promoted]:             destructors.md#constant-promotion


### PR DESCRIPTION
Not all expressions evaluate to a value. Examples are `return`, `loop`, `break`. This is described for infinite `loop`s but not as a statement applicable to a subset of the expressions.

After some consideration and reading the `authoring.md` a "> [!Note]" was added instead of a standalone paragraph. It becomes more of a detail for careful readers.

The first two paragraphs are nearly identical to the original document. The only word removed from the initial paragraph is _always_ because that's not true, and would trip some users up.

It links to [the reference `!`](https://doc.rust-lang.org/reference/types/never.html) but another useful link could be [std !](https://doc.rust-lang.org/std/primitive.never.html). That would make both the text longer, and link to a page that starts with "this is unstable". So the latter was left out.

CC: @ehuss @RalfJung just in case you can review or simply dismiss this.