### PR TITLE
glossary.md: tweak description of "dispatch"

### DIFF
--- a/src/glossary.md
+++ b/src/glossary.md
@@ -64,8 +64,7 @@ root, including through [paths] of public modules.
 
 Dispatch is the mechanism to determine which specific version of code is actually
 run when it involves polymorphism. Two major forms of dispatch are static dispatch and
-dynamic dispatch. While Rust favors static dispatch, it also supports dynamic dispatch
-through a mechanism called ‘trait objects’.
+dynamic dispatch. Rust supports dynamic dispatch through the use of [trait objects][type.trait-object].
 
 ### Dynamically sized type
 

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -62,9 +62,7 @@ root, including through [paths] of public modules.
 
 ### Dispatch
 
-Dispatch is the mechanism to determine which specific version of code is actually
-run when it involves polymorphism. Two major forms of dispatch are static dispatch and
-dynamic dispatch. Rust supports dynamic dispatch through the use of [trait objects][type.trait-object].
+Dispatch is the mechanism to determine which specific version of code is actually run when it involves polymorphism. Two major forms of dispatch are static dispatch and dynamic dispatch. Rust supports dynamic dispatch through the use of [trait objects][type.trait-object].
 
 ### Dynamically sized type
 


### PR DESCRIPTION
- trait objects are not a *mechanism*
- *prefers* is not explained, so rather leave it out