### PR TITLE
Document assignment expression as coercion site

### DIFF
--- a/src/type-coercions.md
+++ b/src/type-coercions.md
@@ -78,6 +78,16 @@ r[coerce.site.return]
   }
   ```
 
+r[coerce.site.assignment]
+* Assigned value operands in assignment expressions
+
+  For example, `y` is coerced to have type `&i8` in the following:
+  ```rust
+  let mut x = &0i8;
+  let y = &mut 42i8;
+  x = y;
+  ```
+
 r[coerce.site.subexpr]
 If the expression in one of these coercion sites is a coercion-propagating
 expression, then the relevant sub-expressions in that expression are also


### PR DESCRIPTION
I was recently confused as for why this is allowed in Rust
```rust
let mut a = &12;
let b = &&34;
a = b; 
```
as I couldn't find that documented anywhere.

I was told that assignment expressions are in fact coercion sites which explains the example above.

This PR documents assignment expressions as coercion sites in the reference.