### PR TITLE
specify `if let` guards with updated scoping rules

### DIFF
--- a/src/destructors.md
+++ b/src/destructors.md
@@ -107,14 +107,6 @@ r[destructors.scope.nesting.match-guard]
 r[destructors.scope.nesting.match-arm]
 * The parent of the expression after the `=>` in a `match` expression is the scope of the arm that it's in.
 
-r[destructors.scope.nesting.match-guard-pattern]
-* The parent of an `if let` guard pattern is the scope of the guard expression.
-
-r[destructors.scope.nesting.match-guard-bindings]
-* Variables bound by `if let` guard patterns have their drop scope determined by guard success:
-  - On guard failure: dropped immediately after guard evaluation
-  - On guard success: scope extends to the end of the match arm body
-
 r[destructors.scope.nesting.match]
 * The parent of the arm scope is the scope of the `match` expression that it belongs to.
 
@@ -149,8 +141,8 @@ patterns_in_parameters(
 r[destructors.scope.bindings]
 ### Scopes of local variables
 
-r[destructors.scope.bindings.intro]
-Local variables declared in a `let` statement are associated to the scope of the block that contains the `let` statement. Local variables declared in a `match` expression are associated to the arm scope of the `match` arm that they are declared in.
+r[destructors.scope.bindings.let]
+Local variables declared in a `let` statement are associated to the scope of the block that contains the `let` statement.
 
 ```rust
 # struct PrintOnDrop(&'static str);
@@ -164,6 +156,49 @@ let declared_first = PrintOnDrop("Dropped last in outer scope");
     let declared_in_block = PrintOnDrop("Dropped in inner scope");
 }
 let declared_last = PrintOnDrop("Dropped first in outer scope");
+```
+
+r[destructors.scope.bindings.match-arm]
+Local variables declared in a `match` expression or pattern-matching `match` guard are associated to the arm scope of the `match` arm that they are declared in.
+
+```rust
+# #![allow(irrefutable_let_patterns)]
+# struct PrintOnDrop(&'static str);
+# impl Drop for PrintOnDrop {
+#     fn drop(&mut self) {
+#         println!("drop({})", self.0);
+#     }
+# }
+match PrintOnDrop("Dropped last in the first arm's scope") {
+    // When guard evaluation succeeds, control-flow stays in the arm and
+    // values may be moved from the scrutinee into the arm's bindings,
+    // causing them to be dropped in the arm's scope.
+    x if let y = PrintOnDrop("Dropped second in the first arm's scope")
+        && let z = PrintOnDrop("Dropped first in the first arm's scope") =>
+    {
+        let declared_in_block = PrintOnDrop("Dropped in inner scope");
+        // Pattern-matching guards' bindings and temporaries are dropped in
+        // reverse order, dropping each guard condition operand's bindings
+        // before its temporaries. Lastly, variables bound by the arm's
+        // pattern are dropped.
+    }
+    _ => unreachable!(),
+}
+
+match PrintOnDrop("Dropped in the enclosing temporary scope") {
+    // When guard evaluation fails, control-flow leaves the arm scope,
+    // causing bindings and temporaries from earlier pattern-matching
+    // guard condition operands to be dropped. This occurs before evaluating
+    // the next arm's guard or body.
+    _ if let y = PrintOnDrop("Dropped in the first arm's scope")
+        && false => unreachable!(),
+    // When a guard is executed multiple times due to self-overlapping
+    // or-patterns, control-flow leaves the arm scope when the guard fails
+    // and re-enters the arm scope before executing the guard again.
+    _ | _ if let y = PrintOnDrop("Dropped in the second arm's scope twice")
+        && false => unreachable!(),
+    _ => {},
+}
 ```
 
 r[destructors.scope.bindings.patterns]
@@ -233,9 +268,8 @@ Apart from lifetime extension, the temporary scope of an expression is the small
 * A statement.
 * The body of an [`if`], [`while`] or [`loop`] expression.
 * The `else` block of an `if` expression.
-* The condition expression of an `if` or `while` expression.
-* A `match` guard expression, including `if let` guard patterns.
-* The body expression for a match arm.
+* The non-pattern matching condition expression of an `if` or `while` expression or a non-pattern-matching `match` [guard condition operand].
+* The pattern-matching guard, if present, and body expression for a `match` arm.
 * Each operand of a [lazy boolean expression].
 * The pattern-matching condition(s) and consequent body of [`if`] ([destructors.scope.temporary.edition2024]).
 * The pattern-matching condition and loop body of [`while`].
@@ -298,8 +332,16 @@ while let x = PrintOnDrop("while let scrutinee").0 {
 // Scrutinee is dropped at the end of the function, before local variables
 // (because this is the tail expression of the function body block).
 match PrintOnDrop("Matched value in final expression") {
-    // Dropped once the condition has been evaluated
+    // Non-pattern-matching guards' temporaries are dropped once the
+    // condition has been evaluated
     _ if PrintOnDrop("guard condition").0 == "" => (),
+    // Pattern-matching guards' temporaries are dropped when leaving the
+    // arm's scope
+    _ if let "guard scrutinee" = PrintOnDrop("guard scrutinee").0 => {
+        let _ = &PrintOnDrop("lifetime-extended temporary in inner scope");
+        // `lifetime-extended temporary in inner scope` is dropped here
+    }
+    // `guard scrutinee` is dropped here
     _ => (),
 }
 ```
@@ -580,55 +622,6 @@ pin!({ &temp() }); // ERROR
 format_args!("{:?}", { &temp() }); // ERROR
 ```
 
-r[destructors.scope.match-guards]
-### Match Guards and Pattern Binding
-
-r[destructors.scope.match-guards.basic]
-Match guard expressions create their own temporary scope. Variables bound within guard patterns have conditional drop scopes based on guard evaluation results.
-
-r[destructors.scope.match-guards.if-let]
-For `if let` guards specifically:
-
-1. **Guard pattern evaluation**: The `if let` pattern is evaluated within the guard's temporary scope.
-2. **Conditional binding scope**:
-   - If the pattern matches, bound variables extend their scope to the match arm body
-   - If the pattern fails, bound variables are dropped immediately
-3. **Temporary cleanup**: Temporaries created during guard evaluation are dropped when the guard scope ends, regardless of pattern match success.
-
-r[destructors.scope.match-guards.multiple]
-For multiple guards connected by `&&`:
-- Each guard maintains its own temporary scope
-- Failed guards drop their bindings before subsequent guard evaluation
-- Only successful guard bindings are available in the arm body
-- Guards are evaluated left-to-right with short-circuit semantics
-
-```rust
-# struct PrintOnDrop(&'static str);
-# impl Drop for PrintOnDrop {
-#     fn drop(&mut self) {
-#         println!("drop({})", self.0);
-#     }
-# }
-# fn expensive_operation(x: i32) -> Option<PrintOnDrop> {
-#     Some(PrintOnDrop("expensive result"))
-# }
-
-match Some(42) {
-    // Guard creates temporary scope for pattern evaluation
-    Some(x) if let Some(y) = expensive_operation(x) => {
-        // Both x (from main pattern) and y (from guard) are live
-        // y will be dropped at end of this arm
-        println!("Success case");
-    } // y dropped here
-    Some(x) => {
-        // If guard failed, y was already dropped during guard evaluation
-        // expensive_operation result was also dropped
-        println!("Guard failed case");
-    }
-    None => {}
-}
-```
-
 r[destructors.forget]
 ## Not running destructors
 
@@ -655,6 +648,7 @@ There is one additional case to be aware of: when a panic reaches a [non-unwindi
 [destructors]: destructors.md
 [destructuring assignment]: expr.assign.destructure
 [expression]: expressions.md
+[guard condition operand]: expressions/match-expr.md#match-guard-chains
 [identifier pattern]: patterns.md#identifier-patterns
 [initialized]: glossary.md#initialized
 [interior mutability]: interior-mutability.md

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -23,11 +23,25 @@ MatchArmGuard ->
     `if` MatchConditions
 
 MatchConditions ->
-    MatchCondition ( `&&` MatchCondition )*
+     Expression
+   | MatchConditionChain
 
-MatchCondition ->
-      OuterAttribute* `let` Pattern `=` Scrutinee
-    | Expression
+MatchConditionChain ->
+    MatchChainCondition ( `&&` MatchChainCondition )*
+
+MatchChainCondition ->
+     Expression _except [ExcludedMatchConditions]_
+   | OuterAttribute* `let` Pattern `=` MatchGuardScrutinee
+
+MatchGuardScrutinee -> Expression _except [ExcludedMatchConditions]_
+
+@root ExcludedMatchConditions ->
+      LazyBooleanExpression
+    | RangeExpr
+    | RangeFromExpr
+    | RangeInclusiveExpr
+    | AssignmentExpression
+    | CompoundAssignmentExpression
 ```
 <!-- TODO: The exception above isn't accurate, see https://github.com/rust-lang/reference/issues/569 -->
 
@@ -174,71 +188,42 @@ r[expr.match.guard.no-mutation]
 Moreover, by holding a shared reference while evaluating the guard, mutation inside guards is also prevented.
 
 r[expr.match.if.let.guard]
-## If Let Guards
-Match arms can include `if let` guards to allow conditional pattern matching within the guard clause.
+## If-let Guards
+Match arms can have additional conditions using *if-let guards*. These allow using `if let` expressions within match guard clauses, enabling conditional pattern matching directly in the guard.
 
 r[expr.match.if.let.guard.syntax]
-```rust,ignore
-match expression {
-    pattern if let subpattern = guard_expr => arm_body,
-    ...
+```rust
+enum Command {
+    Run(String),
+    Stop,
+}
+
+match cmd {
+    Command::Run(name) if let Some(first_char) = name.chars().next() => {
+        // Both `name` and `first_char` are available here
+        println!("Running: {} (starts with '{}')", name, first_char);
+    }
+    Command::Run(name) => {
+        println!("Cannot run command: {}", name);
+    }
+    _ => {}
 }
 ```
-Here, `guard_expr` is evaluated and matched against `subpattern`. If the `if let` expression in the guard matches successfully, the arm's body is executed. Otherwise, pattern matching continues to the next arm.
+Here, the guard condition `let Some(first_char) = name.chars().next()` is evaluated. If the `if let` expression successfully matches (i.e., the string has at least one character), the arm's body is executed with both `name` and `first_char` available. Otherwise, pattern matching continues to the next arm.
+
+The key point is that the `if let` guard creates a new binding (`first_char`) that's only available if the guard succeeds, and this binding can be used alongside the original pattern bindings (`name`) in the arm's body.
 
 r[expr.match.if.let.guard.behavior]
 When the pattern matches successfully, the `if let` expression in the guard is evaluated:
   * The guard proceeds if the inner pattern (`subpattern`) matches the result of `guard_expr`.
   * Otherwise, the next arm is tested.
 
-```rust,ignore
-let value = Some(10);
-
-let msg = match value {
-    Some(x) if let Some(y) = Some(x - 1) => format!("Matched inner value: {}", y),
-    _ => "No match".to_string(),
-};
-```
-
 r[expr.match.if.let.guard.scope]
-* The `if let` guard may refer to variables bound by the outer match pattern.
-* New variables bound inside the `if let` guard (e.g., `y` in the example above) are available within the body of the match arm where the guard evaluates to `true`, but are not accessible in other arms or outside the match expression.
+
+For detailed information about variable scope and drop behavior, see the [scope and drop section].
 
 ```rust,ignore
-let opt = Some(42);
-
-match opt {
-    Some(x) if let Some(y) = Some(x + 1) => {
-        // Both `x` and `y` are available in this arm,
-        // since the pattern matched and the guard evaluated to true.
-        println!("x = {}, y = {}", x, y);
-    }
-    _ => {
-        // `y` is not available here --- it was only bound inside the guard above.
-        // Uncommenting the line below will cause a compile-time error:
-        // println!("{}", y); // error: cannot find value `y` in this scope
-    }
-}
-
-// Outside the match expression, neither `x` nor `y` are in scope.
-```
-
-* The outer pattern variables (`x`) follow the same borrowing behavior as in standard match guards (see below).
-
-r[expr.match.if.let.guard.drop]
-
-* Variables bound inside `if let` guards are dropped before evaluating subsequent match arms.
-
-* Temporaries created during guard evaluation follow standard drop semantics and are cleaned up appropriately.
-
-r[expr.match.if.let.guard.borrowing]
-Variables bound by the outer pattern follow the same borrowing rules as standard match guards:
-* A shared reference is taken to pattern variables before guard evaluation
-* Values are moved or copied only when the guard succeeds
-* Moving from outer pattern variables within the guard is restricted
-
-```rust,ignore
-fn take<T>(value: T) -> Option<T> { Some(value) }
+# fn take<T>(value: T) -> Option<T> { Some(value) }
 
 let val = Some(vec![1, 2, 3]);
 match val {
@@ -249,7 +234,7 @@ match val {
 ```
 > [!NOTE]
 > Multiple matches using the `|` operator can cause the pattern guard and the side effects it has to execute multiple times. For example:
-> ```rust,ignore
+> ```rust
 > use std::cell::Cell;
 >
 > let i: Cell<i32> = Cell::new(0);
@@ -283,3 +268,4 @@ r[expr.match.attributes.inner]
 [Range Pattern]: ../patterns.md#range-patterns
 [scrutinee]: ../glossary.md#scrutinee
 [value expression]: ../expressions.md#place-expressions-and-value-expressions
+[scope and drop section]: ../destructors.md#match-guards-and-pattern-binding

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -9,15 +9,25 @@ MatchExpression ->
         MatchArms?
     `}`
 
-Scrutinee -> Expression _except [StructExpression]_
+Scrutinee ->
+    Expression _except_ [StructExpression]
 
 MatchArms ->
     ( MatchArm `=>` ( ExpressionWithoutBlock `,` | ExpressionWithBlock `,`? ) )*
     MatchArm `=>` Expression `,`?
 
-MatchArm -> OuterAttribute* Pattern MatchArmGuard?
+MatchArm ->
+    OuterAttribute* Pattern MatchArmGuard?
 
-MatchArmGuard -> `if` Expression
+MatchArmGuard ->
+    `if` MatchConditions
+
+MatchConditions ->
+    MatchCondition ( `&&` MatchCondition )*
+
+MatchCondition ->
+      OuterAttribute* `let` Pattern `=` Scrutinee
+    | Expression
 ```
 <!-- TODO: The exception above isn't accurate, see https://github.com/rust-lang/reference/issues/569 -->
 
@@ -162,6 +172,93 @@ Only when the guard evaluates to true is the value moved, or copied, from the sc
 
 r[expr.match.guard.no-mutation]
 Moreover, by holding a shared reference while evaluating the guard, mutation inside guards is also prevented.
+
+r[expr.match.if.let.guard]
+## If Let Guards
+Match arms can include `if let` guards to allow conditional pattern matching within the guard clause.
+
+r[expr.match.if.let.guard.syntax]
+```rust,ignore
+match expression {
+    pattern if let subpattern = guard_expr => arm_body,
+    ...
+}
+```
+Here, `guard_expr` is evaluated and matched against `subpattern`. If the `if let` expression in the guard matches successfully, the arm's body is executed. Otherwise, pattern matching continues to the next arm.
+
+r[expr.match.if.let.guard.behavior]
+When the pattern matches successfully, the `if let` expression in the guard is evaluated:
+  * The guard proceeds if the inner pattern (`subpattern`) matches the result of `guard_expr`.
+  * Otherwise, the next arm is tested.
+
+```rust,ignore
+let value = Some(10);
+
+let msg = match value {
+    Some(x) if let Some(y) = Some(x - 1) => format!("Matched inner value: {}", y),
+    _ => "No match".to_string(),
+};
+```
+
+r[expr.match.if.let.guard.scope]
+* The `if let` guard may refer to variables bound by the outer match pattern.
+* New variables bound inside the `if let` guard (e.g., `y` in the example above) are available within the body of the match arm where the guard evaluates to `true`, but are not accessible in other arms or outside the match expression.
+
+```rust,ignore
+let opt = Some(42);
+
+match opt {
+    Some(x) if let Some(y) = Some(x + 1) => {
+        // Both `x` and `y` are available in this arm,
+        // since the pattern matched and the guard evaluated to true.
+        println!("x = {}, y = {}", x, y);
+    }
+    _ => {
+        // `y` is not available here --- it was only bound inside the guard above.
+        // Uncommenting the line below will cause a compile-time error:
+        // println!("{}", y); // error: cannot find value `y` in this scope
+    }
+}
+
+// Outside the match expression, neither `x` nor `y` are in scope.
+```
+
+* The outer pattern variables (`x`) follow the same borrowing behavior as in standard match guards (see below).
+
+r[expr.match.if.let.guard.drop]
+
+* Variables bound inside `if let` guards are dropped before evaluating subsequent match arms.
+
+* Temporaries created during guard evaluation follow standard drop semantics and are cleaned up appropriately.
+
+r[expr.match.if.let.guard.borrowing]
+Variables bound by the outer pattern follow the same borrowing rules as standard match guards:
+* A shared reference is taken to pattern variables before guard evaluation
+* Values are moved or copied only when the guard succeeds
+* Moving from outer pattern variables within the guard is restricted
+
+```rust,ignore
+fn take<T>(value: T) -> Option<T> { Some(value) }
+
+let val = Some(vec![1, 2, 3]);
+match val {
+    Some(v) if let Some(_) = take(v) => "moved", // ERROR: cannot move `v`
+    Some(v) if let Some(_) = take(v.clone()) => "cloned", // OK
+    _ => "none",
+}
+```
+> [!NOTE]
+> Multiple matches using the `|` operator can cause the pattern guard and the side effects it has to execute multiple times. For example:
+> ```rust,ignore
+> use std::cell::Cell;
+>
+> let i: Cell<i32> = Cell::new(0);
+> match 1 {
+>     1 | _ if let Some(_) = { i.set(i.get() + 1); Some(1) } => {}
+>     _ => {}
+> }
+> assert_eq!(i.get(), 2); // Guard is executed twice
+> ```
 
 r[expr.match.attributes]
 ## Attributes on match arms

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -9,27 +9,23 @@ MatchExpression ->
         MatchArms?
     `}`
 
-Scrutinee ->
-    Expression _except_ [StructExpression]
+Scrutinee -> Expression _except [StructExpression]_
 
 MatchArms ->
     ( MatchArm `=>` ( ExpressionWithoutBlock `,` | ExpressionWithBlock `,`? ) )*
     MatchArm `=>` Expression `,`?
 
-MatchArm ->
-    OuterAttribute* Pattern MatchArmGuard?
+MatchArm -> OuterAttribute* Pattern MatchArmGuard?
 
-MatchArmGuard ->
-    `if` MatchConditions
+MatchArmGuard -> `if` MatchConditions
 
 MatchConditions ->
      Expression
-   | MatchConditionChain
+   | MatchGuardChain
 
-MatchConditionChain ->
-    MatchChainCondition ( `&&` MatchChainCondition )*
+MatchGuardChain -> MatchGuardCondition ( `&&` MatchGuardCondition )*
 
-MatchChainCondition ->
+MatchGuardCondition ->
      Expression _except [ExcludedMatchConditions]_
    | OuterAttribute* `let` Pattern `=` MatchGuardScrutinee
 
@@ -142,11 +138,11 @@ r[expr.match.guard]
 r[expr.match.guard.intro]
 Match arms can accept _match guards_ to further refine the criteria for matching a case.
 
-r[expr.match.guard.type]
-Pattern guards appear after the pattern and consist of a `bool`-typed expression following the `if` keyword.
+r[expr.match.guard.condition]
+Pattern guards appear after the pattern following the `if` keyword and consist of an [Expression] with a [boolean type][type.bool] or a conditional `let` match.
 
 r[expr.match.guard.behavior]
-When the pattern matches successfully, the pattern guard expression is executed. If the expression evaluates to true, the pattern is successfully matched against.
+When the pattern matches successfully, the pattern guard is executed. If all of the guard condition operands evaluate to `true` and all of the `let` patterns successfully match their [scrutinee]s, the match arm is successfully matched against and the arm body is executed.
 
 r[expr.match.guard.next]
 Otherwise, the next pattern, including other matches with the `|` operator in the same arm, is tested.
@@ -182,67 +178,73 @@ r[expr.match.guard.shared-ref]
 Before evaluating the guard, a shared reference is taken to the part of the scrutinee the variable matches on. While evaluating the guard, this shared reference is then used when accessing the variable.
 
 r[expr.match.guard.value]
-Only when the guard evaluates to true is the value moved, or copied, from the scrutinee into the variable. This allows shared borrows to be used inside guards without moving out of the scrutinee in case guard fails to match.
+Only when the guard evaluates successfully is the value moved, or copied, from the scrutinee into the variable. This allows shared borrows to be used inside guards without moving out of the scrutinee in case guard fails to match.
 
 r[expr.match.guard.no-mutation]
 Moreover, by holding a shared reference while evaluating the guard, mutation inside guards is also prevented.
 
-r[expr.match.if.let.guard]
-## If-let Guards
-Match arms can have additional conditions using *if-let guards*. These allow using `if let` expressions within match guard clauses, enabling conditional pattern matching directly in the guard.
+r[expr.match.guard.let]
+Guards can use `let` patterns to conditionally match a scrutinee and to bind new variables into scope when the pattern matches successfully.
 
-r[expr.match.if.let.guard.syntax]
-```rust
-enum Command {
-    Run(String),
-    Stop,
-}
-
-match cmd {
-    Command::Run(name) if let Some(first_char) = name.chars().next() => {
-        // Both `name` and `first_char` are available here
-        println!("Running: {} (starts with '{}')", name, first_char);
-    }
-    Command::Run(name) => {
-        println!("Cannot run command: {}", name);
-    }
-    _ => {}
-}
-```
-Here, the guard condition `let Some(first_char) = name.chars().next()` is evaluated. If the `if let` expression successfully matches (i.e., the string has at least one character), the arm's body is executed with both `name` and `first_char` available. Otherwise, pattern matching continues to the next arm.
-
-The key point is that the `if let` guard creates a new binding (`first_char`) that's only available if the guard succeeds, and this binding can be used alongside the original pattern bindings (`name`) in the arm's body.
-
-r[expr.match.if.let.guard.behavior]
-When the pattern matches successfully, the `if let` expression in the guard is evaluated:
-  * The guard proceeds if the inner pattern (`subpattern`) matches the result of `guard_expr`.
-  * Otherwise, the next arm is tested.
-
-r[expr.match.if.let.guard.scope]
-
-For detailed information about variable scope and drop behavior, see the [scope and drop section].
-
-```rust,ignore
-# fn take<T>(value: T) -> Option<T> { Some(value) }
-
-let val = Some(vec![1, 2, 3]);
-match val {
-    Some(v) if let Some(_) = take(v) => "moved", // ERROR: cannot move `v`
-    Some(v) if let Some(_) = take(v.clone()) => "cloned", // OK
-    _ => "none",
-}
-```
-> [!NOTE]
-> Multiple matches using the `|` operator can cause the pattern guard and the side effects it has to execute multiple times. For example:
-> ```rust
-> use std::cell::Cell;
+> [!EXAMPLE]
+> In this example, the guard condition `let Some(first_char) = name.chars().next()` is evaluated. If the `if let` expression successfully matches (i.e., the string has at least one character), the arm's body is executed with both `name` and `first_char` available. Otherwise, pattern matching continues to the next arm.
 >
-> let i: Cell<i32> = Cell::new(0);
-> match 1 {
->     1 | _ if let Some(_) = { i.set(i.get() + 1); Some(1) } => {}
+> The key point is that the `if let` guard creates a new binding (`first_char`) that's only available if the guard succeeds, and this binding can be used alongside the original pattern bindings (`name`) in the arm's body.
+>
+> ```rust
+> # enum Command {
+> #     Run(String),
+> #     Stop,
+> # }
+> let cmd = Command::Run("example".to_string());
+>
+> match cmd {
+>     Command::Run(name) if let Some(first_char) = name.chars().next() => {
+>         // Both `name` and `first_char` are available here
+>         println!("Running: {name} (starts with '{first_char}')");
+>     }
+>     Command::Run(name) => {
+>         println!("{name} is empty");
+>     }
 >     _ => {}
 > }
-> assert_eq!(i.get(), 2); // Guard is executed twice
+> ```
+
+r[expr.match.guard.chains]
+## Match guard chains
+
+r[expr.match.guard.chains.intro]
+Multiple guard condition operands can be separated with `&&`.
+
+> [!EXAMPLE]
+> ```rust
+> # let foo = Some([123]);
+> # let already_checked = false;
+> match foo {
+>     Some(xs) if let [single] = xs && !already_checked => { dbg!(single); }
+>     _ => {}
+> }
+> ```
+
+r[expr.match.guard.chains.order]
+Similar to a `&&` [LazyBooleanExpression], each operand is evaluated from left-to-right until an operand evaluates as `false` or a `let` match fails, in which case the subsequent operands are not evaluated.
+
+r[expr.match.guard.chains.bindings]
+The bindings of each `let` pattern are put into scope to be available for the next condition operand and the match arm body.
+
+r[expr.match.guard.chains.or]
+If any guard condition operand is a `let` pattern, then none of the condition operands can be a `||` [lazy boolean operator expression][expr.bool-logic] due to ambiguity and precedence with the `let` scrutinee.
+
+> [!EXAMPLE]
+> If a `||` expression is needed, then parentheses can be used. For example:
+>
+> ```rust
+> # let foo = Some(123);
+> match foo {
+>     // Parentheses are required here.
+>     Some(x) if (x < -100 || x > 20) => {}
+>     _ => {}
+> }
 > ```
 
 r[expr.match.attributes]

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -187,10 +187,9 @@ r[expr.match.guard.let]
 Guards can use `let` patterns to conditionally match a scrutinee and to bind new variables into scope when the pattern matches successfully.
 
 > [!EXAMPLE]
-> In this example, the guard condition `let Some(first_char) = name.chars().next()` is evaluated. If the `if let` expression successfully matches (i.e., the string has at least one character), the arm's body is executed with both `name` and `first_char` available. Otherwise, pattern matching continues to the next arm.
+> In this example, the guard condition `let Some(first_char) = name.chars().next()` is evaluated. If the `let` pattern successfully matches (i.e. the string has at least one character), the arm's body is executed. Otherwise, pattern matching continues to the next arm.
 >
-> The key point is that the `if let` guard creates a new binding (`first_char`) that's only available if the guard succeeds, and this binding can be used alongside the original pattern bindings (`name`) in the arm's body.
->
+> The `let` pattern creates a new binding (`first_char`), which can be used alongside the original pattern bindings (`name`) in the arm's body.
 > ```rust
 > # enum Command {
 > #     Run(String),
@@ -239,10 +238,10 @@ If any guard condition operand is a `let` pattern, then none of the condition op
 > If a `||` expression is needed, then parentheses can be used. For example:
 >
 > ```rust
-> # let foo = Some(123);
+> # let foo = Some([123]);
 > match foo {
 >     // Parentheses are required here.
->     Some(x) if (x < -100 || x > 20) => {}
+>     Some(xs) if let [x] = xs && (x < -100 || x > 20) => {}
 >     _ => {}
 > }
 > ```

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -270,4 +270,3 @@ r[expr.match.attributes.inner]
 [Range Pattern]: ../patterns.md#range-patterns
 [scrutinee]: ../glossary.md#scrutinee
 [value expression]: ../expressions.md#place-expressions-and-value-expressions
-[scope and drop section]: ../destructors.md#match-guards-and-pattern-binding

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -20,8 +20,8 @@ MatchArm -> OuterAttribute* Pattern MatchArmGuard?
 MatchArmGuard -> `if` MatchConditions
 
 MatchConditions ->
-     Expression
-   | MatchGuardChain
+     MatchGuardChain
+   | Expression
 
 MatchGuardChain -> MatchGuardCondition ( `&&` MatchGuardCondition )*
 

--- a/src/names/scopes.md
+++ b/src/names/scopes.md
@@ -48,6 +48,8 @@ r[names.scopes.pattern-bindings.let-chains]
 * [`if let`] and [`while let`] bindings are valid in the following conditions as well as the consequent block.
 r[names.scopes.pattern-bindings.match-arm]
 * [`match` arms] bindings are within the [match guard] and the match arm expression.
+r[names.scopes.pattern-bindings.match-guard-if-let]
+* [`if let` guard] bindings are within the guard expression and the match arm expression if the guard succeeds.
 
 r[names.scopes.pattern-bindings.items]
 Local variable scopes do not extend into item declarations.
@@ -331,6 +333,7 @@ impl ImplExample {
 [`macro_use` prelude]: preludes.md#macro_use-prelude
 [`macro_use`]: ../macros-by-example.md#the-macro_use-attribute
 [`match` arms]: ../expressions/match-expr.md
+[`if let` guard]: ../expressions/match-expr.md#if-let-guards
 [`Self`]: ../paths.md#self-1
 [Associated consts]: ../items/associated-items.md#associated-constants
 [associated items]: ../items/associated-items.md

--- a/src/names/scopes.md
+++ b/src/names/scopes.md
@@ -49,7 +49,7 @@ r[names.scopes.pattern-bindings.let-chains]
 r[names.scopes.pattern-bindings.match-arm]
 * [`match` arms] bindings are within the [match guard] and the match arm expression.
 r[names.scopes.pattern-bindings.match-guard-let]
-* [`match` guard `let`] bindings are valid in the following guard conditions and the match arm expression if the guard succeeds.
+* [`match` guard `let`] bindings are valid in the following guard conditions and the match arm expression.
 
 r[names.scopes.pattern-bindings.items]
 Local variable scopes do not extend into item declarations.

--- a/src/names/scopes.md
+++ b/src/names/scopes.md
@@ -48,8 +48,8 @@ r[names.scopes.pattern-bindings.let-chains]
 * [`if let`] and [`while let`] bindings are valid in the following conditions as well as the consequent block.
 r[names.scopes.pattern-bindings.match-arm]
 * [`match` arms] bindings are within the [match guard] and the match arm expression.
-r[names.scopes.pattern-bindings.match-guard-if-let]
-* [`if let` guard] bindings are within the guard expression and the match arm expression if the guard succeeds.
+r[names.scopes.pattern-bindings.match-guard-let]
+* [`match` guard `let`] bindings are valid in the following guard conditions and the match arm expression if the guard succeeds.
 
 r[names.scopes.pattern-bindings.items]
 Local variable scopes do not extend into item declarations.
@@ -333,7 +333,7 @@ impl ImplExample {
 [`macro_use` prelude]: preludes.md#macro_use-prelude
 [`macro_use`]: ../macros-by-example.md#the-macro_use-attribute
 [`match` arms]: ../expressions/match-expr.md
-[`if let` guard]: ../expressions/match-expr.md#if-let-guards
+[`match` guard `let`]: expr.match.guard.let
 [`Self`]: ../paths.md#self-1
 [Associated consts]: ../items/associated-items.md#associated-constants
 [associated items]: ../items/associated-items.md


### PR DESCRIPTION
This is based on rust-lang/reference#1823 by @Kivooeo and @ehuss, rebased to resolve conflicts. Per https://github.com/rust-lang/rust/pull/141295#issuecomment-3172434801, I'm opening this as a separate PR to contribute an updated specification of `if let` guards' drop-scoping rules. The new spec is based on the compiler's implementation[^1], accounting for the changes in rust-lang/rust#143376 and additional corner-cases in examples. I've also done some minor edits to the sections on lexical scope and match expressions, but for the most part they're the same as in rust-lang/reference#1823.

[^1]: As with the rules for other syntactic constructs (e.g. `let` statements and `if` expressions), this is slightly simplified. Due to implementation details, the compiler's notion of drop scopes is more fine-grained than is necessary for the language spec.

Tracking issue: rust-lang/rust#51114
Stabilization: https://github.com/rust-lang/rust/pull/141295
