### PR TITLE
Clarify layout of tuples when last field is unsized

### DIFF
--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -91,7 +91,9 @@ r[layout.tuple]
 ## Tuple layout
 
 r[layout.tuple.def]
-Tuples are laid out according to the [`Rust` representation][`Rust`].
+Tuples are laid out according to the same rules as structs using the [`Rust` representation][`Rust`].
+
+They are laid out like a struct without generic parameters. This means that the last field of the tuple is not guaranteed to be stored at the end.
 
 r[layout.tuple.unit]
 The exception to this is the unit tuple (`()`), which is guaranteed as a [zero-sized type] to have a size of 0 and an alignment of 1.


### PR DESCRIPTION
This is a follow-up to https://github.com/rust-lang/rust/pull/137728.

This PR clarifies that given the two types:
```rs
struct MyTuple1(u32, i32);
struct MyTuple2<T: ?Sized>(u32, T);
```
the tuple `(u32, i32)` is laid out according to the same rules as `MyTuple1`, as opposed to being laid out according to the same rules as `MyTuple2<i32>`. The difference is that for `MyTuple2<i32>`, the `i32` field is always stored last, but that's not necessarily the case for `MyTuple1`.

---

Note that https://github.com/rust-lang/rust/pull/137728 only removed coercions, which is what relied on the layout matching. Tuple types with unsized last field are still legal in the language:
```rs
use core::ptr::slice_from_raw_parts;

fn main() {
    let array = [1u8; 20];

    let ptr = slice_from_raw_parts(array.as_ptr(), 20 - size_of::<i32>());
    println!("{:?}", unsafe { &*(ptr as *const (i32, [u8])) });
}
```
```text
(16843009, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
```
[playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=ef22fce551f90d7141e12293b43f3ccb)