### PR TITLE
Update `link` to use the attribute template

### DIFF
--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -340,7 +340,7 @@ The default for this modifier is `-whole-archive`.
 More implementation details about this modifier can be found in [`whole-archive` documentation for rustc].
 
 r[items.extern.attributes.link.modifiers.verbatim]
-### Linking modifiers: `verbatim`
+#### Linking modifiers: `verbatim`
 
 r[items.extern.attributes.link.modifiers.verbatim.allowed-kinds]
 This modifier is compatible with all linking kinds.

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -255,17 +255,17 @@ The *`link` [attribute][attributes]* specifies the name of a native library that
 > <!-- ignore: requires extern linking -->
 > ```rust,ignore
 > #[link(name = "crypto")]
-> unsafe extern {
+> unsafe extern "C" {
 >     // …
 > }
 >
 > #[link(name = "CoreFoundation", kind = "framework")]
-> unsafe extern {
+> unsafe extern "C" {
 >     // …
 > }
 >
 > #[link(wasm_import_module = "foo")]
-> unsafe extern {
+> unsafe extern "C" {
 >     // …
 > }
 > ```

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -249,7 +249,7 @@ r[items.extern.attributes.link]
 ### The `link` attribute
 
 r[items.extern.attributes.link.intro]
-The *`link` attribute* specifies the name of a native library that the compiler should link with for the items within an `extern` block.
+The *`link` [attribute][attributes]* specifies the name of a native library that the compiler should link with for the items within an `extern` block.
 
 r[items.extern.attributes.link.syntax]
 It uses the [MetaListNameValueStr] syntax to specify its inputs. The `name` key is the name of the native library to link. The `kind` key is an optional value which specifies the kind of library with the following possible values:

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -403,7 +403,7 @@ When building a rlib, `-bundle` means that the native static library is register
 When building a staticlib, `-bundle` means that the native static library is simply not included into the archive and some higher level build system will need to add it later during linking of the final binary.
 
 r[items.extern.attributes.link.modifiers.bundle.no-effect]
-This modifier has no effect when building other targets like executables or dynamic libraries.
+The `bundle` modifier has no effect when building other targets like executables or dynamic libraries.
 
 r[items.extern.attributes.link.modifiers.bundle.default]
 The default for this modifier is `+bundle`.

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -365,11 +365,21 @@ r[items.extern.attributes.link.modifiers]
 r[items.extern.attributes.link.modifiers.intro]
 The optional `modifiers` argument is a way to specify linking modifiers for the library to link.
 
+> [!EXAMPLE]
+> <!-- ignore: requires extern linking -->
+> ```rust,ignore
+> #[link(name = "mylib", kind = "static", modifiers = "+whole-archive")]
+> unsafe extern "C" {}
+> ```
+
 r[items.extern.attributes.link.modifiers.syntax]
 Modifiers are specified as a comma-delimited string with each modifier prefixed with either a `+` or `-` to indicate that the modifier is enabled or disabled, respectively.
 
-r[items.extern.attributes.link.modifiers.multiple]
-Specifying multiple `modifiers` arguments in a single `link` attribute, or multiple identical modifiers in the same `modifiers` argument is not currently supported. Example: `#[link(name = "mylib", kind = "static", modifiers = "+whole-archive")]`.
+r[items.extern.attributes.link.modifiers.once]
+The `modifiers` argument may only be specified once.
+
+r[items.extern.attributes.link.modifiers.duplicates]
+Duplicate modifiers are not allowed within a `modifiers` argument.
 
 r[items.extern.attributes.link.wasm_import_module]
 #### The `wasm_import_module` key

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -447,10 +447,10 @@ r[items.extern.attributes.link.modifiers.verbatim.allowed-kinds]
 This modifier is compatible with all linking kinds.
 
 r[items.extern.attributes.link.modifiers.verbatim.behavior]
-`+verbatim` means that rustc itself won't add any target-specified library prefixes or suffixes (like `lib` or `.a`) to the library name, and will try its best to ask for the same thing from the linker.
+`+verbatim` means that the compiler won't add any target-specified library prefixes or suffixes (like `lib` or `.a`) to the library name, and will try its best to ask for the same thing from the linker.
 
 r[items.extern.attributes.link.modifiers.verbatim.behavior-negative]
-`-verbatim` means that rustc will either add a target-specific prefix and suffix to the library name before passing it to linker, or won't prevent linker from implicitly adding it.
+`-verbatim` means that the compiler will either add a target-specific prefix and suffix to the library name before passing it to linker, or won't prevent linker from implicitly adding it.
 
 r[items.extern.attributes.link.modifiers.verbatim.default]
 The default for this modifier is `-verbatim`.

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -357,7 +357,7 @@ The `raw-dylib` kind indicates a dynamic library where the compiler will generat
 >
 > On Windows, linking against a dynamic library requires that an import library is provided to the linker. This is a special static library that declares all of the symbols exported by the dynamic library in such a way that the linker knows that they have to be dynamically loaded at runtime.
 >
-> Specifying `kind = "dylib"` instructs the Rust compiler to link an import library based on the `name` key. The linker will then use its normal library resolution logic to find that import library. Alternatively, specifying `kind = "raw-dylib"` instructs the compiler to generate an import library during compilation and provide that to the linker instead.
+> Specifying `kind = "dylib"` links an import library based on the `name` key. The linker will then use its normal library resolution logic to find that import library. Alternatively, specifying `kind = "raw-dylib"` generates an import library during compilation and provide that to the linker instead.
 
 r[items.extern.attributes.link.modifiers]
 #### The `modifiers` key

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -312,7 +312,9 @@ r[items.extern.attributes.link.modifiers.bundle.behavior]
 When building a rlib or staticlib `+bundle` means that the native static library will be packed into the rlib or staticlib archive, and then retrieved from there during linking of the final binary.
 
 r[items.extern.attributes.link.modifiers.bundle.behavior-negative]
-When building a rlib `-bundle` means that the native static library is registered as a dependency of that rlib "by name", and object files from it are included only during linking of the final binary, the file search by that name is also performed during final linking. When building a staticlib `-bundle` means that the native static library is simply not included into the archive and some higher level build system will need to add it later during linking of the final binary.
+When building a rlib `-bundle` means that the native static library is registered as a dependency of that rlib "by name", and object files from it are included only during linking of the final binary, the file search by that name is also performed during final linking.
+
+When building a staticlib `-bundle` means that the native static library is simply not included into the archive and some higher level build system will need to add it later during linking of the final binary.
 
 r[items.extern.attributes.link.modifiers.bundle.no-effect]
 This modifier has no effect when building other targets like executables or dynamic libraries.

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -296,7 +296,12 @@ It is valid to add the `link` attribute on an empty extern block. You can use th
 r[items.extern.attributes.link.name]
 #### The `name` key
 
-<!-- TODO: I think it would be helpful to have an intro here that describes how `name` works with some examples of how it works in various situations or platforms. -->
+r[items.extern.attributes.link.name.intro]
+The `name` key specifies the name of the library to link.
+
+<!-- TODO: I think it would be helpful to describe how `name` works with some examples of how it works in various situations or platforms (for example, how prefixes and suffixes work). -->
+
+<!-- TODO: Would be good to specify what happens if the same name is specified multiple times in different attributes. My understanding from https://github.com/rust-lang/rust/blob/c68340350c78eea402c4a85f8d9c1b7d3d607635/compiler/rustc_metadata/src/native_libs.rs#L551-L620 is that it de-duplicates it and uses the "last" instance. I'm not sure if we want to explicitly document that? -->
 
 r[items.extern.attributes.link.name.requirement]
 The `name` key must be included unless `wasm_import_module` is used.

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -271,7 +271,24 @@ The *`link` [attribute][attributes]* specifies the name of a native library that
 > ```
 
 r[items.extern.attributes.link.syntax]
-It uses the [MetaListNameValueStr] syntax to specify its inputs. The `name` key is the name of the native library to link. The `kind` key is an optional value which specifies the kind of library with the following possible values:
+The `link` attribute uses the [MetaListNameValueStr] syntax to specify its inputs. It accepts the following keys:
+
+- [`name`][items.extern.attributes.link.name] --- the name of the native library to link.
+- [`kind`][items.extern.attributes.link.kinds] --- the kind of library.
+- [`modifiers`][items.extern.attributes.link.modifiers] --- modifiers that change the behavior of how the library is linked.
+- [`wasm_import_module`][items.extern.attributes.link.wasm_import_module] --- specifies the WebAssembly module name.
+- [`import_name_type`][items.extern.attributes.link.import_name_type] --- on x86 Windows, this changes how functions are named.
+
+r[items.extern.attributes.link.name]
+#### The `name` key
+
+<!-- TODO: I think it would be helpful to have an intro here that describes how `name` works with some examples of how it works in various situations or platforms. -->
+
+r[items.extern.attributes.link.name.requirement]
+The `name` key must be included unless `wasm_import_module` is used.
+
+r[items.extern.attributes.link.kinds]
+#### The `kind` key
 
 r[items.extern.attributes.link.dylib]
 - `dylib` --- Indicates a dynamic library. This is the default if `kind` is not specified.
@@ -285,10 +302,10 @@ r[items.extern.attributes.link.framework]
 r[items.extern.attributes.link.raw-dylib]
 - `raw-dylib` --- Indicates a dynamic library where the compiler will generate an import library to link against (see [`dylib` versus `raw-dylib`] below for details). This is only valid for Windows targets.
 
-r[items.extern.attributes.link.name-requirement]
-The `name` key must be included if `kind` is specified.
-
 r[items.extern.attributes.link.modifiers]
+#### The `modifiers` key
+
+r[items.extern.attributes.link.modifiers.intro]
 The optional `modifiers` argument is a way to specify linking modifiers for the library to link.
 
 r[items.extern.attributes.link.modifiers.syntax]
@@ -298,6 +315,9 @@ r[items.extern.attributes.link.modifiers.multiple]
 Specifying multiple `modifiers` arguments in a single `link` attribute, or multiple identical modifiers in the same `modifiers` argument is not currently supported. Example: `#[link(name = "mylib", kind = "static", modifiers = "+whole-archive")]`.
 
 r[items.extern.attributes.link.wasm_import_module]
+#### The `wasm_import_module` key
+
+r[items.extern.attributes.link.wasm_import_module.behavior]
 The `wasm_import_module` key may be used to specify the [WebAssembly module] name for the items within an `extern` block when importing symbols from the host environment. The default module name is `env` if `wasm_import_module` is not specified.
 
 r[items.extern.attributes.link.empty-block]

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -279,6 +279,9 @@ The `link` attribute uses the [MetaListNameValueStr] syntax to specify its input
 - [`wasm_import_module`][items.extern.attributes.link.wasm_import_module] --- specifies the WebAssembly module name.
 - [`import_name_type`][items.extern.attributes.link.import_name_type] --- on x86 Windows, this changes how functions are named.
 
+r[items.extern.attributes.link.empty-block]
+It is valid to add the `link` attribute on an empty extern block. You can use this to satisfy the linking requirements of extern blocks elsewhere in your code (including upstream crates) instead of adding the attribute to each extern block.
+
 r[items.extern.attributes.link.name]
 #### The `name` key
 
@@ -319,9 +322,6 @@ r[items.extern.attributes.link.wasm_import_module]
 
 r[items.extern.attributes.link.wasm_import_module.behavior]
 The `wasm_import_module` key may be used to specify the [WebAssembly module] name for the items within an `extern` block when importing symbols from the host environment. The default module name is `env` if `wasm_import_module` is not specified.
-
-r[items.extern.attributes.link.empty-block]
-It is valid to add the `link` attribute on an empty extern block. You can use this to satisfy the linking requirements of extern blocks elsewhere in your code (including upstream crates) instead of adding the attribute to each extern block.
 
 r[items.extern.attributes.link.modifiers.bundle]
 #### Linking modifiers: `bundle`

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -279,6 +279,8 @@ The `link` attribute uses the [MetaListNameValueStr] syntax to specify its input
 - [`wasm_import_module`][items.extern.attributes.link.wasm_import_module] --- specifies the WebAssembly module name.
 - [`import_name_type`][items.extern.attributes.link.import_name_type] --- on x86 Windows, this changes how functions are named.
 
+None of the keys may be specified more than once.
+
 r[items.extern.attributes.link.empty-block]
 It is valid to add the `link` attribute on an empty extern block. You can use this to satisfy the linking requirements of extern blocks elsewhere in your code (including upstream crates) instead of adding the attribute to each extern block.
 

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -245,6 +245,7 @@ r[items.extern.attributes]
 r[items.extern.attributes.intro]
 The following [attributes] control the behavior of external blocks.
 
+<!-- template:attributes -->
 r[items.extern.attributes.link]
 ### The `link` attribute
 
@@ -282,10 +283,10 @@ The `link` attribute uses the [MetaListNameValueStr] syntax to specify its input
 None of the keys may be specified more than once.
 
 r[items.extern.attributes.link.allowed-positions]
-The `link` attribute may be applied to [`extern` blocks].
+The `link` attribute may only be applied to [`extern` blocks].
 
 > [!NOTE]
-> `rustc` currently warns in other positions, but this may be rejected in the future.
+> `rustc` ignores use in other positions but lints against it. This may become an error in the future.
 
 r[items.extern.attributes.link.duplicates]
 The `link` attribute may be specified multiple times, and the corresponding linking instructions for each attribute will be passed to the linker.

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -352,6 +352,13 @@ The `raw-dylib` kind indicates a dynamic library where the compiler will generat
 > unsafe extern "C" {}
 > ```
 
+> [!NOTE]
+> ##### `dylib` versus `raw-dylib`
+>
+> On Windows, linking against a dynamic library requires that an import library is provided to the linker. This is a special static library that declares all of the symbols exported by the dynamic library in such a way that the linker knows that they have to be dynamically loaded at runtime.
+>
+> Specifying `kind = "dylib"` instructs the Rust compiler to link an import library based on the `name` key. The linker will then use its normal library resolution logic to find that import library. Alternatively, specifying `kind = "raw-dylib"` instructs the compiler to generate an import library during compilation and provide that to the linker instead.
+
 r[items.extern.attributes.link.modifiers]
 #### The `modifiers` key
 
@@ -423,14 +430,7 @@ The default for this modifier is `-verbatim`.
 
 More implementation details about this modifier can be found in [`verbatim` documentation for rustc].
 
-r[items.extern.attributes.link.kind-raw-dylib]
-#### `dylib` versus `raw-dylib`
 
-r[items.extern.attributes.link.kind-raw-dylib.intro]
-On Windows, linking against a dynamic library requires that an import library is provided to the linker: this is a special static library that declares all of the symbols exported by the dynamic library in such a way that the linker knows that they have to be dynamically loaded at runtime.
-
-r[items.extern.attributes.link.kind-raw-dylib.import]
-Specifying `kind = "dylib"` instructs the Rust compiler to link an import library based on the `name` key. The linker will then use its normal library resolution logic to find that import library. Alternatively, specifying `kind = "raw-dylib"` instructs the compiler to generate an import library during compilation and provide that to the linker instead.
 
 r[items.extern.attributes.link.kind-raw-dylib.platform-specific]
 `raw-dylib` is only supported on Windows. Using it when targeting other platforms will result in a compiler error.

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -281,6 +281,15 @@ The `link` attribute uses the [MetaListNameValueStr] syntax to specify its input
 
 None of the keys may be specified more than once.
 
+r[items.extern.attributes.link.allowed-positions]
+The `link` attribute may be applied to [`extern` blocks].
+
+> [!NOTE]
+> `rustc` currently warns in other positions, but this may be rejected in the future.
+
+r[items.extern.attributes.link.duplicates]
+The `link` attribute may be specified multiple times, and the corresponding linking instructions for each attribute will be passed to the linker.
+
 r[items.extern.attributes.link.empty-block]
 It is valid to add the `link` attribute on an empty extern block. You can use this to satisfy the linking requirements of extern blocks elsewhere in your code (including upstream crates) instead of adding the attribute to each extern block.
 
@@ -492,3 +501,4 @@ Attributes on extern function parameters follow the same rules and restrictions 
 [value namespace]: ../names/namespaces.md
 [win32 api]: https://learn.microsoft.com/en-us/windows/win32/api/
 [`link_ordinal`]: items.extern.attributes.link_ordinal
+[`extern` blocks]: external-blocks.md

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -395,12 +395,12 @@ r[items.extern.attributes.link.modifiers.bundle.allowed-kinds]
 The `bundle` modifier may only be used with [`static` linking].
 
 r[items.extern.attributes.link.modifiers.bundle.behavior]
-When building a rlib or staticlib `+bundle` means that the native static library will be packed into the rlib or staticlib archive, and then retrieved from there during linking of the final binary.
+When building a rlib or staticlib, `+bundle` means that the native static library will be packed into the rlib or staticlib archive, and then retrieved from there during linking of the final binary.
 
 r[items.extern.attributes.link.modifiers.bundle.behavior-negative]
-When building a rlib `-bundle` means that the native static library is registered as a dependency of that rlib "by name", and object files from it are included only during linking of the final binary, the file search by that name is also performed during final linking.
+When building a rlib, `-bundle` means that the native static library is registered as a dependency of that rlib "by name", and object files from it are included only during linking of the final binary, the file search by that name is also performed during final linking.
 
-When building a staticlib `-bundle` means that the native static library is simply not included into the archive and some higher level build system will need to add it later during linking of the final binary.
+When building a staticlib, `-bundle` means that the native static library is simply not included into the archive and some higher level build system will need to add it later during linking of the final binary.
 
 r[items.extern.attributes.link.modifiers.bundle.no-effect]
 This modifier has no effect when building other targets like executables or dynamic libraries.

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -384,6 +384,13 @@ Duplicate modifiers are not allowed within a `modifiers` argument.
 r[items.extern.attributes.link.modifiers.bundle]
 #### Linking modifiers: `bundle`
 
+> [!EXAMPLE]
+> <!-- ignore: requires extern linking -->
+> ```rust,ignore
+> #[link(name = "mylib", kind = "static", modifiers = "+bundle")]
+> unsafe extern "C" {}
+> ```
+
 r[items.extern.attributes.link.modifiers.bundle.allowed-kinds]
 This modifier is only compatible with the `static` linking kind. Using any other kind will result in a compiler error.
 
@@ -406,6 +413,13 @@ More implementation details about this modifier can be found in [`bundle` docume
 r[items.extern.attributes.link.modifiers.whole-archive]
 #### Linking modifiers: `whole-archive`
 
+> [!EXAMPLE]
+> <!-- ignore: requires extern linking -->
+> ```rust,ignore
+> #[link(name = "mylib", kind = "static", modifiers = "+whole-archive")]
+> unsafe extern "C" {}
+> ```
+
 r[items.extern.attributes.link.modifiers.whole-archive.allowed-kinds]
 This modifier is only compatible with the `static` linking kind. Using any other kind will result in a compiler error.
 
@@ -419,6 +433,13 @@ More implementation details about this modifier can be found in [`whole-archive`
 
 r[items.extern.attributes.link.modifiers.verbatim]
 #### Linking modifiers: `verbatim`
+
+> [!EXAMPLE]
+> <!-- ignore: requires extern linking -->
+> ```rust,ignore
+> #[link(name = "mylib", kind = "static", modifiers = "+verbatim")]
+> unsafe extern "C" {}
+> ```
 
 r[items.extern.attributes.link.modifiers.verbatim.allowed-kinds]
 This modifier is compatible with all linking kinds.
@@ -449,6 +470,13 @@ The `wasm_import_module` key may be used to specify the [WebAssembly module] nam
 
 r[items.extern.attributes.link.import_name_type]
 #### The `import_name_type` key
+
+> [!EXAMPLE]
+> <!-- ignore: requires extern linking -->
+> ```rust,ignore
+> #[link(name = "mylib", kind = "raw-dylib", import_name_type = "undecorated")]
+> unsafe extern "C" {}
+> ```
 
 r[items.extern.attributes.link.import_name_type.intro]
 On x86 Windows, names of functions are "decorated" (i.e., have a specific prefix and/or suffix added) to indicate their calling convention. For example, a `stdcall` calling convention function with the name `fn1` that has no arguments would be decorated as `_fn1@0`. However, the [PE Format] does also permit names to have no prefix or be undecorated. Additionally, the MSVC and GNU toolchains use different decorations for the same calling conventions which means, by default, some Win32 functions cannot be called using the `raw-dylib` link kind via the GNU toolchain.

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -251,6 +251,25 @@ r[items.extern.attributes.link]
 r[items.extern.attributes.link.intro]
 The *`link` [attribute][attributes]* specifies the name of a native library that the compiler should link with for the items within an `extern` block.
 
+> [!EXAMPLE]
+> <!-- ignore: requires extern linking -->
+> ```rust,ignore
+> #[link(name = "crypto")]
+> unsafe extern {
+>     // …
+> }
+>
+> #[link(name = "CoreFoundation", kind = "framework")]
+> unsafe extern {
+>     // …
+> }
+>
+> #[link(wasm_import_module = "foo")]
+> unsafe extern {
+>     // …
+> }
+> ```
+
 r[items.extern.attributes.link.syntax]
 It uses the [MetaListNameValueStr] syntax to specify its inputs. The `name` key is the name of the native library to link. The `kind` key is an optional value which specifies the kind of library with the following possible values:
 
@@ -280,24 +299,6 @@ Specifying multiple `modifiers` arguments in a single `link` attribute, or multi
 
 r[items.extern.attributes.link.wasm_import_module]
 The `wasm_import_module` key may be used to specify the [WebAssembly module] name for the items within an `extern` block when importing symbols from the host environment. The default module name is `env` if `wasm_import_module` is not specified.
-
-<!-- ignore: requires extern linking -->
-```rust,ignore
-#[link(name = "crypto")]
-unsafe extern {
-    // …
-}
-
-#[link(name = "CoreFoundation", kind = "framework")]
-unsafe extern {
-    // …
-}
-
-#[link(wasm_import_module = "foo")]
-unsafe extern {
-    // …
-}
-```
 
 r[items.extern.attributes.link.empty-block]
 It is valid to add the `link` attribute on an empty extern block. You can use this to satisfy the linking requirements of extern blocks elsewhere in your code (including upstream crates) instead of adding the attribute to each extern block.

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -392,7 +392,7 @@ r[items.extern.attributes.link.modifiers.bundle]
 > ```
 
 r[items.extern.attributes.link.modifiers.bundle.allowed-kinds]
-This modifier is only compatible with the `static` linking kind. Using any other kind will result in a compiler error.
+The `bundle` modifier may only be used with [`static` linking].
 
 r[items.extern.attributes.link.modifiers.bundle.behavior]
 When building a rlib or staticlib `+bundle` means that the native static library will be packed into the rlib or staticlib archive, and then retrieved from there during linking of the final binary.
@@ -421,7 +421,7 @@ r[items.extern.attributes.link.modifiers.whole-archive]
 > ```
 
 r[items.extern.attributes.link.modifiers.whole-archive.allowed-kinds]
-This modifier is only compatible with the `static` linking kind. Using any other kind will result in a compiler error.
+The `whole-archive` modifier may only be used with [`static` linking].
 
 r[items.extern.attributes.link.modifiers.whole-archive.behavior]
 `+whole-archive` means that the static library is linked as a whole archive without throwing any object files away.
@@ -578,3 +578,4 @@ Attributes on extern function parameters follow the same rules and restrictions 
 [win32 api]: https://learn.microsoft.com/en-us/windows/win32/api/
 [`link_ordinal`]: items.extern.attributes.link_ordinal
 [`extern` blocks]: external-blocks.md
+[`static` linking]: link.staticlib

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -432,8 +432,6 @@ More implementation details about this modifier can be found in [`verbatim` docu
 
 
 
-r[items.extern.attributes.link.kind-raw-dylib.platform-specific]
-`raw-dylib` is only supported on Windows. Using it when targeting other platforms will result in a compiler error.
 
 r[items.extern.attributes.link.import_name_type]
 #### The `import_name_type` key

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -274,7 +274,7 @@ r[items.extern.attributes.link.syntax]
 The `link` attribute uses the [MetaListNameValueStr] syntax to specify its inputs. It accepts the following keys:
 
 - [`name`][items.extern.attributes.link.name] --- the name of the native library to link.
-- [`kind`][items.extern.attributes.link.kinds] --- the kind of library.
+- [`kind`][items.extern.attributes.link.kind] --- the kind of library.
 - [`modifiers`][items.extern.attributes.link.modifiers] --- modifiers that change the behavior of how the library is linked.
 - [`wasm_import_module`][items.extern.attributes.link.wasm_import_module] --- specifies the WebAssembly module name.
 - [`import_name_type`][items.extern.attributes.link.import_name_type] --- on x86 Windows, this changes how functions are named.
@@ -306,20 +306,51 @@ The `name` key specifies the name of the library to link.
 r[items.extern.attributes.link.name.requirement]
 The `name` key must be included unless `wasm_import_module` is used.
 
-r[items.extern.attributes.link.kinds]
+r[items.extern.attributes.link.kind]
 #### The `kind` key
 
-r[items.extern.attributes.link.dylib]
-- `dylib` --- Indicates a dynamic library. This is the default if `kind` is not specified.
+r[items.extern.attributes.link.kind.intro]
+The `kind` key specifies the kind of the library.
 
-r[items.extern.attributes.link.static]
-- `static` --- Indicates a static library.
+r[items.extern.attributes.link.kind.dylib]
+The `dylib` kind indicates a dynamic library. This is the default if `kind` is not specified.
 
-r[items.extern.attributes.link.framework]
-- `framework` --- Indicates a macOS framework. This is only valid for macOS targets.
+> [!EXAMPLE]
+> <!-- ignore: requires extern linking -->
+> ```rust,ignore
+> #[link(name = "example", kind = "dylib")]
+> unsafe extern "C" {}
+> ```
 
-r[items.extern.attributes.link.raw-dylib]
-- `raw-dylib` --- Indicates a dynamic library where the compiler will generate an import library to link against (see [`dylib` versus `raw-dylib`] below for details). This is only valid for Windows targets.
+r[items.extern.attributes.link.kind.static]
+The `static` kind indicates a static library.
+
+> [!EXAMPLE]
+> <!-- ignore: requires extern linking -->
+> ```rust,ignore
+> #[link(name = "example", kind = "static")]
+> unsafe extern "C" {}
+> ```
+
+r[items.extern.attributes.link.kind.framework]
+The `framework` kind indicates a macOS framework. This is only valid for macOS targets.
+
+> [!EXAMPLE]
+> <!-- ignore: requires extern linking -->
+> ```rust,ignore
+> #[link(name = "CoreFoundation", kind = "framework")]
+> unsafe extern "C" {}
+> ```
+
+r[items.extern.attributes.link.kind.raw-dylib]
+The `raw-dylib` kind indicates a dynamic library where the compiler will generate an import library to link against (see [`dylib` versus `raw-dylib`] below for details). This is only valid for Windows targets.
+
+> [!EXAMPLE]
+> <!-- ignore: requires extern linking -->
+> ```rust,ignore
+> #[link(name = "example", kind = "raw-dylib")]
+> unsafe extern "C" {}
+> ```
 
 r[items.extern.attributes.link.modifiers]
 #### The `modifiers` key

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -408,7 +408,8 @@ This modifier has no effect when building other targets like executables or dyna
 r[items.extern.attributes.link.modifiers.bundle.default]
 The default for this modifier is `+bundle`.
 
-More implementation details about this modifier can be found in [`bundle` documentation for rustc].
+> [!NOTE]
+> More implementation details about this modifier can be found in [`bundle` documentation for rustc].
 
 r[items.extern.attributes.link.modifiers.whole-archive]
 #### Linking modifiers: `whole-archive`
@@ -429,7 +430,8 @@ r[items.extern.attributes.link.modifiers.whole-archive.behavior]
 r[items.extern.attributes.link.modifiers.whole-archive.default]
 The default for this modifier is `-whole-archive`.
 
-More implementation details about this modifier can be found in [`whole-archive` documentation for rustc].
+> [!NOTE]
+> More implementation details about this modifier can be found in [`whole-archive` documentation for rustc].
 
 r[items.extern.attributes.link.modifiers.verbatim]
 #### Linking modifiers: `verbatim`
@@ -453,7 +455,8 @@ r[items.extern.attributes.link.modifiers.verbatim.behavior-negative]
 r[items.extern.attributes.link.modifiers.verbatim.default]
 The default for this modifier is `-verbatim`.
 
-More implementation details about this modifier can be found in [`verbatim` documentation for rustc].
+> [!NOTE]
+> More implementation details about this modifier can be found in [`verbatim` documentation for rustc].
 
 r[items.extern.attributes.link.wasm_import_module]
 #### The `wasm_import_module` key

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -381,12 +381,6 @@ The `modifiers` argument may only be specified once.
 r[items.extern.attributes.link.modifiers.duplicates]
 Duplicate modifiers are not allowed within a `modifiers` argument.
 
-r[items.extern.attributes.link.wasm_import_module]
-#### The `wasm_import_module` key
-
-r[items.extern.attributes.link.wasm_import_module.behavior]
-The `wasm_import_module` key may be used to specify the [WebAssembly module] name for the items within an `extern` block when importing symbols from the host environment. The default module name is `env` if `wasm_import_module` is not specified.
-
 r[items.extern.attributes.link.modifiers.bundle]
 #### Linking modifiers: `bundle`
 
@@ -440,8 +434,18 @@ The default for this modifier is `-verbatim`.
 
 More implementation details about this modifier can be found in [`verbatim` documentation for rustc].
 
+r[items.extern.attributes.link.wasm_import_module]
+#### The `wasm_import_module` key
 
+r[items.extern.attributes.link.wasm_import_module.behavior]
+The `wasm_import_module` key may be used to specify the [WebAssembly module] name for the items within an `extern` block when importing symbols from the host environment. The default module name is `env` if `wasm_import_module` is not specified.
 
+> [!EXAMPLE]
+> <!-- ignore: requires extern linking -->
+> ```rust,ignore
+> #[link(wasm_import_module = "foo")]
+> unsafe extern "C" {}
+> ```
 
 r[items.extern.attributes.link.import_name_type]
 #### The `import_name_type` key


### PR DESCRIPTION
New rules:
- ❗ `items.extern.attributes.link.allowed-positions`
- ❗ `items.extern.attributes.link.duplicates`
- ❗ `items.extern.attributes.link.name`
- ❗ `items.extern.attributes.link.name.intro`
- ❗ `items.extern.attributes.link.kind`
- ❗ `items.extern.attributes.link.kind.intro`
- ❗ `items.extern.attributes.link.modifiers.intro`

Removed rules:
- ❌ `items.extern.attributes.link.kind-raw-dylib`, `items.extern.attributes.link.kind-raw-dylib.intro`,  `items.extern.attributes.link.kind-raw-dylib.import` -- moved into note

Renamed rules:
- `items.extern.attributes.link.dylib` is now `items.extern.attributes.link.kind.dylib`
- `items.extern.attributes.link.static` is now `items.extern.attributes.link.kind.static`
- `items.extern.attributes.link.framework` is now `items.extern.attributes.link.kind.framework`
- `items.extern.attributes.link.raw-dylib` is now `items.extern.attributes.link.kind.raw-dylib`
- `items.extern.attributes.link.name-requirement` is now `items.extern.attributes.link.name.requirement`
- `items.extern.attributes.link.modifiers.multiple` split into `items.extern.attributes.link.modifiers.once` and `items.extern.attributes.link.modifiers.duplicates`
- `items.extern.attributes.link.wasm_import_module` split into `items.extern.attributes.link.wasm_import_module.behavior`
- `items.extern.attributes.link.kind-raw-dylib.platform-specific` moved into `items.extern.attributes.link.kind.raw-dylib`
