### PR TITLE
fix aapcs ABI docs, and state where which ABIs are available

### DIFF
--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -130,30 +130,33 @@ r[items.extern.abi.platform]
 There are also some platform-specific ABI strings:
 
 r[items.extern.abi.cdecl]
-* `unsafe extern "cdecl"` -- The default for x86\_32 C code.
+* `unsafe extern "cdecl"` -- The default for x86\_32 C code. Only available on x86\_32 targets.
 
 r[items.extern.abi.stdcall]
-* `unsafe extern "stdcall"` -- The default for the Win32 API on x86\_32.
+* `unsafe extern "stdcall"` -- The default for the Win32 API on x86\_32. Only available on x86\_32 targets.
 
 r[items.extern.abi.win64]
-* `unsafe extern "win64"` -- The default for C code on x86\_64 Windows.
+* `unsafe extern "win64"` -- The default for C code on x86\_64 Windows. Only available on x86\_64 targets.
 
 r[items.extern.abi.sysv64]
-* `unsafe extern "sysv64"` -- The default for C code on non-Windows x86\_64.
+* `unsafe extern "sysv64"` -- The default for C code on non-Windows x86\_64. Only available on x86\_64 targets.
 
 r[items.extern.abi.aapcs]
-* `unsafe extern "aapcs"` -- The default for ARM.
+* `unsafe extern "aapcs"` -- Softfloat ABI for ARM. Only available on ARM32 targets.
 
 r[items.extern.abi.fastcall]
 * `unsafe extern "fastcall"` -- The `fastcall` ABI -- corresponds to MSVC's
-  `__fastcall` and GCC and clang's `__attribute__((fastcall))`
+  `__fastcall` and GCC and clang's `__attribute__((fastcall))`.
+   Only available on x86\_32 targets.
 
 r[items.extern.abi.thiscall]
 * `unsafe extern "thiscall"` -- The default for C++ member functions on x86\_32 MSVC -- corresponds to MSVC's
-  `__thiscall` and GCC and clang's `__attribute__((thiscall))`
+  `__thiscall` and GCC and clang's `__attribute__((thiscall))`.
+   Only available on x86\_32 targets.
 
 r[items.extern.abi.efiapi]
 * `unsafe extern "efiapi"` -- The ABI used for [UEFI] functions.
+  Only available on x86 and ARM targets (32bit and 64bit).
 
 r[items.extern.abi.platform-unwind-variants]
 Like `"C"` and `"system"`, most platform-specific ABI strings also have a [corresponding `-unwind` variant][unwind-behavior]; specifically, these are:


### PR DESCRIPTION
Fixes https://github.com/rust-lang/reference/issues/1946.

Regarding ABI availability, this documents a post-https://github.com/rust-lang/rust/issues/137018 world. Some of the combinations documented as "not available" here actually do get accepted but trigger a future-compat warning.