### PR TITLE
Remove tuple index carve out

### DIFF
--- a/src/tokens.md
+++ b/src/tokens.md
@@ -624,7 +624,7 @@ r[lex.token.literal.int.tuple-field]
 
 r[lex.token.literal.int.tuple-field.syntax]
 ```grammar,lexer
-TUPLE_INDEX -> INTEGER_LITERAL
+TUPLE_INDEX -> DEC_LITERAL | BIN_LITERAL | OCT_LITERAL | HEX_LITERAL
 ```
 
 r[lex.token.literal.int.tuple-field.intro]
@@ -637,6 +637,8 @@ start with `0` and each successive index increments the value by `1` as a
 decimal value. Thus, only decimal values will match, and the value must not
 have any extra `0` prefix characters.
 
+Tuple indices may not include any suffixes (such as `usize`).
+
 ```rust,compile_fail
 let example = ("dog", "cat", "horse");
 let dog = example.0;
@@ -644,10 +646,9 @@ let cat = example.1;
 // The following examples are invalid.
 let cat = example.01;  // ERROR no field named `01`
 let horse = example.0b10;  // ERROR no field named `0b10`
+let unicorn = example.0usize; // ERROR suffixes on a tuple index are invalid
+let underscore = example.0_0; // ERROR no field `0_0` on type `(&str, &str, &str)`
 ```
-
-> [!NOTE]
-> Tuple indices may include certain suffixes, but this is not intended to be valid, and may be removed in a future version. See <https://github.com/rust-lang/rust/issues/60210> for more information.
 
 r[lex.token.literal.float]
 #### Floating-point literals


### PR DESCRIPTION
> [!CAUTION]
>
> This should only be merged after FCP on https://github.com/rust-lang/rust/pull/145463 passes and the PR is itself merged.

This is being proposed to be removed in <https://github.com/rust-lang/rust/pull/145463> as we never intended for this to be valid syntax. The concrete example forms are in the nomination report in https://github.com/rust-lang/rust/pull/145463#issue-3325732856.

<details>
<summary>Outdated discussion on the grammar</summary>

### Note on `TUPLE_INDEX`

This production looks wrong to me

```grammar,lexer
TUPLE_INDEX -> INTEGER_LITERAL
```

`INTEGER_LITERAL` covers *all* the decimal, binary, octal and hex literal forms, but AFAICT `TUPLE_INDEX` as implemented does not even accept the full range of decimal syntax. I.e.

```grammar,lexer
DEC_LITERAL -> DEC_DIGIT (DEC_DIGIT|`_`)*
```

but e.g.

```rs
fn main() {
    let x = (1,);
    println!("{}", x.0_0); //~ ERROR no field `0_0` on type `({integer},)`
}
```

I believe the accepted `TUPLE_INDEX` grammar here is *only*

```grammar,lexer
DEC_LITERAL -> DEC_DIGIT+
```

Let me know if that sounds right.

</details>