### PR TITLE
Update `no_implicit_prelude` to use the attribute template

### DIFF
--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -155,7 +155,7 @@ r[names.preludes.no_implicit_prelude]
 ## The `no_implicit_prelude` attribute
 
 r[names.preludes.no_implicit_prelude.intro]
-The *`no_implicit_prelude` [attribute]* may be applied at the crate level or on a module to indicate that it should not automatically bring the [standard library prelude], [extern prelude], or [tool prelude] into scope for that module or any of its descendants.
+The *`no_implicit_prelude` [attribute]* is used to prevent implicit preludes from being brought into scope.
 
 > [!EXAMPLE]
 > ```rust
@@ -183,6 +183,9 @@ Duplicate instances of the `no_implicit_prelude` attribute have no effect.
 
 > [!NOTE]
 > `rustc` currently warns on subsequent duplicate `no_implicit_prelude` attributes.
+
+r[names.preludes.no_implicit_prelude.excluded-preludes]
+The `no_implicit_prelude` attribute prevents the [standard library prelude], [extern prelude], and the [tool prelude] from being brought into scope for the module or any of its descendants.
 
 r[names.preludes.no_implicit_prelude.lang]
 This attribute does not affect the [language prelude].

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -195,7 +195,7 @@ The `no_implicit_prelude` attribute does not affect the [language prelude].
 
 r[names.preludes.no_implicit_prelude.edition2018]
 > [!EDITION-2018]
-> In the 2015 edition, the `no_implicit_prelude` attribute does not affect the [`macro_use` prelude], and all macros exported from the standard library are still included in the `macro_use` prelude. Starting in the 2018 edition, it will remove the `macro_use` prelude.
+> In the 2015 edition, the `no_implicit_prelude` attribute does not affect the [`macro_use` prelude], and all macros exported from the standard library are still included in the `macro_use` prelude. Starting in the 2018 edition, the attribute does remove the `macro_use` prelude.
 
 [`extern crate`]: ../items/extern-crates.md
 [`macro_use` attribute]: ../macros-by-example.md#the-macro_use-attribute

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -176,7 +176,7 @@ r[names.preludes.no_implicit_prelude.syntax]
 The `no_implicit_prelude` attribute uses the [MetaWord] syntax.
 
 r[names.preludes.no_implicit_prelude.allowed-positions]
-The `no_implicit_prelude` attribute may only be applied to the crate level or a module.
+The `no_implicit_prelude` attribute may only be applied to the crate or to a module.
 
 > [!NOTE]
 > `rustc` ignores use in other positions but lints against it. This may become an error in the future.

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -157,6 +157,18 @@ r[names.preludes.no_implicit_prelude]
 r[names.preludes.no_implicit_prelude.intro]
 The *`no_implicit_prelude` [attribute]* may be applied at the crate level or on a module to indicate that it should not automatically bring the [standard library prelude], [extern prelude], or [tool prelude] into scope for that module or any of its descendants.
 
+> [!EXAMPLE]
+> ```rust
+> // It can be applied to the crate root to apply to all modules.
+> #![no_implicit_prelude]
+>
+> // Or it can be applied to a module to only affect that module or any of its descendants.
+> #[no_implicit_prelude]
+> mod example {
+>     // ...
+> }
+> ```
+
 r[names.preludes.no_implicit_prelude.lang]
 This attribute does not affect the [language prelude].
 

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -160,10 +160,12 @@ The *`no_implicit_prelude` [attribute]* is used to prevent implicit preludes fro
 
 > [!EXAMPLE]
 > ```rust
-> // It can be applied to the crate root to apply to all modules.
+> // The attribute can be applied to the crate root to affect
+> // all modules.
 > #![no_implicit_prelude]
 >
-> // Or it can be applied to a module to only affect that module or any of its descendants.
+> // Or it can be applied to a module to only affect that module
+> // and its descendants.
 > #[no_implicit_prelude]
 > mod example {
 >     // ...

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -155,10 +155,7 @@ r[names.preludes.no_implicit_prelude]
 ## The `no_implicit_prelude` attribute
 
 r[names.preludes.no_implicit_prelude.intro]
-The *`no_implicit_prelude` [attribute]* may be applied at the crate level or
-on a module to indicate that it should not automatically bring the [standard
-library prelude], [extern prelude], or [tool prelude] into scope for that
-module or any of its descendants.
+The *`no_implicit_prelude` [attribute]* may be applied at the crate level or on a module to indicate that it should not automatically bring the [standard library prelude], [extern prelude], or [tool prelude] into scope for that module or any of its descendants.
 
 r[names.preludes.no_implicit_prelude.lang]
 This attribute does not affect the [language prelude].

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -151,6 +151,7 @@ r[names.preludes.tool.intro]
 The tool prelude includes tool names for external tools in the [type
 namespace]. See the [tool attributes] section for more details.
 
+<!-- template:attributes -->
 r[names.preludes.no_implicit_prelude]
 ## The `no_implicit_prelude` attribute
 
@@ -170,19 +171,19 @@ The *`no_implicit_prelude` [attribute]* is used to prevent implicit preludes fro
 > ```
 
 r[names.preludes.no_implicit_prelude.syntax]
-The `no_implicit_prelude` attribute uses the [MetaWord] syntax and thus does not take any inputs.
+The `no_implicit_prelude` attribute uses the [MetaWord] syntax.
 
 r[names.preludes.no_implicit_prelude.allowed-positions]
 The `no_implicit_prelude` attribute may only be applied to the crate level or a module.
 
 > [!NOTE]
-> `rustc` currently warns in other positions, but this may be rejected in the future.
+> `rustc` ignores use in other positions but lints against it. This may become an error in the future.
 
 r[names.preludes.no_implicit_prelude.duplicates]
-Duplicate instances of the `no_implicit_prelude` attribute have no effect.
+The `no_implicit_prelude` attribute may be used any number of times on a form.
 
 > [!NOTE]
-> `rustc` currently warns on subsequent duplicate `no_implicit_prelude` attributes.
+> `rustc` lints against any use following the first.
 
 r[names.preludes.no_implicit_prelude.excluded-preludes]
 The `no_implicit_prelude` attribute prevents the [standard library prelude], [extern prelude], and the [tool prelude] from being brought into scope for the module or any of its descendants.

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -188,7 +188,7 @@ r[names.preludes.no_implicit_prelude.excluded-preludes]
 The `no_implicit_prelude` attribute prevents the [standard library prelude], [extern prelude], and the [tool prelude] from being brought into scope for the module or any of its descendants.
 
 r[names.preludes.no_implicit_prelude.lang]
-This attribute does not affect the [language prelude].
+The `no_implicit_prelude` attribute does not affect the [language prelude].
 
 r[names.preludes.no_implicit_prelude.edition2018]
 > [!EDITION-2018]

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -169,6 +169,21 @@ The *`no_implicit_prelude` [attribute]* may be applied at the crate level or on 
 > }
 > ```
 
+r[names.preludes.no_implicit_prelude.syntax]
+The `no_implicit_prelude` attribute uses the [MetaWord] syntax and thus does not take any inputs.
+
+r[names.preludes.no_implicit_prelude.allowed-positions]
+The `no_implicit_prelude` attribute may only be applied to the crate level or a module.
+
+> [!NOTE]
+> `rustc` currently warns in other positions, but this may be rejected in the future.
+
+r[names.preludes.no_implicit_prelude.duplicates]
+Duplicate instances of the `no_implicit_prelude` attribute have no effect.
+
+> [!NOTE]
+> `rustc` currently warns on subsequent duplicate `no_implicit_prelude` attributes.
+
 r[names.preludes.no_implicit_prelude.lang]
 This attribute does not affect the [language prelude].
 

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -188,7 +188,7 @@ The `no_implicit_prelude` attribute may be used any number of times on a form.
 > `rustc` lints against any use following the first.
 
 r[names.preludes.no_implicit_prelude.excluded-preludes]
-The `no_implicit_prelude` attribute prevents the [standard library prelude], [extern prelude], [`macro_use` prelude], and the [tool prelude] from being brought into scope for the module or any of its descendants.
+The `no_implicit_prelude` attribute prevents the [standard library prelude], [extern prelude], [`macro_use` prelude], and the [tool prelude] from being brought into scope for the module and its descendants.
 
 r[names.preludes.no_implicit_prelude.lang]
 The `no_implicit_prelude` attribute does not affect the [language prelude].

--- a/src/names/preludes.md
+++ b/src/names/preludes.md
@@ -186,7 +186,7 @@ The `no_implicit_prelude` attribute may be used any number of times on a form.
 > `rustc` lints against any use following the first.
 
 r[names.preludes.no_implicit_prelude.excluded-preludes]
-The `no_implicit_prelude` attribute prevents the [standard library prelude], [extern prelude], and the [tool prelude] from being brought into scope for the module or any of its descendants.
+The `no_implicit_prelude` attribute prevents the [standard library prelude], [extern prelude], [`macro_use` prelude], and the [tool prelude] from being brought into scope for the module or any of its descendants.
 
 r[names.preludes.no_implicit_prelude.lang]
 The `no_implicit_prelude` attribute does not affect the [language prelude].


### PR DESCRIPTION
New rules:
- ❗ `names.preludes.no_implicit_prelude.syntax`
- ❗ `names.preludes.no_implicit_prelude.allowed-positions`
- ❗ `names.preludes.no_implicit_prelude.duplicates`
- ❗ `names.preludes.no_implicit_prelude.excluded-preludes`
