### PR TITLE
Update `macro_export` to use the attribute template

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -33,6 +33,7 @@ use-boolean-and = true
 "/items/modules.html#prelude-items" = "../names/preludes.html"
 "/items/traits.html#object-safety" = "traits.html#dyn-compatibility"
 "/lifetime-elision.html#static-lifetime-elision" = "lifetime-elision.html#const-and-static-elision"
+"/macros-by-example.html#path-based-scope" = "macros-by-example.html#the-macro_export-attribute"
 "/procedural-macros.html#derive-macros" = "procedural-macros.html#the-proc_macro_derive-attribute"
 "/runtime.html#the-panic_handler-attribute" = "panic.html#the-panic_handler-attribute"
 "/unsafe-blocks.html" = "unsafe-keyword.html"

--- a/src/attributes.md
+++ b/src/attributes.md
@@ -359,7 +359,7 @@ The following is an index of all built-in attributes.
 [`link_ordinal`]: items/external-blocks.md#the-link_ordinal-attribute
 [`link_section`]: abi.md#the-link_section-attribute
 [`link`]: items/external-blocks.md#the-link-attribute
-[`macro_export`]: macros-by-example.md#path-based-scope
+[`macro_export`]: macros-by-example.md#the-macro_export-attribute
 [`macro_use`]: macros-by-example.md#the-macro_use-attribute
 [`must_use`]: attributes/diagnostics.md#the-must_use-attribute
 [`naked`]: attributes/codegen.md#the-naked-attribute

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -368,6 +368,7 @@ r[macro.decl.scope.macro_use.export]
 Macros to be imported with `macro_use` must be exported with
 [`macro_export`][macro.decl.scope.macro_export].
 
+<!-- template:attributes -->
 r[macro.decl.scope.macro_export]
 ### The `macro_export` attribute
 
@@ -399,13 +400,13 @@ r[macro.decl.scope.macro_export.allowed-positions]
 The `macro_export` attribute may be applied to `macro_rules` definitions.
 
 > [!NOTE]
-> `rustc` currently warns in other positions, but this may be rejected in the future.
+> `rustc` ignores use in other positions but lints against it. This may become an error in the future.
 
 r[macro.decl.scope.macro_export.duplicates]
-Only the first instance of `macro_export` on a macro is honored. Subsequent `macro_export` attributes are ignored.
+Only the first use of `macro_export` on a macro has effect.
 
 > [!NOTE]
-> `rustc` currently warns on subsequent duplicate `macro_export` attributes.
+> `rustc` lints against any use following the first.
 
 r[macro.decl.scope.macro_export.path-based]
 By default, macros only have [textually-based scoping](#textual-scope). When the `macro_export` attribute is used, the macro is reexported in the crate root, and can be referred to using a path to the macro in the crate root.

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -374,9 +374,6 @@ r[macro.decl.scope.macro_export]
 r[macro.decl.scope.macro_export.intro]
 The *`macro_export` [attribute][attributes]* marks a macro to be publicly exported from the crate, and makes it available in the root of the crate for path-based resolution.
 
-
-r[macro.decl.scope.path.export]
-Macros labeled with `#[macro_export]` are always `pub` and can be referred to by other crates, either by path or by `#[macro_use]` as described above.
 > [!EXAMPLE]
 > ```rust
 > self::m!();
@@ -409,6 +406,53 @@ Only the first instance of `macro_export` on a macro is honored. Subsequent `mac
 
 > [!NOTE]
 > `rustc` currently warns on subsequent duplicate `macro_export` attributes.
+
+r[macro.decl.scope.macro_export.path-based]
+By default, macros only have [textually-based scoping](#textual-scope). When the `macro_export` attribute is used, the macro is reexported in the crate root, and can be referred to using a path to the macro in the crate root.
+
+r[macro.decl.scope.macro_export.export]
+The `macro_export` attribute causes a macro to be publicly exported from the crate root so that it can be referred to by other crates using a path.
+
+> [!EXAMPLE]
+> Given the following defined in a crate named `log`:
+> ```rust
+> #[macro_export]
+> macro_rules! warn {
+>     ($message:expr) => { eprintln!("WARN: {}", $message) };
+> }
+> ```
+> Then you can refer to the macro via a path to the crate:
+> <!-- ignore: requires external crates -->
+> ```rust,ignore
+> fn main() {
+>     log::warn!("example warning");
+> }
+> ```
+
+r[macro.decl.scope.macro_export.macro_use]
+`macro_export` also allows the use of [`macro_use`][macro.decl.scope.macro_use] on an `extern crate` to import the macro into the [`macro_use` prelude].
+
+> [!EXAMPLE]
+> Given the following defined in a crate named `log`:
+> ```rust
+> #[macro_export]
+> macro_rules! warn {
+>     ($message:expr) => { eprintln!("WARN: {}", $message) };
+> }
+> ```
+> Using `macro_use` in a dependent crate means the macro can be used from the prelude:
+> <!-- ignore: requires external crates -->
+> ```rust,ignore
+> #[macro_use]
+> extern crate log;
+>
+> pub mod util {
+>     pub fn do_thing() {
+>         // Resolved via macro prelude.
+>         warn!("example warning");
+>     }
+> }
+> ```
 
 r[macro.decl.hygiene]
 ## Hygiene

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -365,8 +365,8 @@ lazy_static!{}
 ```
 
 r[macro.decl.scope.macro_use.export]
-Macros to be imported with `#[macro_use]` must be exported with
-`#[macro_export]`, which is described below.
+Macros to be imported with `macro_use` must be exported with
+[`macro_export`][macro.decl.scope.macro_export].
 
 r[macro.decl.scope.macro_export]
 ### The `macro_export` attribute

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -371,8 +371,8 @@ Macros to be imported with `macro_use` must be exported with
 r[macro.decl.scope.macro_export]
 ### The `macro_export` attribute
 
-By default, a macro has no path-based scope. However, if it has the `#[macro_export]` attribute, then it is declared in the crate root scope and can be referred to normally as such:
 r[macro.decl.scope.macro_export.intro]
+The *`macro_export` [attribute][attributes]* marks a macro to be publicly exported from the crate, and makes it available in the root of the crate for path-based resolution.
 
 
 r[macro.decl.scope.path.export]

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -395,6 +395,21 @@ Macros labeled with `#[macro_export]` are always `pub` and can be referred to by
 > }
 > ```
 
+r[macro.decl.scope.macro_export.syntax]
+The `macro_export` attribute uses the [MetaWord] syntax, or the [MetaListIdents] syntax with a single value of [`local_inner_macros`][macro.decl.scope.macro_export.local_inner_macros].
+
+r[macro.decl.scope.macro_export.allowed-positions]
+The `macro_export` attribute can be applied to `macro_rules` definitions.
+
+> [!NOTE]
+> `rustc` currently warns in other positions, but this may be rejected in the future.
+
+r[macro.decl.scope.macro_export.duplicates]
+Only the first instance of `macro_export` on a macro is honored. Subsequent `macro_export` attributes are ignored.
+
+> [!NOTE]
+> `rustc` currently warns on subsequent duplicate `macro_export` attributes.
+
 r[macro.decl.hygiene]
 ## Hygiene
 

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -372,9 +372,7 @@ r[macro.decl.scope.path]
 ### Path-based scope
 
 r[macro.decl.scope.path.intro]
-By default, a macro has no path-based scope. However, if it has the
-`#[macro_export]` attribute, then it is declared in the crate root scope and can
-be referred to normally as such:
+By default, a macro has no path-based scope. However, if it has the `#[macro_export]` attribute, then it is declared in the crate root scope and can be referred to normally as such:
 
 ```rust
 self::m!();
@@ -394,8 +392,7 @@ mod mac {
 ```
 
 r[macro.decl.scope.path.export]
-Macros labeled with `#[macro_export]` are always `pub` and can be referred to
-by other crates, either by path or by `#[macro_use]` as described above.
+Macros labeled with `#[macro_export]` are always `pub` and can be referred to by other crates, either by path or by `#[macro_use]` as described above.
 
 r[macro.decl.hygiene]
 ## Hygiene
@@ -495,20 +492,11 @@ macro_rules! call_foo {
 fn foo() {}
 ```
 
-> **Version differences**: Prior to Rust 1.30, `$crate` and
-> `local_inner_macros` (below) were unsupported. They were added alongside
-> path-based imports of macros (described above), to ensure that helper macros
-> did not need to be manually imported by users of a macro-exporting crate.
-> Crates written for earlier versions of Rust that use helper macros need to be
-> modified to use `$crate` or `local_inner_macros` to work well with path-based
-> imports.
+> [!NOTE]
+> Prior to Rust 1.30, `$crate` and `local_inner_macros` (below) were unsupported. They were added alongside path-based imports of macros (described above), to ensure that helper macros did not need to be manually imported by users of a macro-exporting crate. Crates written for earlier versions of Rust that use helper macros need to be modified to use `$crate` or `local_inner_macros` to work well with path-based imports.
 
 r[macro.decl.hygiene.local_inner_macros]
-When a macro is exported, the `#[macro_export]` attribute can have the
-`local_inner_macros` keyword added to automatically prefix all contained macro
-invocations with `$crate::`. This is intended primarily as a tool to migrate
-code written before `$crate` was added to the language to work with Rust 2018's
-path-based imports of macros. Its use is discouraged in new code.
+When a macro is exported, the `#[macro_export]` attribute can have the `local_inner_macros` keyword added to automatically prefix all contained macro invocations with `$crate::`. This is intended primarily as a tool to migrate code written before `$crate` was added to the language to work with Rust 2018's path-based imports of macros. Its use is discouraged in new code.
 
 ```rust
 #[macro_export(local_inner_macros)]

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -396,7 +396,7 @@ r[macro.decl.scope.macro_export.syntax]
 The `macro_export` attribute uses the [MetaWord] syntax, or the [MetaListIdents] syntax with a single value of [`local_inner_macros`][macro.decl.scope.macro_export.local_inner_macros].
 
 r[macro.decl.scope.macro_export.allowed-positions]
-The `macro_export` attribute can be applied to `macro_rules` definitions.
+The `macro_export` attribute may be applied to `macro_rules` definitions.
 
 > [!NOTE]
 > `rustc` currently warns in other positions, but this may be rejected in the future.
@@ -451,6 +451,22 @@ r[macro.decl.scope.macro_export.macro_use]
 >         // Resolved via macro prelude.
 >         warn!("example warning");
 >     }
+> }
+> ```
+
+r[macro.decl.scope.macro_export.local_inner_macros]
+Adding `local_inner_macros` to the `macro_export` attribute also causes all single-segment macro invocations in the macro definition to have an implicit `$crate::` prefix. This is intended primarily as a tool to migrate code written before [`$crate`] was added to the language to work with Rust 2018's path-based imports of macros. Its use is discouraged in new code.
+
+> [!EXAMPLE]
+> ```rust
+> #[macro_export(local_inner_macros)]
+> macro_rules! helped {
+>     () => { helper!() } // Automatically converted to $crate::helper!().
+> }
+>
+> #[macro_export]
+> macro_rules! helper {
+>     () => { () }
 > }
 > ```
 
@@ -553,22 +569,7 @@ fn foo() {}
 ```
 
 > [!NOTE]
-> Prior to Rust 1.30, `$crate` and `local_inner_macros` (below) were unsupported. They were added alongside path-based imports of macros (described above), to ensure that helper macros did not need to be manually imported by users of a macro-exporting crate. Crates written for earlier versions of Rust that use helper macros need to be modified to use `$crate` or `local_inner_macros` to work well with path-based imports.
-
-r[macro.decl.hygiene.local_inner_macros]
-When a macro is exported, the `#[macro_export]` attribute can have the `local_inner_macros` keyword added to automatically prefix all contained macro invocations with `$crate::`. This is intended primarily as a tool to migrate code written before `$crate` was added to the language to work with Rust 2018's path-based imports of macros. Its use is discouraged in new code.
-
-```rust
-#[macro_export(local_inner_macros)]
-macro_rules! helped {
-    () => { helper!() } // Automatically converted to $crate::helper!().
-}
-
-#[macro_export]
-macro_rules! helper {
-    () => { () }
-}
-```
+> Prior to Rust 1.30, `$crate` and [`local_inner_macros`][macro.decl.scope.macro_export.local_inner_macros] were unsupported. They were added alongside [path-based imports of macros][macro.decl.scope.macro_export], to ensure that helper macros did not need to be manually imported by users of a macro-exporting crate. Crates written for earlier versions of Rust that use helper macros need to be modified to use `$crate` or `local_inner_macros` to work well with path-based imports.
 
 r[macro.decl.follow-set]
 ## Follow-set ambiguity restrictions

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -374,25 +374,26 @@ r[macro.decl.scope.macro_export]
 By default, a macro has no path-based scope. However, if it has the `#[macro_export]` attribute, then it is declared in the crate root scope and can be referred to normally as such:
 r[macro.decl.scope.macro_export.intro]
 
-```rust
-self::m!();
-m!(); // OK: Path-based lookup finds m in the current module.
-
-mod inner {
-    super::m!();
-    crate::m!();
-}
-
-mod mac {
-    #[macro_export]
-    macro_rules! m {
-        () => {};
-    }
-}
-```
 
 r[macro.decl.scope.path.export]
 Macros labeled with `#[macro_export]` are always `pub` and can be referred to by other crates, either by path or by `#[macro_use]` as described above.
+> [!EXAMPLE]
+> ```rust
+> self::m!();
+> m!(); // OK: Path-based lookup finds m in the current module.
+>
+> mod inner {
+>     super::m!();
+>     crate::m!();
+> }
+>
+> mod mac {
+>     #[macro_export]
+>     macro_rules! m {
+>         () => {};
+>     }
+> }
+> ```
 
 r[macro.decl.hygiene]
 ## Hygiene

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -368,11 +368,11 @@ r[macro.decl.scope.macro_use.export]
 Macros to be imported with `#[macro_use]` must be exported with
 `#[macro_export]`, which is described below.
 
-r[macro.decl.scope.path]
-### Path-based scope
+r[macro.decl.scope.macro_export]
+### The `macro_export` attribute
 
-r[macro.decl.scope.path.intro]
 By default, a macro has no path-based scope. However, if it has the `#[macro_export]` attribute, then it is declared in the crate root scope and can be referred to normally as such:
+r[macro.decl.scope.macro_export.intro]
 
 ```rust
 self::m!();

--- a/src/names.md
+++ b/src/names.md
@@ -137,7 +137,7 @@ to with certain [path qualifiers] or aliases.
 [`for`]: expressions/loop-expr.md#iterator-loops
 [`if let`]: expressions/if-expr.md#if-let-patterns
 [`let` statement]: statements.md#let-statements
-[`macro_export` attribute]: macros-by-example.md#path-based-scope
+[`macro_export` attribute]: macros-by-example.md#the-macro_export-attribute
 [`macro_rules` declarations]: macros-by-example.md
 [`macro_use` attribute]: macros-by-example.md#the-macro_use-attribute
 [`match`]: expressions/match-expr.md

--- a/src/names/scopes.md
+++ b/src/names/scopes.md
@@ -343,7 +343,7 @@ impl ImplExample {
 [`if let`]: ../expressions/if-expr.md#if-let-patterns
 [`while let`]: ../expressions/loop-expr.md#while-let-patterns
 [`let` statement]: ../statements.md#let-statements
-[`macro_export`]: ../macros-by-example.md#path-based-scope
+[`macro_export`]: ../macros-by-example.md#the-macro_export-attribute
 [`macro_use` prelude]: preludes.md#macro_use-prelude
 [`macro_use`]: ../macros-by-example.md#the-macro_use-attribute
 [`match` arms]: ../expressions/match-expr.md


### PR DESCRIPTION
New rules:
- ❗ `macro.decl.scope.macro_export.syntax`
- ❗ `macro.decl.scope.macro_export.allowed-positions`
- ❗ `macro.decl.scope.macro_export.duplicates`
- ❗ `macro.decl.scope.macro_export.path-based`
- ❗ `macro.decl.scope.macro_export.macro_use`

Renamed rules:
- `macro.decl.scope.path` is now `macro.decl.scope.macro_export`
- `macro.decl.scope.path.intro` is now `macro.decl.scope.macro_export.intro`
- `macro.decl.scope.path.export` is now `macro.decl.scope.macro_export.export`
- `macro.decl.hygiene.local_inner_macros` is now `macro.decl.scope.macro_export.local_inner_macros`
