### PR TITLE
Update `link_section` to use the attribute template

### DIFF
--- a/src/abi.md
+++ b/src/abi.md
@@ -90,10 +90,10 @@ r[abi.link_section]
 ## The `link_section` attribute
 
 r[abi.link_section.intro]
-The *`link_section` attribute* specifies the section of the object file that a [function] or [static]'s content will be placed into.
 
 r[abi.link_section.syntax]
 The `link_section` attribute uses the [MetaNameValueStr] syntax to specify the section name.
+The *`link_section` [attribute]* specifies the section of the object file that a [function] or [static]'s content will be placed into.
 
 <!-- no_run: don't link. The format of the section name is platform-specific. -->
 ```rust,no_run

--- a/src/abi.md
+++ b/src/abi.md
@@ -124,7 +124,7 @@ Only the first use of `link_section` on an item has effect.
 > `rustc` lints against any use following the first with a future-compatibility warning. This may become an error in the future.
 
 r[abi.link_section.unsafe]
-This attribute is unsafe as it allows users to place data and code into sections of memory not expecting them, such as mutable data into read-only areas.
+The `link_section` attribute must be marked with [`unsafe`][attributes.safety] because it allows users to place data and code into sections of memory not expecting them, such as mutable data into read-only areas.
 
 r[abi.link_section.edition2024]
 > [!EDITION-2024]

--- a/src/abi.md
+++ b/src/abi.md
@@ -105,14 +105,26 @@ The *`link_section` [attribute]* specifies the section of the object file that a
 r[abi.link_section.syntax]
 The `link_section` attribute uses the [MetaNameValueStr] syntax to specify the section name.
 
-r[abi.link_section.unsafe]
-This attribute is unsafe as it allows users to place data and code into sections of memory not expecting them, such as mutable data into read-only areas.
+r[abi.link_section.allowed-positions]
+The `link_section` attribute may only be applied to:
+
+- [Static items][items.static]
+- [Free functions][items.fn]
+- [Inherent associated functions][items.associated.fn]
+- [Trait impl functions][items.impl.trait]
+- [Trait definition functions][items.traits] with a body
+
+> [!NOTE]
+> `rustc` currently warns in other positions, but this may be rejected in the future.
 
 r[abi.link_section.duplicates]
 Only the first use of `link_section` on an item has effect.
 
 > [!NOTE]
 > `rustc` lints against any use following the first with a future-compatibility warning. This may become an error in the future.
+
+r[abi.link_section.unsafe]
+This attribute is unsafe as it allows users to place data and code into sections of memory not expecting them, such as mutable data into read-only areas.
 
 r[abi.link_section.edition2024]
 > [!EDITION-2024]

--- a/src/abi.md
+++ b/src/abi.md
@@ -120,7 +120,7 @@ Only the first use of `link_section` on an item has effect.
 > `rustc` lints against any use following the first with a future-compatibility warning. This may become an error in the future.
 
 r[abi.link_section.unsafe]
-This attribute is unsafe as it allows users to place data and code into sections of memory not expecting them, such as mutable data into read-only areas.
+The `link_section` attribute must be marked with [`unsafe`][attributes.safety] because it allows users to place data and code into sections of memory not expecting them, such as mutable data into read-only areas.
 
 r[abi.link_section.edition2024]
 > [!EDITION-2024]

--- a/src/abi.md
+++ b/src/abi.md
@@ -101,14 +101,26 @@ The *`link_section` [attribute]* specifies the section of the object file that a
 r[abi.link_section.syntax]
 The `link_section` attribute uses the [MetaNameValueStr] syntax to specify the section name.
 
-r[abi.link_section.unsafe]
-This attribute is unsafe as it allows users to place data and code into sections of memory not expecting them, such as mutable data into read-only areas.
+r[abi.link_section.allowed-positions]
+The `link_section` attribute may only be applied to:
+
+- [Static items][items.static]
+- [Free functions][items.fn]
+- [Inherent associated functions][items.associated.fn]
+- [Trait impl functions][items.impl.trait]
+- [Trait definition functions][items.traits] with a body
+
+> [!NOTE]
+> `rustc` currently warns in other positions, but this may be rejected in the future.
 
 r[abi.link_section.duplicates]
 Only the first use of `link_section` on an item has effect.
 
 > [!NOTE]
 > `rustc` lints against any use following the first with a future-compatibility warning. This may become an error in the future.
+
+r[abi.link_section.unsafe]
+This attribute is unsafe as it allows users to place data and code into sections of memory not expecting them, such as mutable data into read-only areas.
 
 r[abi.link_section.edition2024]
 > [!EDITION-2024]

--- a/src/abi.md
+++ b/src/abi.md
@@ -90,19 +90,20 @@ r[abi.link_section]
 ## The `link_section` attribute
 
 r[abi.link_section.intro]
+The *`link_section` [attribute]* specifies the section of the object file that a [function] or [static]'s content will be placed into.
+
+> [!EXAMPLE]
+> <!-- no_run: don't link. The format of the section name is platform-specific. -->
+> ```rust,no_run
+> # #[cfg(target_os = "linux")] {
+> #[unsafe(no_mangle)]
+> #[unsafe(link_section = ".example_section")]
+> pub static VAR1: u32 = 1;
+> # }
+> ```
 
 r[abi.link_section.syntax]
 The `link_section` attribute uses the [MetaNameValueStr] syntax to specify the section name.
-The *`link_section` [attribute]* specifies the section of the object file that a [function] or [static]'s content will be placed into.
-
-<!-- no_run: don't link. The format of the section name is platform-specific. -->
-```rust,no_run
-# #[cfg(target_os = "linux")] {
-#[unsafe(no_mangle)]
-#[unsafe(link_section = ".example_section")]
-pub static VAR1: u32 = 1;
-# }
-```
 
 r[abi.link_section.unsafe]
 This attribute is unsafe as it allows users to place data and code into sections of memory not expecting them, such as mutable data into read-only areas.

--- a/src/abi.md
+++ b/src/abi.md
@@ -82,6 +82,7 @@ r[abi.no_mangle.edition2024]
 > [!EDITION-2024]
 > Before the 2024 edition it is allowed to use the `no_mangle` attribute without the `unsafe` qualification.
 
+<!-- template:attributes -->
 r[abi.link_section]
 ## The `link_section` attribute
 
@@ -111,7 +112,7 @@ The `link_section` attribute may only be applied to:
 - [Trait definition functions][items.traits] with a body
 
 > [!NOTE]
-> `rustc` currently warns in other positions, but this may be rejected in the future.
+> `rustc` ignores use in other positions but lints against it. This may become an error in the future.
 
 r[abi.link_section.duplicates]
 Only the first use of `link_section` on an item has effect.

--- a/src/abi.md
+++ b/src/abi.md
@@ -86,10 +86,10 @@ r[abi.link_section]
 ## The `link_section` attribute
 
 r[abi.link_section.intro]
-The *`link_section` attribute* specifies the section of the object file that a [function] or [static]'s content will be placed into.
 
 r[abi.link_section.syntax]
 The `link_section` attribute uses the [MetaNameValueStr] syntax to specify the section name.
+The *`link_section` [attribute]* specifies the section of the object file that a [function] or [static]'s content will be placed into.
 
 <!-- no_run: don't link. The format of the section name is platform-specific. -->
 ```rust,no_run

--- a/src/abi.md
+++ b/src/abi.md
@@ -126,6 +126,9 @@ r[abi.link_section.edition2024]
 > [!EDITION-2024]
 > Before the 2024 edition it is allowed to use the `link_section` attribute without the `unsafe` qualification.
 
+r[abi.link_section.null]
+The section name must not contain a [NUL] character.
+
 r[abi.export_name]
 ## The `export_name` attribute
 

--- a/src/abi.md
+++ b/src/abi.md
@@ -86,19 +86,20 @@ r[abi.link_section]
 ## The `link_section` attribute
 
 r[abi.link_section.intro]
+The *`link_section` [attribute]* specifies the section of the object file that a [function] or [static]'s content will be placed into.
+
+> [!EXAMPLE]
+> <!-- no_run: don't link. The format of the section name is platform-specific. -->
+> ```rust,no_run
+> # #[cfg(target_os = "linux")] {
+> #[unsafe(no_mangle)]
+> #[unsafe(link_section = ".example_section")]
+> pub static VAR1: u32 = 1;
+> # }
+> ```
 
 r[abi.link_section.syntax]
 The `link_section` attribute uses the [MetaNameValueStr] syntax to specify the section name.
-The *`link_section` [attribute]* specifies the section of the object file that a [function] or [static]'s content will be placed into.
-
-<!-- no_run: don't link. The format of the section name is platform-specific. -->
-```rust,no_run
-# #[cfg(target_os = "linux")] {
-#[unsafe(no_mangle)]
-#[unsafe(link_section = ".example_section")]
-pub static VAR1: u32 = 1;
-# }
-```
 
 r[abi.link_section.unsafe]
 This attribute is unsafe as it allows users to place data and code into sections of memory not expecting them, such as mutable data into read-only areas.

--- a/src/abi.md
+++ b/src/abi.md
@@ -130,6 +130,9 @@ r[abi.link_section.edition2024]
 > [!EDITION-2024]
 > Before the 2024 edition it is allowed to use the `link_section` attribute without the `unsafe` qualification.
 
+r[abi.link_section.null]
+The section name must not contain a [NUL] character.
+
 r[abi.export_name]
 ## The `export_name` attribute
 

--- a/src/abi.md
+++ b/src/abi.md
@@ -90,8 +90,7 @@ r[abi.link_section]
 ## The `link_section` attribute
 
 r[abi.link_section.intro]
-The *`link_section` attribute* specifies the section of the object file that a
-[function] or [static]'s content will be placed into.
+The *`link_section` attribute* specifies the section of the object file that a [function] or [static]'s content will be placed into.
 
 r[abi.link_section.syntax]
 The `link_section` attribute uses the [MetaNameValueStr] syntax to specify the section name.
@@ -106,8 +105,7 @@ pub static VAR1: u32 = 1;
 ```
 
 r[abi.link_section.unsafe]
-This attribute is unsafe as it allows users to place data and code into sections
-of memory not expecting them, such as mutable data into read-only areas.
+This attribute is unsafe as it allows users to place data and code into sections of memory not expecting them, such as mutable data into read-only areas.
 
 r[abi.link_section.duplicates]
 Only the first use of `link_section` on an item has effect.

--- a/src/abi.md
+++ b/src/abi.md
@@ -86,6 +86,7 @@ r[abi.no_mangle.edition2024]
 > [!EDITION-2024]
 > Before the 2024 edition it is allowed to use the `no_mangle` attribute without the `unsafe` qualification.
 
+<!-- template:attributes -->
 r[abi.link_section]
 ## The `link_section` attribute
 
@@ -115,7 +116,7 @@ The `link_section` attribute may only be applied to:
 - [Trait definition functions][items.traits] with a body
 
 > [!NOTE]
-> `rustc` currently warns in other positions, but this may be rejected in the future.
+> `rustc` ignores use in other positions but lints against it. This may become an error in the future.
 
 r[abi.link_section.duplicates]
 Only the first use of `link_section` on an item has effect.


### PR DESCRIPTION
New rules:
- ❗ `abi.link_section.allowed-positions`
- ❗ `abi.link_section.duplicates`
- ❗ `abi.link_section.null`
