### PR TITLE
Update `link_name` to use the attribute template

### DIFF
--- a/src/attributes/derive.md
+++ b/src/attributes/derive.md
@@ -96,7 +96,7 @@ r[attributes.derive.automatically_derived.duplicates]
 Duplicate instances of the `automatically_derived` attribute on the same implementation have no effect.
 
 > [!NOTE]
-> `rustc` lints against duplicate use of this attribute.
+> `rustc` lints against duplicate use of this attribute on uses following the first.
 
 r[attributes.derive.automatically_derived.behavior]
 The `automatically_derived` attribute has no behavior.

--- a/src/items/extern-crates.md
+++ b/src/items/extern-crates.md
@@ -104,7 +104,7 @@ r[items.extern-crate.no_link.duplicates]
 Duplicate instances of the `no_link` attribute are ignored.
 
 > [!NOTE]
-> `rustc` lints against duplicate use  of this attribute.
+> `rustc` lints against duplicate use of this attribute.
 
 [identifier]: ../identifiers.md
 [RFC 940]: https://github.com/rust-lang/rfcs/blob/master/text/0940-hyphens-considered-harmful.md

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -397,15 +397,16 @@ r[items.extern.attributes.link_name]
 r[items.extern.attributes.link_name.intro]
 The *`link_name` [attribute][attributes]* may be specified on declarations inside an `extern` block to indicate the symbol to import for the given function or static.
 
+> [!EXAMPLE]
+> ```rust
+> unsafe extern {
+>     #[link_name = "actual_symbol_name"]
+>     safe fn name_in_rust();
+> }
+> ```
+
 r[items.extern.attributes.link_name.syntax]
 It uses the [MetaNameValueStr] syntax to specify the name of the symbol.
-
-```rust
-unsafe extern {
-    #[link_name = "actual_symbol_name"]
-    safe fn name_in_rust();
-}
-```
 
 r[items.extern.attributes.link_name.exclusive]
 Using this attribute with the `link_ordinal` attribute will result in a compiler error.

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -395,30 +395,30 @@ r[items.extern.attributes.link_name]
 ### The `link_name` attribute
 
 r[items.extern.attributes.link_name.intro]
-The *`link_name` [attribute][attributes]* may be specified on declarations inside an `extern` block to indicate the symbol to import for the given function or static.
+The *`link_name` [attribute][attributes]* may be applied to declarations inside an `extern` block to specify the symbol to import for the given function or static.
 
 > [!EXAMPLE]
 > ```rust
-> unsafe extern {
+> unsafe extern "C" {
 >     #[link_name = "actual_symbol_name"]
 >     safe fn name_in_rust();
 > }
 > ```
 
 r[items.extern.attributes.link_name.syntax]
-The `link_name` attribute uses the [MetaNameValueStr] syntax to specify the name of the symbol.
+The `link_name` attribute uses the [MetaNameValueStr] syntax.
 
 r[items.extern.attributes.link_name.allowed-positions]
-The `link_name` attribute may be specified on a function or static in an `extern` block.
+The `link_name` attribute may only be applied to a function or static item in an `extern` block.
 
 > [!NOTE]
-> `rustc` currently warns in other positions, but this may be rejected in the future.
+> `rustc` currently accepts and ignores the attribute in other positions but lints against it. This may become a hard error in the future.
 
 r[items.extern.attributes.link_name.duplicates]
 Only the last instance of `link_name` on an item is used to determine the symbol name.
 
 > [!NOTE]
-> `rustc` currently warns on preceding duplicate `link_name` attributes. This may become an error in the future.
+> `rustc` lints against duplicate use of this attribute on uses preceding the last. This may become a hard error in the future.
 
 r[items.extern.attributes.link_name.link_ordinal]
 The `link_name` attribute may not be used with the [`link_ordinal`] attribute.

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -406,10 +406,22 @@ The *`link_name` [attribute][attributes]* may be specified on declarations insid
 > ```
 
 r[items.extern.attributes.link_name.syntax]
-It uses the [MetaNameValueStr] syntax to specify the name of the symbol.
+The `link_name` attribute uses the [MetaNameValueStr] syntax to specify the name of the symbol.
 
-r[items.extern.attributes.link_name.exclusive]
-Using this attribute with the `link_ordinal` attribute will result in a compiler error.
+r[items.extern.attributes.link_name.allowed-positions]
+The `link_name` attribute may be specified on a function or static in an `extern` block.
+
+> [!NOTE]
+> `rustc` currently warns in other positions, but this may be rejected in the future.
+
+r[items.extern.attributes.link_name.duplicates]
+Only the last instance of `link_name` on an item is used to determine the symbol name.
+
+> [!NOTE]
+> `rustc` currently warns on preceding duplicate `link_name` attributes. This may become an error in the future.
+
+r[items.extern.attributes.link_name.link_ordinal]
+The `link_name` attribute may not be used with the [`link_ordinal`] attribute.
 
 r[items.extern.attributes.link_ordinal]
 ### The `link_ordinal` attribute
@@ -460,3 +472,4 @@ restrictions as [regular function parameters].
 [statics]: static-items.md
 [unwind-behavior]: functions.md#unwinding
 [value namespace]: ../names/namespaces.md
+[`link_ordinal`]: items.extern.attributes.link_ordinal

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -395,8 +395,7 @@ r[items.extern.attributes.link_name]
 ### The `link_name` attribute
 
 r[items.extern.attributes.link_name.intro]
-The *`link_name` attribute* may be specified on declarations inside an `extern`
-block to indicate the symbol to import for the given function or static.
+The *`link_name` attribute* may be specified on declarations inside an `extern` block to indicate the symbol to import for the given function or static.
 
 r[items.extern.attributes.link_name.syntax]
 It uses the [MetaNameValueStr] syntax to specify the name of the symbol.
@@ -409,8 +408,7 @@ unsafe extern {
 ```
 
 r[items.extern.attributes.link_name.exclusive]
-Using this attribute with the `link_ordinal` attribute will result in a
-compiler error.
+Using this attribute with the `link_ordinal` attribute will result in a compiler error.
 
 r[items.extern.attributes.link_ordinal]
 ### The `link_ordinal` attribute

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -395,7 +395,7 @@ r[items.extern.attributes.link_name]
 ### The `link_name` attribute
 
 r[items.extern.attributes.link_name.intro]
-The *`link_name` attribute* may be specified on declarations inside an `extern` block to indicate the symbol to import for the given function or static.
+The *`link_name` [attribute][attributes]* may be specified on declarations inside an `extern` block to indicate the symbol to import for the given function or static.
 
 r[items.extern.attributes.link_name.syntax]
 It uses the [MetaNameValueStr] syntax to specify the name of the symbol.


### PR DESCRIPTION
New rules:
- ❗ `items.extern.attributes.link_name.allowed-positions`
- ❗ `items.extern.attributes.link_name.duplicates`

Renamed rules:
- `items.extern.attributes.link_name.exclusive` is now `items.extern.attributes.link_name.link_ordinal`
