### PR TITLE
Update `no_mangle` to use the attribute template

### DIFF
--- a/src/abi.md
+++ b/src/abi.md
@@ -67,13 +67,13 @@ r[abi.no_mangle]
 r[abi.no_mangle.intro]
 The *`no_mangle` attribute* may be used on any [item] to disable standard symbol name mangling. The symbol for the item will be the identifier of the item's name.
 
-r[abi.no_mangle.unsafe]
-This attribute is unsafe as an unmangled symbol may collide with another symbol with the same name (or with a well-known symbol), leading to undefined behavior.
-
 ```rust
 #[unsafe(no_mangle)]
 extern "C" fn foo() {}
 ```
+
+r[abi.no_mangle.unsafe]
+The `no_mangle` attribute must be marked with [`unsafe`][attributes.safety] because an unmangled symbol may collide with another symbol with the same name (or with a well-known symbol), leading to undefined behavior.
 
 r[abi.no_mangle.edition2024]
 > [!EDITION-2024]

--- a/src/abi.md
+++ b/src/abi.md
@@ -100,6 +100,9 @@ Only the first instance of `no_mangle` on an item is honored. Subsequent `no_man
 > [!NOTE]
 > `rustc` currently warns on subsequent duplicate `no_mangle` attributes.
 
+r[abi.no_mangle.export_name]
+If `no_mangle` is used with [`export_name`][abi.export_name], then the `export_name` is used instead.
+
 r[abi.no_mangle.unsafe]
 The `no_mangle` attribute must be marked with [`unsafe`][attributes.safety] because an unmangled symbol may collide with another symbol with the same name (or with a well-known symbol), leading to undefined behavior.
 

--- a/src/abi.md
+++ b/src/abi.md
@@ -117,6 +117,9 @@ In addition to disabling name mangling, the item will be publicly exported from 
 r[abi.no_mangle.ascii-only]
 `no_mangle` may only be used on items with a name that only contains ASCII characters.
 
+r[abi.no_mangle.generic]
+`no_mangle` has no effect on generic items.
+
 r[abi.link_section]
 ## The `link_section` attribute
 

--- a/src/abi.md
+++ b/src/abi.md
@@ -67,9 +67,6 @@ r[abi.no_mangle]
 r[abi.no_mangle.intro]
 The *`no_mangle` attribute* may be used on any [item] to disable standard symbol name mangling. The symbol for the item will be the identifier of the item's name.
 
-r[abi.no_mangle.publicly-exported]
-Additionally, the item will be publicly exported from the produced library or object file, similar to the [`used` attribute](#the-used-attribute).
-
 r[abi.no_mangle.unsafe]
 This attribute is unsafe as an unmangled symbol may collide with another symbol with the same name (or with a well-known symbol), leading to undefined behavior.
 
@@ -81,6 +78,9 @@ extern "C" fn foo() {}
 r[abi.no_mangle.edition2024]
 > [!EDITION-2024]
 > Before the 2024 edition it is allowed to use the `no_mangle` attribute without the `unsafe` qualification.
+
+r[abi.no_mangle.publicly-exported]
+In addition to disabling name mangling, the item will be publicly exported from the produced library or object file, similar to the [`used` attribute](#the-used-attribute).
 
 r[abi.link_section]
 ## The `link_section` attribute

--- a/src/abi.md
+++ b/src/abi.md
@@ -67,10 +67,11 @@ r[abi.no_mangle]
 r[abi.no_mangle.intro]
 The *`no_mangle` attribute* may be used on functions and statics to disable standard symbol name mangling. The symbol for the item will be the identifier of the item's name.
 
-```rust
-#[unsafe(no_mangle)]
-extern "C" fn foo() {}
-```
+> [!EXAMPLE]
+> ```rust
+> #[unsafe(no_mangle)]
+> extern "C" fn foo() {}
+> ```
 
 r[abi.no_mangle.syntax]
 The `no_mangle` attribute uses the [MetaWord] syntax and thus does not take any inputs.

--- a/src/abi.md
+++ b/src/abi.md
@@ -113,6 +113,9 @@ r[abi.no_mangle.edition2024]
 r[abi.no_mangle.publicly-exported]
 In addition to disabling name mangling, the item will be publicly exported from the produced library or object file, similar to the [`used` attribute](#the-used-attribute).
 
+r[abi.no_mangle.ascii-only]
+`no_mangle` may only be used on items with a name that only contains ASCII characters.
+
 r[abi.link_section]
 ## The `link_section` attribute
 

--- a/src/abi.md
+++ b/src/abi.md
@@ -65,7 +65,7 @@ r[abi.no_mangle]
 ## The `no_mangle` attribute
 
 r[abi.no_mangle.intro]
-The *`no_mangle` attribute* may be used on any [item] to disable standard symbol name mangling. The symbol for the item will be the identifier of the item's name.
+The *`no_mangle` attribute* may be used on functions and statics to disable standard symbol name mangling. The symbol for the item will be the identifier of the item's name.
 
 ```rust
 #[unsafe(no_mangle)]

--- a/src/abi.md
+++ b/src/abi.md
@@ -72,6 +72,34 @@ The *`no_mangle` attribute* may be used on functions and statics to disable stan
 extern "C" fn foo() {}
 ```
 
+r[abi.no_mangle.syntax]
+The `no_mangle` attribute uses the [MetaWord] syntax and thus does not take any inputs.
+
+r[abi.no_mangle.allowed-positions]
+The `no_mangle` attribute may only be applied to:
+
+- [Static items][items.static]
+- [Free functions][items.fn]
+- [Inherent associated functions][items.associated.fn]
+- [Trait impl functions][items.impl.trait]
+
+It may not be used with a [closure].
+
+> [!NOTE]
+> `rustc` currently warns in other positions, but this may be rejected in the future.
+
+<!-- TODO: Currently it works on a trait function with a body, but generates a warning about being phased out. how do we document that?
+https://github.com/rust-lang/rust/pull/86492#issuecomment-885682960
+-->
+
+<!-- TODO: should this clarify that external block items are already unmangled?, and thus the attribute does nothing? Currently it is "phased out" warning. -->
+
+r[abi.no_mangle.duplicates]
+Only the first instance of `no_mangle` on an item is honored. Subsequent `no_mangle` attributes are ignored.
+
+> [!NOTE]
+> `rustc` currently warns on subsequent duplicate `no_mangle` attributes.
+
 r[abi.no_mangle.unsafe]
 The `no_mangle` attribute must be marked with [`unsafe`][attributes.safety] because an unmangled symbol may collide with another symbol with the same name (or with a well-known symbol), leading to undefined behavior.
 
@@ -141,6 +169,7 @@ r[abi.export_name.edition2024]
 > Before the 2024 edition it is allowed to use the `export_name` attribute without the `unsafe` qualification.
 
 [attribute]: attributes.md
+[closure]: expr.closure
 [extern functions]: items/functions.md#extern-function-qualifier
 [external blocks]: items/external-blocks.md
 [function]: items/functions.md

--- a/src/abi.md
+++ b/src/abi.md
@@ -65,7 +65,7 @@ r[abi.no_mangle]
 ## The `no_mangle` attribute
 
 r[abi.no_mangle.intro]
-The *`no_mangle` attribute* may be used on functions and statics to disable standard symbol name mangling. The symbol for the item will be the identifier of the item's name.
+The *`no_mangle` [attribute]* disables the standard symbol name mangling on a [function] or [static]. The symbol for the item is the item's identifier.
 
 > [!EXAMPLE]
 > ```rust
@@ -74,7 +74,7 @@ The *`no_mangle` attribute* may be used on functions and statics to disable stan
 > ```
 
 r[abi.no_mangle.syntax]
-The `no_mangle` attribute uses the [MetaWord] syntax and thus does not take any inputs.
+The `no_mangle` attribute uses the [MetaWord] syntax.
 
 r[abi.no_mangle.allowed-positions]
 The `no_mangle` attribute may only be applied to:
@@ -85,7 +85,7 @@ The `no_mangle` attribute may only be applied to:
 - [Trait impl functions][items.impl.trait]
 
 > [!NOTE]
-> `rustc` currently warns in other positions, but this may be rejected in the future.
+> `rustc` lints against use in other positions. This may become an error in the future.
 
 <!-- TODO: Currently it works on a trait function with a body, but generates a warning about being phased out. how do we document that?
 https://github.com/rust-lang/rust/pull/86492#issuecomment-885682960
@@ -94,32 +94,35 @@ https://github.com/rust-lang/rust/pull/86492#issuecomment-885682960
 <!-- TODO: should this clarify that external block items are already unmangled?, and thus the attribute does nothing? Currently it is "phased out" warning. -->
 
 r[abi.no_mangle.closures]
-`no_mangle` may not be used with a [closure].
+The `no_mangle` attribute may not be used with a [closure].
 
 r[abi.no_mangle.generics]
-`no_mangle` may not be used on an item with generic parameters.
+The `no_mangle` attribute may not be used on an item with generic parameters.
 
 r[abi.no_mangle.duplicates]
-Only the first instance of `no_mangle` on an item is honored. Subsequent `no_mangle` attributes are ignored.
+Only the first use of `no_mangle` on an item has effect.
 
 > [!NOTE]
-> `rustc` currently warns on subsequent duplicate `no_mangle` attributes.
+> `rustc` lints against any use following the first.
 
 r[abi.no_mangle.export_name]
-If `no_mangle` is used with [`export_name`][abi.export_name], then the `export_name` is used instead.
+When the `no_mangle` and [`export_name`][abi.export_name] attributes are both applied to the same item, the symbol name from `export_name` is used, and `no_mangle` has no effect.
+
+> [!NOTE]
+> `rustc` lints against this combination.
 
 r[abi.no_mangle.unsafe]
 The `no_mangle` attribute must be marked with [`unsafe`][attributes.safety] because an unmangled symbol may collide with another symbol with the same name (or with a well-known symbol), leading to undefined behavior.
 
 r[abi.no_mangle.edition2024]
 > [!EDITION-2024]
-> Before the 2024 edition it is allowed to use the `no_mangle` attribute without the `unsafe` qualification.
+> Before the 2024 edition, it is allowed to use the `no_mangle` attribute without `unsafe`.
 
 r[abi.no_mangle.publicly-exported]
-In addition to disabling name mangling, the item will be publicly exported from the produced library or object file, similar to the [`used` attribute](#the-used-attribute).
+In addition to disabling name mangling, the `no_mangle` attribute causes the symbol to be publicly exported from the produced library or object file, similar to the [`used`][abi.used] attribute.
 
 r[abi.no_mangle.ascii-only]
-`no_mangle` may only be used on items with a name that only contains ASCII characters.
+The `no_mangle` attribute may only be used on items with a name that contains only ASCII characters.
 
 r[abi.link_section]
 ## The `link_section` attribute

--- a/src/abi.md
+++ b/src/abi.md
@@ -84,8 +84,6 @@ The `no_mangle` attribute may only be applied to:
 - [Inherent associated functions][items.associated.fn]
 - [Trait impl functions][items.impl.trait]
 
-It may not be used with a [closure].
-
 > [!NOTE]
 > `rustc` currently warns in other positions, but this may be rejected in the future.
 
@@ -94,6 +92,12 @@ https://github.com/rust-lang/rust/pull/86492#issuecomment-885682960
 -->
 
 <!-- TODO: should this clarify that external block items are already unmangled?, and thus the attribute does nothing? Currently it is "phased out" warning. -->
+
+r[abi.no_mangle.closures]
+`no_mangle` may not be used with a [closure].
+
+r[abi.no_mangle.generics]
+`no_mangle` may not be used on an item with generic parameters.
 
 r[abi.no_mangle.duplicates]
 Only the first instance of `no_mangle` on an item is honored. Subsequent `no_mangle` attributes are ignored.
@@ -116,9 +120,6 @@ In addition to disabling name mangling, the item will be publicly exported from 
 
 r[abi.no_mangle.ascii-only]
 `no_mangle` may only be used on items with a name that only contains ASCII characters.
-
-r[abi.no_mangle.generic]
-`no_mangle` has no effect on generic items.
 
 r[abi.link_section]
 ## The `link_section` attribute


### PR DESCRIPTION
New rules:
- ❗ `abi.no_mangle.syntax`
- ❗ `abi.no_mangle.allowed-positions`
- ❗ `abi.no_mangle.duplicates`
- ❗ `abi.no_mangle.export_name`
- ❗ `abi.no_mangle.ascii-only`
- ❗ `abi.no_mangle.generic`
