### PR TITLE
Update `windows_subsystem` to use the attribute template

### DIFF
--- a/src/runtime.md
+++ b/src/runtime.md
@@ -13,7 +13,7 @@ r[runtime.windows_subsystem]
 ## The `windows_subsystem` attribute
 
 r[runtime.windows_subsystem.intro]
-The *`windows_subsystem` attribute* may be applied at the crate level to set the [subsystem] when linking on a Windows target.
+The *`windows_subsystem` [attribute][attributes]* sets the [subsystem] when linking on a Windows target.
 
 > [!EXAMPLE]
 > ```rust
@@ -21,10 +21,19 @@ The *`windows_subsystem` attribute* may be applied at the crate level to set the
 > ```
 
 r[runtime.windows_subsystem.syntax]
-It uses the [MetaNameValueStr] syntax to specify the subsystem with a value of either `console` or `windows`.
+The `windows_subsystem` attribute uses the [MetaNameValueStr] syntax to specify the subsystem with a value of either `console` or `windows`.
+
+r[runtime.windows_subsystem.allowed-positions]
+The `windows_subsystem` attribute may only be applied to the crate root.
+
+r[runtime.windows_subsystem.duplicates]
+Only the first instance of `windows_subsystem` on an item is honored. Subsequent `example` attributes are ignored.
+
+> [!NOTE]
+> `rustc` currently warns on subsequent duplicate `example` attributes. This may become an error in the future.
 
 r[runtime.windows_subsystem.ignored]
-This attribute is ignored on non-Windows targets, and for non-`bin` [crate types].
+The `windows_subsystem` attribute is ignored on non-Windows targets, and for non-`bin` [crate types].
 
 r[runtime.windows_subsystem.console]
 The "console" subsystem is the default. If a console process is run from an existing console then it will be attached to that console, otherwise a new console window will be created.

--- a/src/runtime.md
+++ b/src/runtime.md
@@ -13,24 +13,19 @@ r[runtime.windows_subsystem]
 ## The `windows_subsystem` attribute
 
 r[runtime.windows_subsystem.intro]
-The *`windows_subsystem` attribute* may be applied at the crate level to set
-the [subsystem] when linking on a Windows target.
+The *`windows_subsystem` attribute* may be applied at the crate level to set the [subsystem] when linking on a Windows target.
 
 r[runtime.windows_subsystem.syntax]
-It uses the [MetaNameValueStr] syntax to specify the subsystem with a value of either
-`console` or `windows`.
+It uses the [MetaNameValueStr] syntax to specify the subsystem with a value of either `console` or `windows`.
 
 r[runtime.windows_subsystem.ignored]
 This attribute is ignored on non-Windows targets, and for non-`bin` [crate types].
 
 r[runtime.windows_subsystem.console]
-The "console" subsystem is the default. If a console process is run from an
-existing console then it will be attached to that console, otherwise a new
-console window will be created.
+The "console" subsystem is the default. If a console process is run from an existing console then it will be attached to that console, otherwise a new console window will be created.
 
 r[runtime.windows_subsystem.windows]
-The "windows" subsystem is commonly used by GUI applications that do not want to
-display a console window on startup. It will run detached from any existing console.
+The "windows" subsystem is commonly used by GUI applications that do not want to display a console window on startup. It will run detached from any existing console.
 
 ```rust
 #![windows_subsystem = "windows"]

--- a/src/runtime.md
+++ b/src/runtime.md
@@ -21,25 +21,28 @@ The *`windows_subsystem` [attribute][attributes]* sets the [subsystem] when link
 > ```
 
 r[runtime.windows_subsystem.syntax]
-The `windows_subsystem` attribute uses the [MetaNameValueStr] syntax to specify the subsystem with a value of either `console` or `windows`.
+The `windows_subsystem` attribute uses the [MetaNameValueStr] syntax. Accepted values are `"console"` and `"windows"`.
 
 r[runtime.windows_subsystem.allowed-positions]
 The `windows_subsystem` attribute may only be applied to the crate root.
 
 r[runtime.windows_subsystem.duplicates]
-Only the first instance of `windows_subsystem` on an item is honored. Subsequent `example` attributes are ignored.
+Only the first use of `windows_subsystem` is honored.
 
 > [!NOTE]
-> `rustc` currently warns on subsequent duplicate `example` attributes. This may become an error in the future.
+> `rustc` currently lints against uses following the first. This may become a hard error in the future.
 
 r[runtime.windows_subsystem.ignored]
-The `windows_subsystem` attribute is ignored on non-Windows targets, and for non-`bin` [crate types].
+The `windows_subsystem` attribute is ignored on non-Windows targets and non-`bin` [crate types].
 
 r[runtime.windows_subsystem.console]
-The "console" subsystem is the default. If a console process is run from an existing console then it will be attached to that console, otherwise a new console window will be created.
+The `"console"` subsystem is the default. If a console process is run from an existing console then it will be attached to that console; otherwise a new console window will be created.
 
 r[runtime.windows_subsystem.windows]
-The "windows" subsystem is commonly used by GUI applications that do not want to display a console window on startup. It will run detached from any existing console.
+The `"windows"` subsystem will run detached from any existing console.
+
+> [!NOTE]
+> The `"windows"` subsystem is commonly used by GUI applications that do not want to display a console window on startup.
 
 [`GlobalAlloc`]: alloc::alloc::GlobalAlloc
 [crate types]: linkage.md

--- a/src/runtime.md
+++ b/src/runtime.md
@@ -15,6 +15,11 @@ r[runtime.windows_subsystem]
 r[runtime.windows_subsystem.intro]
 The *`windows_subsystem` attribute* may be applied at the crate level to set the [subsystem] when linking on a Windows target.
 
+> [!EXAMPLE]
+> ```rust
+> #![windows_subsystem = "windows"]
+> ```
+
 r[runtime.windows_subsystem.syntax]
 It uses the [MetaNameValueStr] syntax to specify the subsystem with a value of either `console` or `windows`.
 
@@ -26,10 +31,6 @@ The "console" subsystem is the default. If a console process is run from an exis
 
 r[runtime.windows_subsystem.windows]
 The "windows" subsystem is commonly used by GUI applications that do not want to display a console window on startup. It will run detached from any existing console.
-
-```rust
-#![windows_subsystem = "windows"]
-```
 
 [`GlobalAlloc`]: alloc::alloc::GlobalAlloc
 [crate types]: linkage.md


### PR DESCRIPTION
New rules:
- ❗ `runtime.windows_subsystem.allowed-positions`
- ❗ `runtime.windows_subsystem.duplicates`
