### PR TITLE
Update `cfg_attr` to use the attribute template

### DIFF
--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -415,6 +415,8 @@ Multiple `cfg_attr` attributes may be specified.
 
 r[cfg.cfg_attr.behaviour]
 When the configuration predicate is true, this attribute expands out to the attributes listed after the predicate. For example, the following module will either be found at `linux.rs` or `windows.rs` based on the target.
+r[cfg.cfg_attr.attr-restriction]
+The [`crate_type`] and [`crate_name`] attributes cannot be used with `cfg_attr`.
 
 
 r[cfg.cfg_attr.attribute-list]
@@ -433,8 +435,6 @@ fn bewitched() {}
 
 > [!NOTE]
 > The `cfg_attr` can expand to another `cfg_attr`. For example, `#[cfg_attr(target_os = "linux", cfg_attr(feature = "multithreaded", some_other_attribute))]` is valid. This example would be equivalent to `#[cfg_attr(all(target_os = "linux", feature ="multithreaded"), some_other_attribute)]`.
-
-The [`crate_type`] and [`crate_name`] attributes cannot be used with `cfg_attr`.
 
 r[cfg.macro]
 ### The `cfg` macro

--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -410,6 +410,8 @@ CfgAttrs -> Attr (`,` Attr)* `,`?
 r[cfg.cfg_attr.allowed-positions]
 The `cfg_attr` attribute is allowed anywhere attributes are allowed.
 
+r[cfg.cfg_attr.duplicates]
+Multiple `cfg_attr` attributes may be specified.
 
 r[cfg.cfg_attr.behaviour]
 When the configuration predicate is true, this attribute expands out to the attributes listed after the predicate. For example, the following module will either be found at `linux.rs` or `windows.rs` based on the target.

--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -393,13 +393,10 @@ CfgAttrs -> Attr (`,` Attr)* `,`?
 ```
 
 r[cfg.cfg_attr.general]
-The `cfg_attr` [attribute] conditionally includes [attributes] based on a
-configuration predicate.
+The `cfg_attr` [attribute] conditionally includes [attributes] based on a configuration predicate.
 
 r[cfg.cfg_attr.behaviour]
-When the configuration predicate is true, this attribute expands out to the
-attributes listed after the predicate. For example, the following module will
-either be found at `linux.rs` or `windows.rs` based on the target.
+When the configuration predicate is true, this attribute expands out to the attributes listed after the predicate. For example, the following module will either be found at `linux.rs` or `windows.rs` based on the target.
 
 <!-- ignore: `mod` needs multiple files -->
 ```rust,ignore
@@ -409,8 +406,7 @@ mod os;
 ```
 
 r[cfg.cfg_attr.attribute-list]
-Zero, one, or more attributes may be listed. Multiple attributes will each be
-expanded into separate attributes. For example:
+Zero, one, or more attributes may be listed. Multiple attributes will each be expanded into separate attributes. For example:
 
 <!-- ignore: fake attributes -->
 ```rust,ignore

--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -420,18 +420,19 @@ r[cfg.cfg_attr.behavior]
 When the configuration predicate is true, `cfg_attr` expands out to the attributes listed after the predicate.
 
 r[cfg.cfg_attr.attribute-list]
-Zero, one, or more attributes may be listed. Multiple attributes will each be expanded into separate attributes. For example:
+Zero, one, or more attributes may be listed. Multiple attributes will each be expanded into separate attributes.
 
-<!-- ignore: fake attributes -->
-```rust,ignore
-#[cfg_attr(feature = "magic", sparkles, crackles)]
-fn bewitched() {}
-
-// When the `magic` feature flag is enabled, the above will expand to:
-#[sparkles]
-#[crackles]
-fn bewitched() {}
-```
+> [!EXAMPLE]
+> <!-- ignore: fake attributes -->
+> ```rust,ignore
+> #[cfg_attr(feature = "magic", sparkles, crackles)]
+> fn bewitched() {}
+>
+> // When the `magic` feature flag is enabled, the above will expand to:
+> #[sparkles]
+> #[crackles]
+> fn bewitched() {}
+> ```
 
 > [!NOTE]
 > The `cfg_attr` can expand to another `cfg_attr`. For example, `#[cfg_attr(target_os = "linux", cfg_attr(feature = "multithreaded", some_other_attribute))]` is valid. This example would be equivalent to `#[cfg_attr(all(target_os = "linux", feature ="multithreaded"), some_other_attribute)]`.

--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -413,11 +413,11 @@ The `cfg_attr` attribute is allowed anywhere attributes are allowed.
 r[cfg.cfg_attr.duplicates]
 Multiple `cfg_attr` attributes may be specified.
 
-r[cfg.cfg_attr.behaviour]
-When the configuration predicate is true, this attribute expands out to the attributes listed after the predicate. For example, the following module will either be found at `linux.rs` or `windows.rs` based on the target.
 r[cfg.cfg_attr.attr-restriction]
 The [`crate_type`] and [`crate_name`] attributes cannot be used with `cfg_attr`.
 
+r[cfg.cfg_attr.behavior]
+When the configuration predicate is true, `cfg_attr` expands out to the attributes listed after the predicate.
 
 r[cfg.cfg_attr.attribute-list]
 Zero, one, or more attributes may be listed. Multiple attributes will each be expanded into separate attributes. For example:

--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -399,6 +399,8 @@ The *`cfg_attr` [attribute]* conditionally includes attributes based on a config
 > ```
 
 r[cfg.cfg_attr.syntax]
+The syntax for the `cfg_attr` attribute is:
+
 ```grammar,configuration
 @root CfgAttrAttribute -> `cfg_attr` `(` ConfigurationPredicate `,` CfgAttrs? `)`
 

--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -388,6 +388,16 @@ r[cfg.cfg_attr]
 r[cfg.cfg_attr.intro]
 The *`cfg_attr` [attribute]* conditionally includes attributes based on a configuration predicate.
 
+> [!EXAMPLE]
+> The following module will either be found at `linux.rs` or `windows.rs` based on the target.
+>
+> <!-- ignore: `mod` needs multiple files -->
+> ```rust,ignore
+> #[cfg_attr(target_os = "linux", path = "linux.rs")]
+> #[cfg_attr(windows, path = "windows.rs")]
+> mod os;
+> ```
+
 r[cfg.cfg_attr.syntax]
 ```grammar,configuration
 @root CfgAttrAttribute -> `cfg_attr` `(` ConfigurationPredicate `,` CfgAttrs? `)`
@@ -399,12 +409,6 @@ CfgAttrs -> Attr (`,` Attr)* `,`?
 r[cfg.cfg_attr.behaviour]
 When the configuration predicate is true, this attribute expands out to the attributes listed after the predicate. For example, the following module will either be found at `linux.rs` or `windows.rs` based on the target.
 
-<!-- ignore: `mod` needs multiple files -->
-```rust,ignore
-#[cfg_attr(target_os = "linux", path = "linux.rs")]
-#[cfg_attr(windows, path = "windows.rs")]
-mod os;
-```
 
 r[cfg.cfg_attr.attribute-list]
 Zero, one, or more attributes may be listed. Multiple attributes will each be expanded into separate attributes. For example:

--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -385,6 +385,9 @@ The `cfg` attribute is allowed anywhere attributes are allowed.
 r[cfg.cfg_attr]
 ### The `cfg_attr` attribute
 
+r[cfg.cfg_attr.intro]
+The *`cfg_attr` [attribute]* conditionally includes attributes based on a configuration predicate.
+
 r[cfg.cfg_attr.syntax]
 ```grammar,configuration
 @root CfgAttrAttribute -> `cfg_attr` `(` ConfigurationPredicate `,` CfgAttrs? `)`
@@ -392,8 +395,6 @@ r[cfg.cfg_attr.syntax]
 CfgAttrs -> Attr (`,` Attr)* `,`?
 ```
 
-r[cfg.cfg_attr.general]
-The `cfg_attr` [attribute] conditionally includes [attributes] based on a configuration predicate.
 
 r[cfg.cfg_attr.behaviour]
 When the configuration predicate is true, this attribute expands out to the attributes listed after the predicate. For example, the following module will either be found at `linux.rs` or `windows.rs` based on the target.

--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -407,6 +407,9 @@ The syntax for the `cfg_attr` attribute is:
 CfgAttrs -> Attr (`,` Attr)* `,`?
 ```
 
+r[cfg.cfg_attr.allowed-positions]
+The `cfg_attr` attribute is allowed anywhere attributes are allowed.
+
 
 r[cfg.cfg_attr.behaviour]
 When the configuration predicate is true, this attribute expands out to the attributes listed after the predicate. For example, the following module will either be found at `linux.rs` or `windows.rs` based on the target.
@@ -428,9 +431,6 @@ fn bewitched() {}
 
 > [!NOTE]
 > The `cfg_attr` can expand to another `cfg_attr`. For example, `#[cfg_attr(target_os = "linux", cfg_attr(feature = "multithreaded", some_other_attribute))]` is valid. This example would be equivalent to `#[cfg_attr(all(target_os = "linux", feature ="multithreaded"), some_other_attribute)]`.
-
-r[cfg.cfg_attr.restriction]
-The `cfg_attr` attribute is allowed anywhere attributes are allowed.
 
 The [`crate_type`] and [`crate_name`] attributes cannot be used with `cfg_attr`.
 


### PR DESCRIPTION
New rules:
- ❗ `cfg.cfg_attr.duplicates`

Renamed rules:
- `cfg.cfg_attr.general` is now `cfg.cfg_attr.intro`
- `cfg.cfg_attr.behaviour` is now `cfg.cfg_attr.behavior`
- `cfg.cfg_attr.restriction` split into `cfg.cfg_attr.allowed-positions` and `cfg.cfg_attr.attr-restriction`
