### PR TITLE
Add missing rule identifier for const outer generics

### DIFF
--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -248,6 +248,7 @@ r[const-eval.const-context.generic]
 r[const-eval.const-context.block]
 * A [const block]
 
+r[const-eval.const-context.outer-generics]
 Const contexts that are used as parts of types (array type and repeat length
 expressions as well as const generic arguments) can only make restricted use of
 surrounding generic parameters: such an expression must either be a single bare


### PR DESCRIPTION
In the section on const contexts, we have a rule about when outer generics cannot be used.  This was missing a rule identifier, so the text appeared to be part of the preceding rule.  Let's fix that.

cc @ehuss