### PR TITLE
Fix indentation of static path restriction text

### DIFF
--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -46,7 +46,7 @@ r[const-eval.const-expr.path-static]
   * Reads from `extern` statics are not allowed in any constant evaluation context.
   * If the evaluation is *not* carried out in an initializer of a `static` item, then reads from any mutable `static` are not allowed. A mutable `static` is a `static mut` item, or a `static` item with an interior-mutable type.
 
-These requirements are checked only when the constant is evaluated. In other words, having such accesses syntactically occur in const contexts is allowed as long as they never get executed.
+  These requirements are checked only when the constant is evaluated. In other words, having such accesses syntactically occur in const contexts is allowed as long as they never get executed.
 
 r[const-eval.const-expr.tuple]
 * [Tuple expressions].


### PR DESCRIPTION
In the const eval chapter, we have a list of kinds of expressions that are allowed.  Paths to statics are one kind that is allowed, but have certain restrictions we describe in bullet points.  We then have text that clarifies when these bullet points are checked.

This text was outdented beyond the relevant item, which broke up the outer bullet point list and created (momentary) ambiguity about the scope of the rules the language might be affecting.

cc @ehuss
