### PR TITLE
Update `no_std` to use the attribute template

### DIFF
--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -76,6 +76,7 @@ See https://github.com/rust-lang/rust/issues/57288 for more about the
 alloc/test limitation.
 -->
 
+<!-- template:attributes -->
 r[names.preludes.extern.no_std]
 ### The `no_std` attribute
 
@@ -95,16 +96,16 @@ The *`no_std` [attribute][attributes]* is used to prevent the automatic linking 
 > Using `no_std` does not prevent the standard library from being linked in. It is still valid to put `extern crate std;` into the crate and dependencies can also link it in.
 
 r[names.preludes.extern.no_std.syntax]
-The `no_std` attribute uses the [MetaWord] syntax and thus does not take any inputs.
+The `no_std` attribute uses the [MetaWord] syntax.
 
 r[names.preludes.extern.no_std.allowed-positions]
 The `no_std` attribute may only be applied to the crate root.
 
 r[names.preludes.extern.no_std.duplicates]
-Duplicate instances of the `no_std` attribute have no effect.
+The `no_std` attribute may be used any number of times on a form.
 
 > [!NOTE]
-> `rustc` currently warns on subsequent duplicate `no_std` attributes.
+> `rustc` lints against any use following the first.
 
 r[names.preludes.extern.no_std.module]
 The `no_std` attribute changes the [standard library prelude] to use the `core` prelude instead of `std`.

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -80,15 +80,10 @@ r[names.preludes.extern.no_std]
 ### The `no_std` attribute
 
 r[names.preludes.extern.no_std.intro]
-By default, the standard library is automatically included in the crate root
-module. The [`std`] crate is added to the root, along with an implicit
-[`macro_use` attribute] pulling in all macros exported from `std` into the
-[`macro_use` prelude]. Both [`core`] and [`std`] are added to the [extern
-prelude].
+By default, the standard library is automatically included in the crate root module. The [`std`] crate is added to the root, along with an implicit [`macro_use` attribute] pulling in all macros exported from `std` into the [`macro_use` prelude]. Both [`core`] and [`std`] are added to the [extern prelude].
 
 r[names.preludes.extern.no_std.allowed-positions]
-The *`no_std` [attribute]* may be applied at the crate level to prevent the
-[`std`] crate from being automatically added into scope.
+The *`no_std` [attribute]* may be applied at the crate level to prevent the [`std`] crate from being automatically added into scope.
 
 It does three things:
 
@@ -97,8 +92,7 @@ r[names.preludes.extern.no_std.extern]
 r[names.preludes.extern.no_std.module]
 * Affects which module is used to make up the [standard library prelude] (as described above).
 r[names.preludes.extern.no_std.core]
-* Injects the [`core`] crate into the crate root instead of [`std`], and pulls
-  in all macros exported from `core` in the [`macro_use` prelude].
+* Injects the [`core`] crate into the crate root instead of [`std`], and pulls in all macros exported from `core` in the [`macro_use` prelude].
 
 > [!NOTE]
 > Using the core prelude over the standard prelude is useful when either the crate is targeting a platform that does not support the standard library or is purposefully not using the capabilities of the standard library. Those capabilities are mainly dynamic memory allocation (e.g. `Box` and `Vec`) and file and network capabilities (e.g. `std::fs` and `std::io`).

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -80,7 +80,7 @@ r[names.preludes.extern.no_std]
 ### The `no_std` attribute
 
 r[names.preludes.extern.no_std.intro]
-By default, the standard library is automatically included in the crate root module. The [`std`] crate is added to the root, along with an implicit [`macro_use` attribute] pulling in all macros exported from `std` into the [`macro_use` prelude]. Both [`core`] and [`std`] are added to the [extern prelude].
+The *`no_std` [attribute][attributes]* is used to prevent the automatic linking of the [`std`] crate, deferring to [`core`] instead.
 
 > [!EXAMPLE]
 > <!-- ignore: test infrastructure can't handle no_std -->
@@ -98,18 +98,16 @@ r[names.preludes.extern.no_std.syntax]
 The `no_std` attribute uses the [MetaWord] syntax and thus does not take any inputs.
 
 r[names.preludes.extern.no_std.allowed-positions]
-The *`no_std` [attribute]* may be applied at the crate level to prevent the [`std`] crate from being automatically added into scope.
+The `no_std` attribute may only be applied to the crate root.
 
-It does three things:
 
-r[names.preludes.extern.no_std.extern]
-* Prevents `std` from being added to the [extern prelude](#extern-prelude).
 r[names.preludes.extern.no_std.module]
-* Affects which module is used to make up the [standard library prelude] (as described above).
-r[names.preludes.extern.no_std.core]
-* Injects the [`core`] crate into the crate root instead of [`std`], and pulls in all macros exported from `core` in the [`macro_use` prelude].
+The `no_std` attribute changes the [standard library prelude] to use the `core` prelude instead of `std`.
 
+r[names.preludes.extern.no_std.inject]
+By default, the [`std`] crate is injected into the [extern prelude], and all macros exported from `std` are added to the [`macro_use` prelude].
 
+If the `no_std` attribute is specified, then the [`core`] crate is used instead of `std`, and similarly all macros exported from `core` are placed into the [`macro_use` prelude].
 
 r[names.preludes.lang]
 ## Language prelude

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -157,7 +157,6 @@ r[names.preludes.no_implicit_prelude.edition2018]
 [`macro_use` attribute]: ../macros-by-example.md#the-macro_use-attribute
 [`macro_use` prelude]: #macro_use-prelude
 [`no_std` attribute]: #the-no_std-attribute
-[`no_std` attribute]: #the-no_std-attribute
 [attribute]: ../attributes.md
 [Boolean type]: ../types/boolean.md
 [Built-in attributes]: ../attributes.md#built-in-attributes-index

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -110,10 +110,8 @@ The `no_std` attribute may be used any number of times on a form.
 r[names.preludes.extern.no_std.module]
 The `no_std` attribute changes the [standard library prelude] to use the `core` prelude instead of the `std` prelude.
 
-r[names.preludes.extern.no_std.inject]
-By default, the [`std`] crate is injected into the [extern prelude], and all macros exported from `std` are added to the [`macro_use` prelude].
-
-If the `no_std` attribute is specified, then the [`core`] crate is used instead of the `std` crate, and similarly all macros exported from `core` are placed into the [`macro_use` prelude].
+r[names.preludes.extern.no_std.macro_use]
+By default, all macros exported from the `std` crate are added to the [`macro_use` prelude]. If the `no_std` attribute is specified, then all macros exported from the `core` crate are placed into the [`macro_use` prelude] instead.
 
 r[names.preludes.extern.no_std.edition2018]
 > [!EDITION-2018]

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -82,6 +82,9 @@ r[names.preludes.extern.no_std]
 r[names.preludes.extern.no_std.intro]
 By default, the standard library is automatically included in the crate root module. The [`std`] crate is added to the root, along with an implicit [`macro_use` attribute] pulling in all macros exported from `std` into the [`macro_use` prelude]. Both [`core`] and [`std`] are added to the [extern prelude].
 
+r[names.preludes.extern.no_std.syntax]
+The `no_std` attribute uses the [MetaWord] syntax and thus does not take any inputs.
+
 r[names.preludes.extern.no_std.allowed-positions]
 The *`no_std` [attribute]* may be applied at the crate level to prevent the [`std`] crate from being automatically added into scope.
 

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -82,6 +82,12 @@ r[names.preludes.extern.no_std]
 r[names.preludes.extern.no_std.intro]
 By default, the standard library is automatically included in the crate root module. The [`std`] crate is added to the root, along with an implicit [`macro_use` attribute] pulling in all macros exported from `std` into the [`macro_use` prelude]. Both [`core`] and [`std`] are added to the [extern prelude].
 
+> [!EXAMPLE]
+> <!-- ignore: test infrastructure can't handle no_std -->
+> ```rust,ignore
+> #![no_std]
+> ```
+
 r[names.preludes.extern.no_std.syntax]
 The `no_std` attribute uses the [MetaWord] syntax and thus does not take any inputs.
 

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -100,6 +100,11 @@ The `no_std` attribute uses the [MetaWord] syntax and thus does not take any inp
 r[names.preludes.extern.no_std.allowed-positions]
 The `no_std` attribute may only be applied to the crate root.
 
+r[names.preludes.extern.no_std.duplicates]
+Duplicate instances of the `no_std` attribute have no effect.
+
+> [!NOTE]
+> `rustc` currently warns on subsequent duplicate `no_std` attributes.
 
 r[names.preludes.extern.no_std.module]
 The `no_std` attribute changes the [standard library prelude] to use the `core` prelude instead of `std`.

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -109,6 +109,10 @@ By default, the [`std`] crate is injected into the [extern prelude], and all mac
 
 If the `no_std` attribute is specified, then the [`core`] crate is used instead of `std`, and similarly all macros exported from `core` are placed into the [`macro_use` prelude].
 
+r[names.preludes.extern.no_std.edition2018]
+> [!EDITION-2018]
+> Before the 2018 edition, `std` is also injected into the crate root. `core` is injected instead of `std` if `no_std` is specified. Starting with the 2018 edition, these are not injected into the crate root.
+
 r[names.preludes.lang]
 ## Language prelude
 

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -93,7 +93,7 @@ The *`no_std` [attribute][attributes]* causes the [`std`] crate to not be linked
 > Using `no_std` is useful when either the crate is targeting a platform that does not support the standard library or is purposefully not using the capabilities of the standard library. Those capabilities are mainly dynamic memory allocation (e.g. `Box` and `Vec`) and file and network capabilities (e.g. `std::fs` and `std::io`).
 
 > [!WARNING]
-> Using `no_std` does not prevent the standard library from being linked in. It is still valid to put `extern crate std;` into the crate and dependencies can also link it in.
+> Using `no_std` does not prevent the standard library from being linked. It is still valid to write `extern crate std` in the crate or in one of its dependencies; this will cause the compiler to link the `std` crate into the program.
 
 r[names.preludes.extern.no_std.syntax]
 The `no_std` attribute uses the [MetaWord] syntax.

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -81,7 +81,7 @@ r[names.preludes.extern.no_std]
 ### The `no_std` attribute
 
 r[names.preludes.extern.no_std.intro]
-The *`no_std` [attribute][attributes]* causes the [`std`] crate to not be linked automatically, deferring to the [`core`] crate instead.
+The *`no_std` [attribute][attributes]* causes the [`std`] crate to not be linked automatically, the [standard library prelude] to instead use the `core` prelude, and the [`macro_use` prelude] to instead use the macros exported from the `core` crate.
 
 > [!EXAMPLE]
 > <!-- ignore: test infrastructure can't handle no_std -->
@@ -183,7 +183,7 @@ r[names.preludes.no_implicit_prelude.edition2018]
 [Machine-dependent integer types]: ../types/numeric.md#machine-dependent-integer-types
 [Macro namespace]: namespaces.md
 [name resolution]: name-resolution.md
-[Standard library prelude]: #standard-library-prelude
+[standard library prelude]: names.preludes.std
 [Textual types]: ../types/textual.md
 [tool attributes]: ../attributes.md#tool-attributes
 [Tool prelude]: #tool-prelude

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -88,6 +88,12 @@ By default, the standard library is automatically included in the crate root mod
 > #![no_std]
 > ```
 
+> [!NOTE]
+> Using `no_std` is useful when either the crate is targeting a platform that does not support the standard library or is purposefully not using the capabilities of the standard library. Those capabilities are mainly dynamic memory allocation (e.g. `Box` and `Vec`) and file and network capabilities (e.g. `std::fs` and `std::io`).
+
+> [!WARNING]
+> Using `no_std` does not prevent the standard library from being linked in. It is still valid to put `extern crate std;` into the crate and dependencies can also link it in.
+
 r[names.preludes.extern.no_std.syntax]
 The `no_std` attribute uses the [MetaWord] syntax and thus does not take any inputs.
 
@@ -103,11 +109,7 @@ r[names.preludes.extern.no_std.module]
 r[names.preludes.extern.no_std.core]
 * Injects the [`core`] crate into the crate root instead of [`std`], and pulls in all macros exported from `core` in the [`macro_use` prelude].
 
-> [!NOTE]
-> Using the core prelude over the standard prelude is useful when either the crate is targeting a platform that does not support the standard library or is purposefully not using the capabilities of the standard library. Those capabilities are mainly dynamic memory allocation (e.g. `Box` and `Vec`) and file and network capabilities (e.g. `std::fs` and `std::io`).
 
-> [!WARNING]
-> Using `no_std` does not prevent the standard library from being linked in. It is still valid to put `extern crate std;` into the crate and dependencies can also link it in.
 
 r[names.preludes.lang]
 ## Language prelude

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -108,16 +108,16 @@ The `no_std` attribute may be used any number of times on a form.
 > `rustc` lints against any use following the first.
 
 r[names.preludes.extern.no_std.module]
-The `no_std` attribute changes the [standard library prelude] to use the `core` prelude instead of `std`.
+The `no_std` attribute changes the [standard library prelude] to use the `core` prelude instead of the `std` prelude.
 
 r[names.preludes.extern.no_std.inject]
 By default, the [`std`] crate is injected into the [extern prelude], and all macros exported from `std` are added to the [`macro_use` prelude].
 
-If the `no_std` attribute is specified, then the [`core`] crate is used instead of `std`, and similarly all macros exported from `core` are placed into the [`macro_use` prelude].
+If the `no_std` attribute is specified, then the [`core`] crate is used instead of the `std` crate, and similarly all macros exported from `core` are placed into the [`macro_use` prelude].
 
 r[names.preludes.extern.no_std.edition2018]
 > [!EDITION-2018]
-> Before the 2018 edition, `std` is also injected into the crate root. `core` is injected instead of `std` if `no_std` is specified. Starting with the 2018 edition, these are not injected into the crate root.
+> Before the 2018 edition, `std` is injected into the crate root by default. If `no_std` is specified, `core` is injected instead. Starting with the 2018 edition, regardless of `no_std` being specified, neither is injected into the crate root.
 
 r[names.preludes.lang]
 ## Language prelude

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -81,7 +81,7 @@ r[names.preludes.extern.no_std]
 ### The `no_std` attribute
 
 r[names.preludes.extern.no_std.intro]
-The *`no_std` [attribute][attributes]* is used to prevent the automatic linking of the [`std`] crate, deferring to [`core`] instead.
+The *`no_std` [attribute][attributes]* causes the [`std`] crate to not be linked automatically, deferring to the [`core`] crate instead.
 
 > [!EXAMPLE]
 > <!-- ignore: test infrastructure can't handle no_std -->


### PR DESCRIPTION
New rules:
- ❗ `names.preludes.extern.no_std.syntax`
- ❗ `names.preludes.extern.no_std.duplicates`
- ❗ `names.preludes.extern.no_std.edition2018`

Renamed rules:
- `names.preludes.extern.no_std.extern` and `names.preludes.extern.no_std.core` is now `names.preludes.extern.no_std.inject`
