### PR TITLE
Update `export_name` to use the attribute template

### DIFF
--- a/src/abi.md
+++ b/src/abi.md
@@ -126,7 +126,7 @@ The *`export_name` [attribute]* specifies the name of the symbol that will be ex
 > ```
 
 r[abi.export_name.syntax]
-The `export_name `attribute uses the [MetaNameValueStr] syntax to specify the symbol name.
+The `export_name` attribute uses the [MetaNameValueStr] syntax to specify the symbol name.
 
 r[abi.export_name.unsafe]
 This attribute is unsafe as a symbol with a custom name may collide with another symbol with the same name (or with a well-known symbol), leading to undefined behavior.

--- a/src/abi.md
+++ b/src/abi.md
@@ -158,6 +158,9 @@ If `export_name` is used with [`no_mangle`][abi.no_mangle], then the `export_nam
 r[abi.export_name.publicly-exported]
 The `export_name` attribute causes the symbol to be publicly exported from the produced library or object file, similar to the [`used` attribute](#the-used-attribute).
 
+r[abi.export_name.null]
+The exported name must not contain a [NUL] character.
+
 [attribute]: attributes.md
 [extern functions]: items/functions.md#extern-function-qualifier
 [external blocks]: items/external-blocks.md

--- a/src/abi.md
+++ b/src/abi.md
@@ -152,6 +152,9 @@ r[abi.export_name.edition2024]
 > [!EDITION-2024]
 > Before the 2024 edition it is allowed to use the `export_name` attribute without the `unsafe` qualification.
 
+r[abi.export_name.no_mangle]
+If `export_name` is used with [`no_mangle`][abi.no_mangle], then the `export_name` is used instead.
+
 [attribute]: attributes.md
 [extern functions]: items/functions.md#extern-function-qualifier
 [external blocks]: items/external-blocks.md

--- a/src/abi.md
+++ b/src/abi.md
@@ -128,14 +128,25 @@ The *`export_name` [attribute]* specifies the name of the symbol that will be ex
 r[abi.export_name.syntax]
 The `export_name` attribute uses the [MetaNameValueStr] syntax to specify the symbol name.
 
-r[abi.export_name.unsafe]
-This attribute is unsafe as a symbol with a custom name may collide with another symbol with the same name (or with a well-known symbol), leading to undefined behavior.
+r[abi.export_name.allowed-positions]
+The `export_name` attribute may only be applied to:
+
+- [Static items][items.static]
+- [Free functions][items.fn]
+- [Inherent associated functions][items.associated.fn]
+- [Trait impl functions][items.impl.trait]
+
+> [!NOTE]
+> `rustc` currently ignores `export_name` in some positions, but this may be rejected in the future.
 
 r[abi.export_name.duplicates]
 Only the first use of `export_name` on an item has effect.
 
 > [!NOTE]
 > `rustc` lints against any use following the first with a future-compatibility warning. This may become an error in the future.
+
+r[abi.export_name.unsafe]
+This attribute is unsafe as a symbol with a custom name may collide with another symbol with the same name (or with a well-known symbol), leading to undefined behavior.
 
 r[abi.export_name.edition2024]
 > [!EDITION-2024]

--- a/src/abi.md
+++ b/src/abi.md
@@ -122,6 +122,7 @@ r[abi.link_section.edition2024]
 > [!EDITION-2024]
 > Before the 2024 edition it is allowed to use the `link_section` attribute without the `unsafe` qualification.
 
+<!-- template:attributes -->
 r[abi.export_name]
 ## The `export_name` attribute
 

--- a/src/abi.md
+++ b/src/abi.md
@@ -167,6 +167,9 @@ If `export_name` is used with [`no_mangle`][abi.no_mangle], then the `export_nam
 r[abi.export_name.publicly-exported]
 The `export_name` attribute causes the symbol to be publicly exported from the produced library or object file, similar to the [`used` attribute](#the-used-attribute).
 
+r[abi.export_name.null]
+The exported name must not contain a [NUL] character.
+
 [attribute]: attributes.md
 [extern functions]: items/functions.md#extern-function-qualifier
 [external blocks]: items/external-blocks.md

--- a/src/abi.md
+++ b/src/abi.md
@@ -137,14 +137,25 @@ The *`export_name` [attribute]* specifies the name of the symbol that will be ex
 r[abi.export_name.syntax]
 The `export_name` attribute uses the [MetaNameValueStr] syntax to specify the symbol name.
 
-r[abi.export_name.unsafe]
-This attribute is unsafe as a symbol with a custom name may collide with another symbol with the same name (or with a well-known symbol), leading to undefined behavior.
+r[abi.export_name.allowed-positions]
+The `export_name` attribute may only be applied to:
+
+- [Static items][items.static]
+- [Free functions][items.fn]
+- [Inherent associated functions][items.associated.fn]
+- [Trait impl functions][items.impl.trait]
+
+> [!NOTE]
+> `rustc` currently ignores `export_name` in some positions, but this may be rejected in the future.
 
 r[abi.export_name.duplicates]
 Only the first use of `export_name` on an item has effect.
 
 > [!NOTE]
 > `rustc` lints against any use following the first with a future-compatibility warning. This may become an error in the future.
+
+r[abi.export_name.unsafe]
+This attribute is unsafe as a symbol with a custom name may collide with another symbol with the same name (or with a well-known symbol), leading to undefined behavior.
 
 r[abi.export_name.edition2024]
 > [!EDITION-2024]

--- a/src/abi.md
+++ b/src/abi.md
@@ -155,7 +155,7 @@ Only the first use of `export_name` on an item has effect.
 > `rustc` lints against any use following the first with a future-compatibility warning. This may become an error in the future.
 
 r[abi.export_name.unsafe]
-This attribute is unsafe as a symbol with a custom name may collide with another symbol with the same name (or with a well-known symbol), leading to undefined behavior.
+The `export_name` attribute must be marked with [`unsafe`][attributes.safety] because a symbol with a custom name may collide with another symbol with the same name (or with a well-known symbol), leading to undefined behavior.
 
 r[abi.export_name.edition2024]
 > [!EDITION-2024]

--- a/src/abi.md
+++ b/src/abi.md
@@ -113,6 +113,7 @@ r[abi.link_section.edition2024]
 > [!EDITION-2024]
 > Before the 2024 edition it is allowed to use the `link_section` attribute without the `unsafe` qualification.
 
+<!-- template:attributes -->
 r[abi.export_name]
 ## The `export_name` attribute
 

--- a/src/abi.md
+++ b/src/abi.md
@@ -126,8 +126,7 @@ r[abi.export_name]
 ## The `export_name` attribute
 
 r[abi.export_name.intro]
-The *`export_name` attribute* specifies the name of the symbol that will be
-exported on a [function] or [static].
+The *`export_name` attribute* specifies the name of the symbol that will be exported on a [function] or [static].
 
 r[abi.export_name.syntax]
 The `export_name `attribute uses the [MetaNameValueStr] syntax to specify the symbol name.
@@ -138,9 +137,7 @@ pub fn name_in_rust() { }
 ```
 
 r[abi.export_name.unsafe]
-This attribute is unsafe as a symbol with a custom name may collide with another
-symbol with the same name (or with a well-known symbol), leading to undefined
-behavior.
+This attribute is unsafe as a symbol with a custom name may collide with another symbol with the same name (or with a well-known symbol), leading to undefined behavior.
 
 r[abi.export_name.duplicates]
 Only the first use of `export_name` on an item has effect.

--- a/src/abi.md
+++ b/src/abi.md
@@ -135,7 +135,7 @@ The *`export_name` [attribute]* specifies the name of the symbol that will be ex
 > ```
 
 r[abi.export_name.syntax]
-The `export_name `attribute uses the [MetaNameValueStr] syntax to specify the symbol name.
+The `export_name` attribute uses the [MetaNameValueStr] syntax to specify the symbol name.
 
 r[abi.export_name.unsafe]
 This attribute is unsafe as a symbol with a custom name may collide with another symbol with the same name (or with a well-known symbol), leading to undefined behavior.

--- a/src/abi.md
+++ b/src/abi.md
@@ -128,13 +128,14 @@ r[abi.export_name]
 r[abi.export_name.intro]
 The *`export_name` attribute* specifies the name of the symbol that will be exported on a [function] or [static].
 
+> [!EXAMPLE]
+> ```rust
+> #[unsafe(export_name = "exported_symbol_name")]
+> pub fn name_in_rust() { }
+> ```
+
 r[abi.export_name.syntax]
 The `export_name `attribute uses the [MetaNameValueStr] syntax to specify the symbol name.
-
-```rust
-#[unsafe(export_name = "exported_symbol_name")]
-pub fn name_in_rust() { }
-```
 
 r[abi.export_name.unsafe]
 This attribute is unsafe as a symbol with a custom name may collide with another symbol with the same name (or with a well-known symbol), leading to undefined behavior.

--- a/src/abi.md
+++ b/src/abi.md
@@ -168,8 +168,8 @@ If `export_name` is used with [`no_mangle`][abi.no_mangle], then the `export_nam
 r[abi.export_name.publicly-exported]
 The `export_name` attribute causes the symbol to be publicly exported from the produced library or object file, similar to the [`used` attribute](#the-used-attribute).
 
-r[abi.export_name.null]
-The exported name must not contain a [NUL] character.
+r[abi.export_name.invalid-names]
+The exported name must not be the empty string, and must not contain any `U+0000` (NUL) bytes.
 
 r[abi.export_name.generic]
 `export_name` has no effect on generic items.

--- a/src/abi.md
+++ b/src/abi.md
@@ -161,6 +161,9 @@ The `export_name` attribute causes the symbol to be publicly exported from the p
 r[abi.export_name.null]
 The exported name must not contain a [NUL] character.
 
+r[abi.export_name.generic]
+`export_name` has no effect on generic items.
+
 [attribute]: attributes.md
 [extern functions]: items/functions.md#extern-function-qualifier
 [external blocks]: items/external-blocks.md

--- a/src/abi.md
+++ b/src/abi.md
@@ -161,6 +161,9 @@ r[abi.export_name.edition2024]
 > [!EDITION-2024]
 > Before the 2024 edition it is allowed to use the `export_name` attribute without the `unsafe` qualification.
 
+r[abi.export_name.no_mangle]
+If `export_name` is used with [`no_mangle`][abi.no_mangle], then the `export_name` is used instead.
+
 [attribute]: attributes.md
 [extern functions]: items/functions.md#extern-function-qualifier
 [external blocks]: items/external-blocks.md

--- a/src/abi.md
+++ b/src/abi.md
@@ -146,7 +146,7 @@ Only the first use of `export_name` on an item has effect.
 > `rustc` lints against any use following the first with a future-compatibility warning. This may become an error in the future.
 
 r[abi.export_name.unsafe]
-This attribute is unsafe as a symbol with a custom name may collide with another symbol with the same name (or with a well-known symbol), leading to undefined behavior.
+The `export_name` attribute must be marked with [`unsafe`][attributes.safety] because a symbol with a custom name may collide with another symbol with the same name (or with a well-known symbol), leading to undefined behavior.
 
 r[abi.export_name.edition2024]
 > [!EDITION-2024]

--- a/src/abi.md
+++ b/src/abi.md
@@ -170,6 +170,9 @@ The `export_name` attribute causes the symbol to be publicly exported from the p
 r[abi.export_name.null]
 The exported name must not contain a [NUL] character.
 
+r[abi.export_name.generic]
+`export_name` has no effect on generic items.
+
 [attribute]: attributes.md
 [extern functions]: items/functions.md#extern-function-qualifier
 [external blocks]: items/external-blocks.md

--- a/src/abi.md
+++ b/src/abi.md
@@ -164,6 +164,9 @@ r[abi.export_name.edition2024]
 r[abi.export_name.no_mangle]
 If `export_name` is used with [`no_mangle`][abi.no_mangle], then the `export_name` is used instead.
 
+r[abi.export_name.publicly-exported]
+The `export_name` attribute causes the symbol to be publicly exported from the produced library or object file, similar to the [`used` attribute](#the-used-attribute).
+
 [attribute]: attributes.md
 [extern functions]: items/functions.md#extern-function-qualifier
 [external blocks]: items/external-blocks.md

--- a/src/abi.md
+++ b/src/abi.md
@@ -119,13 +119,14 @@ r[abi.export_name]
 r[abi.export_name.intro]
 The *`export_name` attribute* specifies the name of the symbol that will be exported on a [function] or [static].
 
+> [!EXAMPLE]
+> ```rust
+> #[unsafe(export_name = "exported_symbol_name")]
+> pub fn name_in_rust() { }
+> ```
+
 r[abi.export_name.syntax]
 The `export_name `attribute uses the [MetaNameValueStr] syntax to specify the symbol name.
-
-```rust
-#[unsafe(export_name = "exported_symbol_name")]
-pub fn name_in_rust() { }
-```
 
 r[abi.export_name.unsafe]
 This attribute is unsafe as a symbol with a custom name may collide with another symbol with the same name (or with a well-known symbol), leading to undefined behavior.

--- a/src/abi.md
+++ b/src/abi.md
@@ -155,6 +155,9 @@ r[abi.export_name.edition2024]
 r[abi.export_name.no_mangle]
 If `export_name` is used with [`no_mangle`][abi.no_mangle], then the `export_name` is used instead.
 
+r[abi.export_name.publicly-exported]
+The `export_name` attribute causes the symbol to be publicly exported from the produced library or object file, similar to the [`used` attribute](#the-used-attribute).
+
 [attribute]: attributes.md
 [extern functions]: items/functions.md#extern-function-qualifier
 [external blocks]: items/external-blocks.md

--- a/src/abi.md
+++ b/src/abi.md
@@ -117,7 +117,7 @@ r[abi.export_name]
 ## The `export_name` attribute
 
 r[abi.export_name.intro]
-The *`export_name` attribute* specifies the name of the symbol that will be exported on a [function] or [static].
+The *`export_name` [attribute]* specifies the name of the symbol that will be exported on a [function] or [static].
 
 > [!EXAMPLE]
 > ```rust

--- a/src/abi.md
+++ b/src/abi.md
@@ -159,8 +159,8 @@ If `export_name` is used with [`no_mangle`][abi.no_mangle], then the `export_nam
 r[abi.export_name.publicly-exported]
 The `export_name` attribute causes the symbol to be publicly exported from the produced library or object file, similar to the [`used` attribute](#the-used-attribute).
 
-r[abi.export_name.null]
-The exported name must not contain a [NUL] character.
+r[abi.export_name.invalid-names]
+The exported name must not be the empty string, and must not contain any `U+0000` (NUL) bytes.
 
 r[abi.export_name.generic]
 `export_name` has no effect on generic items.

--- a/src/abi.md
+++ b/src/abi.md
@@ -126,7 +126,7 @@ r[abi.export_name]
 ## The `export_name` attribute
 
 r[abi.export_name.intro]
-The *`export_name` attribute* specifies the name of the symbol that will be exported on a [function] or [static].
+The *`export_name` [attribute]* specifies the name of the symbol that will be exported on a [function] or [static].
 
 > [!EXAMPLE]
 > ```rust


### PR DESCRIPTION
New rules:
- ❗ `abi.export_name.allowed-positions`
- ❗ `abi.export_name.duplicates`
- ❗ `abi.export_name.no_mangle`
- ❗ `abi.export_name.publicly-exported`
- ❗ `abi.export_name.invalid-names`
- ❗ `abi.export_name.generic`
