### PR TITLE
Switch enum grammar to use "variant"

### DIFF
--- a/src/items/enumerations.md
+++ b/src/items/enumerations.md
@@ -4,19 +4,19 @@ r[items.enum]
 r[items.enum.syntax]
 ```grammar,items
 Enumeration ->
-    `enum` IDENTIFIER GenericParams? WhereClause? `{` EnumItems? `}`
+    `enum` IDENTIFIER GenericParams? WhereClause? `{` EnumVariants? `}`
 
-EnumItems -> EnumItem ( `,` EnumItem )* `,`?
+EnumVariants -> EnumVariant ( `,` EnumVariant )* `,`?
 
-EnumItem ->
+EnumVariant ->
     OuterAttribute* Visibility?
-    IDENTIFIER ( EnumItemTuple | EnumItemStruct )? EnumItemDiscriminant?
+    IDENTIFIER ( EnumVariantTuple | EnumVariantStruct )? EnumVariantDiscriminant?
 
-EnumItemTuple -> `(` TupleFields? `)`
+EnumVariantTuple -> `(` TupleFields? `)`
 
-EnumItemStruct -> `{` StructFields? `}`
+EnumVariantStruct -> `{` StructFields? `}`
 
-EnumItemDiscriminant -> `=` Expression
+EnumVariantDiscriminant -> `=` Expression
 ```
 
 r[items.enum.intro]


### PR DESCRIPTION
This switches the grammar for enum to use the term "variant" instead of "item". "item" already has a specific meaning, and I think this unnecessarily overloads it. Also, the text never uses this phrasing (it only uses variant).