### PR TITLE
Fix build output directory in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ mdbook test
 
 For authors, consider using the server functionality which supports automatic reload.
 
-To build the Reference locally (in `build/`) and open it in a web
+To build the Reference locally (in `book/`) and open it in a web
 browser, run:
 
 ```sh


### PR DESCRIPTION
The html files are written to the `book/` directory, not the `build/` directory.