### PR TITLE
Update `macro_use` to use the attribute template

### DIFF
--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -343,6 +343,9 @@ The `macro_use` attribute may be applied to modules or `extern crate`.
 > [!NOTE]
 > `rustc` currently warns in other positions, but this may be rejected in the future.
 
+r[macro.decl.scope.macro_use.extern-crate-self]
+The `macro_use` attribute may not be used on [`extern crate self`].
+
 r[macro.decl.scope.macro_use.duplicates]
 Duplicate instances of `macro_use` that are in the [MetaWord] syntax have no effect if there is already a `macro_use` with the [MetaWord] syntax.
 
@@ -687,6 +690,7 @@ expansions, taking separators into account. This means:
 
 For more detail, see the [formal specification].
 
+[`extern crate self`]: items.extern-crate.self
 [`macro_use` prelude]: names/preludes.md#macro_use-prelude
 [block labels]: expressions/loop-expr.md#labelled-block-expressions
 [delimiters]: tokens.md#delimiters

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -330,9 +330,7 @@ r[macro.decl.scope.macro_use]
 ### The `macro_use` attribute
 
 r[macro.decl.scope.macro_use.mod-decl]
-The *`macro_use` attribute* has two purposes. First, it can be used to make a
-module's macro scope not end when the module is closed, by applying it to a
-module:
+The *`macro_use` attribute* has two purposes. First, it can be used to make a module's macro scope not end when the module is closed, by applying it to a module:
 
 ```rust
 #[macro_use]
@@ -346,14 +344,7 @@ m!();
 ```
 
 r[macro.decl.scope.macro_use.prelude]
-Second, it can be used to import macros from another crate, by attaching it to
-an `extern crate` declaration appearing in the crate's root module. Macros
-imported this way are imported into the [`macro_use` prelude], not textually,
-which means that they can be shadowed by any other name. While macros imported
-by `#[macro_use]` can be used before the import statement, in case of a
-conflict, the last macro imported wins. Optionally, a list of macros to import
-can be specified using the [MetaListIdents] syntax; this is not supported
-when `#[macro_use]` is applied to a module.
+Second, it can be used to import macros from another crate, by attaching it to an `extern crate` declaration appearing in the crate's root module. Macros imported this way are imported into the [`macro_use` prelude], not textually, which means that they can be shadowed by any other name. While macros imported by `#[macro_use]` can be used before the import statement, in case of a conflict, the last macro imported wins. Optionally, a list of macros to import can be specified using the [MetaListIdents] syntax; this is not supported when `#[macro_use]` is applied to a module.
 
 <!-- ignore: requires external crates -->
 ```rust,ignore
@@ -365,8 +356,7 @@ lazy_static!{}
 ```
 
 r[macro.decl.scope.macro_use.export]
-Macros to be imported with `macro_use` must be exported with
-[`macro_export`][macro.decl.scope.macro_export].
+Macros to be imported with `macro_use` must be exported with [`macro_export`][macro.decl.scope.macro_export].
 
 <!-- template:attributes -->
 r[macro.decl.scope.macro_export]

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -326,6 +326,7 @@ fn foo() {
 // m!(); // Error: m is not in scope.
 ```
 
+<!-- template:attributes -->
 r[macro.decl.scope.macro_use]
 ### The `macro_use` attribute
 
@@ -333,21 +334,21 @@ r[macro.decl.scope.macro_use.intro]
 The *`macro_use` [attribute][attributes]* has two purposes. It may be used on modules to extend the scope of macros defined within them, and it may be used on [`extern crate`][items.extern-crate] to import macros from another crate.
 
 r[macro.decl.scope.macro_use.syntax]
-When used on a module, the `macro_use` attribute uses the [MetaWord] syntax and thus does not take any inputs.
+When used on a module, the `macro_use` attribute uses the [MetaWord] syntax.
 
-When used on an `extern crate`, it uses either the [MetaWord] or [MetaListIdents] syntax.
+When used on an `extern crate`, it uses either the [MetaWord] or [MetaListIdents] syntax (described in [macro.decl.scope.macro_use.prelude]).
 
 r[macro.decl.scope.macro_use.allowed-positions]
 The `macro_use` attribute may be applied to modules or `extern crate`.
 
 > [!NOTE]
-> `rustc` currently warns in other positions, but this may be rejected in the future.
+> `rustc` ignores use in other positions but lints against it. This may become an error in the future.
 
 r[macro.decl.scope.macro_use.extern-crate-self]
 The `macro_use` attribute may not be used on [`extern crate self`].
 
 r[macro.decl.scope.macro_use.duplicates]
-Duplicate instances of `macro_use` that are in the [MetaWord] syntax have no effect if there is already a `macro_use` with the [MetaWord] syntax.
+The `macro_use` attribute may be used any number of times on a form.
 
 Multiple instances of `macro_use` that are in the [MetaListIdents] syntax may be specified. The union of all specified macros to import will be imported.
 
@@ -370,7 +371,7 @@ When `macro_use` is used on a module, it causes the module's macro scope to not 
 > ```
 
 r[macro.decl.scope.macro_use.prelude]
-When `macro_use` is used on an `extern crate` declaration in the crate root, it imports exported macros from that crate.
+Specifying `macro_use` on an `extern crate` declaration in the crate root imports exported macros from that crate.
 
 Macros imported this way are imported into the [`macro_use` prelude], not textually, which means that they can be shadowed by any other name. While macros imported by `macro_use` can be used before the import statement, in case of a conflict, the last macro imported wins.
 

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -329,31 +329,59 @@ fn foo() {
 r[macro.decl.scope.macro_use]
 ### The `macro_use` attribute
 
+r[macro.decl.scope.macro_use.intro]
+The *`macro_use` [attribute][attributes]* has two purposes. It may be used on modules to extend the scope of macros defined within them, and it may be used on [`extern crate`][items.extern-crate] to import macros from another crate.
+
+r[macro.decl.scope.macro_use.syntax]
+When used on a module, the `macro_use` attribute uses the [MetaWord] syntax and thus does not take any inputs.
+
+When used on an `extern crate`, it uses either the [MetaWord] or [MetaListIdents] syntax.
+
+r[macro.decl.scope.macro_use.allowed-positions]
+The `macro_use` attribute may be applied to modules or `extern crate`.
+
+> [!NOTE]
+> `rustc` currently warns in other positions, but this may be rejected in the future.
+
+r[macro.decl.scope.macro_use.duplicates]
+Duplicate instances of `macro_use` that are in the [MetaWord] syntax have no effect if there is already a `macro_use` with the [MetaWord] syntax.
+
+Multiple instances of `macro_use` that are in the [MetaListIdents] syntax may be specified. The union of all specified macros to import will be imported.
+
+> [!NOTE]
+> `rustc` warns about duplicate [MetaWord] `macro_use` attributes.
+
 r[macro.decl.scope.macro_use.mod-decl]
-The *`macro_use` attribute* has two purposes. First, it can be used to make a module's macro scope not end when the module is closed, by applying it to a module:
+When `macro_use` is used on a module, it causes the module's macro scope to not end when the module is closed.
 
-```rust
-#[macro_use]
-mod inner {
-    macro_rules! m {
-        () => {};
-    }
-}
-
-m!();
-```
+> [!EXAMPLE]
+> ```rust
+> #[macro_use]
+> mod inner {
+>     macro_rules! m {
+>         () => {};
+>     }
+> }
+>
+> m!();
+> ```
 
 r[macro.decl.scope.macro_use.prelude]
-Second, it can be used to import macros from another crate, by attaching it to an `extern crate` declaration appearing in the crate's root module. Macros imported this way are imported into the [`macro_use` prelude], not textually, which means that they can be shadowed by any other name. While macros imported by `#[macro_use]` can be used before the import statement, in case of a conflict, the last macro imported wins. Optionally, a list of macros to import can be specified using the [MetaListIdents] syntax; this is not supported when `#[macro_use]` is applied to a module.
+When `macro_use` is used on an `extern crate` declaration in the crate root, it imports exported macros from that crate.
 
-<!-- ignore: requires external crates -->
-```rust,ignore
-#[macro_use(lazy_static)] // Or #[macro_use] to import all macros.
-extern crate lazy_static;
+Macros imported this way are imported into the [`macro_use` prelude], not textually, which means that they can be shadowed by any other name. While macros imported by `macro_use` can be used before the import statement, in case of a conflict, the last macro imported wins.
 
-lazy_static!{}
-// self::lazy_static!{} // Error: lazy_static is not defined in `self`
-```
+When using the [MetaWord] syntax, all exported macros are imported. When using the [MetaListIdents] syntax, only the specified macros are imported.
+
+> [!EXAMPLE]
+> <!-- ignore: requires external crates -->
+> ```rust,ignore
+> #[macro_use(lazy_static)] // Or #[macro_use] to import all macros.
+> extern crate lazy_static;
+>
+> lazy_static!{}
+> // self::lazy_static!{} // Error: lazy_static is not defined in `self`
+> ```
 
 r[macro.decl.scope.macro_use.export]
 Macros to be imported with `macro_use` must be exported with [`macro_export`][macro.decl.scope.macro_export].

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -331,12 +331,28 @@ r[macro.decl.scope.macro_use]
 ### The `macro_use` attribute
 
 r[macro.decl.scope.macro_use.intro]
-The *`macro_use` [attribute][attributes]* has two purposes. It may be used on modules to extend the scope of macros defined within them, and it may be used on [`extern crate`][items.extern-crate] to import macros from another crate.
+The *`macro_use` [attribute][attributes]* has two purposes: it may be used on modules to extend the scope of macros defined within them, and it may be used on [`extern crate`][items.extern-crate] to import macros from another crate into the [`macro_use` prelude].
+
+> [!EXAMPLE]
+> ```rust
+> #[macro_use]
+> mod inner {
+>     macro_rules! m {
+>         () => {};
+>     }
+> }
+> m!();
+> ```
+>
+> ```rust,ignore
+> #[macro_use]
+> extern crate log;
+> ```
 
 r[macro.decl.scope.macro_use.syntax]
-When used on a module, the `macro_use` attribute uses the [MetaWord] syntax.
+When used on modules, the `macro_use` attribute uses the [MetaWord] syntax.
 
-When used on an `extern crate`, it uses either the [MetaWord] or [MetaListIdents] syntax (described in [macro.decl.scope.macro_use.prelude]).
+When used on `extern crate`, it uses the [MetaWord] and [MetaListIdents] syntaxes. For more on how these syntaxes may be used, see [macro.decl.scope.macro_use.prelude].
 
 r[macro.decl.scope.macro_use.allowed-positions]
 The `macro_use` attribute may be applied to modules or `extern crate`.
@@ -350,13 +366,15 @@ The `macro_use` attribute may not be used on [`extern crate self`].
 r[macro.decl.scope.macro_use.duplicates]
 The `macro_use` attribute may be used any number of times on a form.
 
-Multiple instances of `macro_use` that are in the [MetaListIdents] syntax may be specified. The union of all specified macros to import will be imported.
+Multiple instances of `macro_use` in the [MetaListIdents] syntax may be specified. The union of all specified macros will be imported.
 
 > [!NOTE]
-> `rustc` warns about duplicate [MetaWord] `macro_use` attributes.
+> On modules, `rustc` lints against any [MetaWord] `macro_use` attributes following the first.
+>
+> On `extern crate`, `rustc` lints against any `macro_use` attributes that have no effect due to not importing any macros not already imported by another `macro_use` attribute. If two or more [MetaListIdents] `macro_use` attributes import the same macro, the first is linted against. If any [MetaWord] `macro_use` attributes are present, all [MetaListIdents] `macro_use` attributes are linted against. If two or more [MetaWord] `macro_use` attributes are present, the ones following the first are linted against.
 
 r[macro.decl.scope.macro_use.mod-decl]
-When `macro_use` is used on a module, it causes the module's macro scope to not end when the module is closed.
+When `macro_use` is used on a module, the module's macro scope extends beyond the module's lexical scope.
 
 > [!EXAMPLE]
 > ```rust
@@ -366,8 +384,7 @@ When `macro_use` is used on a module, it causes the module's macro scope to not 
 >         () => {};
 >     }
 > }
->
-> m!();
+> m!(); // OK
 > ```
 
 r[macro.decl.scope.macro_use.prelude]
@@ -380,11 +397,11 @@ When using the [MetaWord] syntax, all exported macros are imported. When using t
 > [!EXAMPLE]
 > <!-- ignore: requires external crates -->
 > ```rust,ignore
-> #[macro_use(lazy_static)] // Or #[macro_use] to import all macros.
+> #[macro_use(lazy_static)] // Or `#[macro_use]` to import all macros.
 > extern crate lazy_static;
 >
 > lazy_static!{}
-> // self::lazy_static!{} // Error: lazy_static is not defined in `self`
+> // self::lazy_static!{} // ERROR: lazy_static is not defined in `self`.
 > ```
 
 r[macro.decl.scope.macro_use.export]


### PR DESCRIPTION
New rules:
- ❗ `macro.decl.scope.macro_use.intro`
- ❗ `macro.decl.scope.macro_use.syntax`
- ❗ `macro.decl.scope.macro_use.allowed-positions`
- ❗ `macro.decl.scope.macro_use.duplicates`
