### PR TITLE
Update `global_allocator` to use the attribute template

### DIFF
--- a/src/runtime.md
+++ b/src/runtime.md
@@ -7,11 +7,12 @@ r[runtime.global_allocator]
 ## The `global_allocator` attribute
 
 r[runtime.global_allocator.intro]
-The *`global_allocator` [attribute][attributes]* is used to define a [memory allocator][std::alloc].
+The *`global_allocator` [attribute][attributes]* selects a [memory allocator][std::alloc].
 
 > [!EXAMPLE]
 > ```rust
-> use std::alloc::{GlobalAlloc, System, Layout};
+> use core::alloc::{GlobalAlloc, Layout};
+> use std::alloc::System;
 >
 > struct MyAllocator;
 >
@@ -19,7 +20,6 @@ The *`global_allocator` [attribute][attributes]* is used to define a [memory all
 >     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
 >         unsafe { System.alloc(layout) }
 >     }
->
 >     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
 >         unsafe { System.dealloc(ptr, layout) }
 >     }
@@ -30,19 +30,19 @@ The *`global_allocator` [attribute][attributes]* is used to define a [memory all
 > ```
 
 r[runtime.global_allocator.syntax]
-The `global_allocator` attribute uses the [MetaWord] syntax and thus does not take any inputs.
+The `global_allocator` attribute uses the [MetaWord] syntax.
 
 r[runtime.global_allocator.allowed-positions]
-The `global_allocator` attribute may only be applied to a [static item] that implements the [`GlobalAlloc`] trait.
+The `global_allocator` attribute may only be applied to a [static item] whose type implements the [`GlobalAlloc`] trait.
 
 r[runtime.global_allocator.duplicates]
-The `global_allocator` attribute may only be specified once on an item.
+The `global_allocator` attribute may only be used once on an item.
 
 r[runtime.global_allocator.single]
-At most one `global_allocator` may be specified in the crate graph.
+The `global_allocator` attribute may only be used once in the crate graph.
 
 r[runtime.global_allocator.stdlib]
-The `global_allocator` attribute is exported in the [standard library prelude][core::prelude::v1].
+The `global_allocator` attribute is exported from the [standard library prelude][core::prelude::v1].
 
 r[runtime.windows_subsystem]
 ## The `windows_subsystem` attribute

--- a/src/runtime.md
+++ b/src/runtime.md
@@ -6,8 +6,43 @@ This section documents features that define some aspects of the Rust runtime.
 r[runtime.global_allocator]
 ## The `global_allocator` attribute
 
-The *`global_allocator` attribute* is used on a [static item] implementing the
-[`GlobalAlloc`] trait to set the global allocator.
+r[runtime.global_allocator.intro]
+The *`global_allocator` [attribute][attributes]* is used to define a [memory allocator][std::alloc].
+
+> [!EXAMPLE]
+> ```rust
+> use std::alloc::{GlobalAlloc, System, Layout};
+>
+> struct MyAllocator;
+>
+> unsafe impl GlobalAlloc for MyAllocator {
+>     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+>         unsafe { System.alloc(layout) }
+>     }
+>
+>     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+>         unsafe { System.dealloc(ptr, layout) }
+>     }
+> }
+>
+> #[global_allocator]
+> static GLOBAL: MyAllocator = MyAllocator;
+> ```
+
+r[runtime.global_allocator.syntax]
+The `global_allocator` attribute uses the [MetaWord] syntax and thus does not take any inputs.
+
+r[runtime.global_allocator.allowed-positions]
+The `global_allocator` attribute may only be applied to a [static item] that implements the [`GlobalAlloc`] trait.
+
+r[runtime.global_allocator.duplicates]
+The `global_allocator` attribute may only be specified once on an item.
+
+r[runtime.global_allocator.single]
+At most one `global_allocator` may be specified in the crate graph.
+
+r[runtime.global_allocator.stdlib]
+The `global_allocator` attribute is exported in the [standard library prelude][core::prelude::v1].
 
 r[runtime.windows_subsystem]
 ## The `windows_subsystem` attribute


### PR DESCRIPTION
New rules:
- ❗ `runtime.global_allocator.intro`
- ❗ `runtime.global_allocator.syntax`
- ❗ `runtime.global_allocator.allowed-positions`
- ❗ `runtime.global_allocator.duplicates`
- ❗ `runtime.global_allocator.single`
- ❗ `runtime.global_allocator.stdlib`
