### PR TITLE
Switch to using native mdbook fragment redirects

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   merge_group:
 
 env:
-  MDBOOK_VERSION: 0.4.48
+  MDBOOK_VERSION: 0.4.52
 
 jobs:
   code-tests:

--- a/book.toml
+++ b/book.toml
@@ -15,7 +15,19 @@ smart-punctuation = true
 "grammar.md" = { enable = false }
 
 [output.html.redirect]
+"/crates-and-source-files.html#preludes-and-no_std" = "names/preludes.html"
 "/expressions/enum-variant-expr.html" = "struct-expr.html"
+"/expressions/if-expr.html#if-let-expressions" = "if-expr.html#if-let-patterns"
+"/expressions/loop-expr.html#predicate-pattern-loops" = "loop-expr.html#while-let-patterns"
+"/expressions/operator-expr.html#slice-dst-pointer-to-pointer-cast" = "operator-expr.html#pointer-to-pointer-cast"
+"/expressions/operator-expr.html#the-question-mark-operator" = "operator-expr.html#the-try-propagation-expression"
+"/glossary.html#object-safe-traits" = "glossary.html#dyn-compatible-traits"
+"/items/extern-crates.html#extern-prelude" = "../names/preludes.html#extern-prelude"
+"/items/modules.html#prelude-items" = "../names/preludes.html"
+"/items/traits.html#object-safety" = "traits.html#dyn-compatibility"
+"/lifetime-elision.html#static-lifetime-elision" = "lifetime-elision.html#const-and-static-elision"
+"/procedural-macros.html#derive-macros" = "procedural-macros.html#the-proc_macro_derive-attribute"
+"/runtime.html#the-panic_handler-attribute" = "panic.html#the-panic_handler-attribute"
 "/unsafe-blocks.html" = "unsafe-keyword.html"
 "/unsafe-functions.html" = "unsafe-keyword.html"
 

--- a/src/crates-and-source-files.md
+++ b/src/crates-and-source-files.md
@@ -172,17 +172,3 @@ or `_` (U+005F) characters.
 [shebang]: input-format.md#shebang-removal
 [trait or lifetime bounds]: trait-bounds.md
 [where clauses]: items/generics.md#where-clauses
-
-<script>
-(function() {
-    var fragments = {
-        "#preludes-and-no_std": "names/preludes.html",
-    };
-    var target = fragments[window.location.hash];
-    if (target) {
-        var url = window.location.toString();
-        var base = url.substring(0, url.lastIndexOf('/'));
-        window.location.replace(base + "/" + target);
-    }
-})();
-</script>

--- a/src/expressions/if-expr.md
+++ b/src/expressions/if-expr.md
@@ -181,17 +181,3 @@ r[expr.if.edition2024]
 [`match` expressions]: match-expr.md
 [boolean type]: ../types/boolean.md
 [scrutinee]: ../glossary.md#scrutinee
-
-<script>
-(function() {
-    var fragments = {
-        "#if-let-expressions": "if-expr.html#if-let-patterns",
-    };
-    var target = fragments[window.location.hash];
-    if (target) {
-        var url = window.location.toString();
-        var base = url.substring(0, url.lastIndexOf('/'));
-        window.location.replace(base + "/" + target);
-    }
-})();
-</script>

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -398,17 +398,3 @@ In the case a `loop` has an associated `break`, it is not considered diverging, 
 [boolean type]: ../types/boolean.md
 [scrutinee]: ../glossary.md#scrutinee
 [temporary values]: ../expressions.md#temporaries
-
-<script>
-(function() {
-    var fragments = {
-        "#predicate-pattern-loops": "loop-expr.html#while-let-patterns",
-    };
-    var target = fragments[window.location.hash];
-    if (target) {
-        var url = window.location.toString();
-        var base = url.substring(0, url.lastIndexOf('/'));
-        window.location.replace(base + "/" + target);
-    }
-})();
-</script>

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -968,18 +968,3 @@ Like assignment expressions, compound assignment expressions always produce [the
 [undefined behavior]: ../behavior-considered-undefined.md
 [Underscore expressions]: ./underscore-expr.md
 [range expressions]: ./range-expr.md
-
-<script>
-(function() {
-    var fragments = {
-        "#slice-dst-pointer-to-pointer-cast": "operator-expr.html#pointer-to-pointer-cast",
-        "#the-question-mark-operator": "operator-expr.html#the-try-propagation-expression",
-    };
-    var target = fragments[window.location.hash];
-    if (target) {
-        var url = window.location.toString();
-        var base = url.substring(0, url.lastIndexOf('/'));
-        window.location.replace(base + "/" + target);
-    }
-})();
-</script>

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -328,17 +328,3 @@ example of an uninhabited type is the [never type] `!`, or an enum with no varia
 [unions]: items/unions.md
 [variable bindings]: patterns.md
 [visibility rules]: visibility-and-privacy.md
-
-<script>
-(function() {
-    var fragments = {
-        "#object-safe-traits": "glossary.html#dyn-compatible-traits",
-    };
-    var target = fragments[window.location.hash];
-    if (target) {
-        var url = window.location.toString();
-        var base = url.substring(0, url.lastIndexOf('/'));
-        window.location.replace(base + "/" + target);
-    }
-})();
-</script>

--- a/src/items/extern-crates.md
+++ b/src/items/extern-crates.md
@@ -113,17 +113,3 @@ Duplicate instances of the `no_link` attribute are ignored.
 [`macro_use` prelude]: ../names/preludes.md#macro_use-prelude
 [`crate_name` attributes]: ../crates-and-source-files.md#the-crate_name-attribute
 [type namespace]: ../names/namespaces.md
-
-<script>
-(function() {
-    var fragments = {
-        "#extern-prelude": "../names/preludes.html#extern-prelude",
-    };
-    var target = fragments[window.location.hash];
-    if (target) {
-        var url = window.location.toString();
-        var base = url.substring(0, url.lastIndexOf('/'));
-        window.location.replace(base + "/" + target);
-    }
-})();
-</script>

--- a/src/items/modules.md
+++ b/src/items/modules.md
@@ -170,17 +170,3 @@ The built-in attributes that have meaning on a module are [`cfg`],
 [scopes chapter]: ../names/scopes.md
 [the lint check attributes]: ../attributes/diagnostics.md#lint-check-attributes
 [type namespace]: ../names/namespaces.md
-
-<script>
-(function() {
-    var fragments = {
-        "#prelude-items": "../names/preludes.html",
-    };
-    var target = fragments[window.location.hash];
-    if (target) {
-        var url = window.location.toString();
-        var base = url.substring(0, url.lastIndexOf('/'));
-        window.location.replace(base + "/" + target);
-    }
-})();
-</script>

--- a/src/items/traits.md
+++ b/src/items/traits.md
@@ -410,17 +410,3 @@ fn main() {
 [`async`]: functions.md#async-functions
 [`const`]: functions.md#const-functions
 [type namespace]: ../names/namespaces.md
-
-<script>
-(function() {
-    var fragments = {
-        "#object-safety": "traits.html#dyn-compatibility",
-    };
-    var target = fragments[window.location.hash];
-    if (target) {
-        var url = window.location.toString();
-        var base = url.substring(0, url.lastIndexOf('/'));
-        window.location.replace(base + "/" + target);
-    }
-})();
-</script>

--- a/src/lifetime-elision.md
+++ b/src/lifetime-elision.md
@@ -245,17 +245,3 @@ const RESOLVED_STATIC: &dyn Fn(&Foo, &Bar) -> &Baz = &somefunc;
 [RFC 1156]: https://github.com/rust-lang/rfcs/blob/master/text/1156-adjust-default-object-bounds.md
 [static]: items/static-items.md
 [trait object]: types/trait-object.md
-
-<script>
-(function() {
-    var fragments = {
-        "#static-lifetime-elision": "lifetime-elision.html#const-and-static-elision",
-    };
-    var target = fragments[window.location.hash];
-    if (target) {
-        var url = window.location.toString();
-        var base = url.substring(0, url.lastIndexOf('/'));
-        window.location.replace(base + "/" + target);
-    }
-})();
-</script>

--- a/src/procedural-macros.md
+++ b/src/procedural-macros.md
@@ -416,17 +416,3 @@ their equivalent `#[doc = r"str"]` attributes when passed to macros.
 [type expressions]: types.md#type-expressions
 [type]: types.md
 [union]: items/unions.md
-
-<script>
-(function() {
-    var fragments = {
-        "#derive-macros": "procedural-macros.html#the-proc_macro_derive-attribute",
-    };
-    var target = fragments[window.location.hash];
-    if (target) {
-        var url = window.location.toString();
-        var base = url.substring(0, url.lastIndexOf('/'));
-        window.location.replace(base + "/" + target);
-    }
-})();
-</script>

--- a/src/runtime.md
+++ b/src/runtime.md
@@ -83,17 +83,3 @@ The `"windows"` subsystem will run detached from any existing console.
 [crate types]: linkage.md
 [static item]: items/static-items.md
 [subsystem]: https://msdn.microsoft.com/en-us/library/fcc1zstk.aspx
-
-<script>
-(function() {
-    var fragments = {
-        "#the-panic_handler-attribute": "panic.html#the-panic_handler-attribute",
-    };
-    var target = fragments[window.location.hash];
-    if (target) {
-        var url = window.location.toString();
-        var base = url.substring(0, url.lastIndexOf('/'));
-        window.location.replace(base + "/" + target);
-    }
-})();
-</script>


### PR DESCRIPTION
Mdbook recently gained the ability to redirect fragments. This removes the embedded scripts to use this mechanism instead.