### PR TITLE
Fix traits implemented for function items

### DIFF
--- a/src/types/function-item.md
+++ b/src/types/function-item.md
@@ -50,8 +50,13 @@ let foo_ptr_2 = if want_i32 {
 ```
 
 r[type.fn-item.traits]
-All function items implement [`Fn`], [`FnMut`], [`FnOnce`], [`Copy`],
-[`Clone`], [`Send`], and [`Sync`].
+All function items implement [`Copy`], [`Clone`], [`Send`], and [`Sync`].
+
+[`Fn`], [`FnMut`], and [`FnOnce`] are implemented unless the function has any of the following:
+
+- an [`unsafe`][unsafe.fn] qualifier
+- a [`target_feature` attribute][attributes.codegen.target_feature]
+- an [ABI][items.fn.extern] other than `"Rust"`
 
 [`Clone`]: ../special-types-and-traits.md#clone
 [`Copy`]: ../special-types-and-traits.md#copy


### PR DESCRIPTION
This fixes the set of traits implemented for function items. `Fn` family traits are not implemented in some cases. This is roughly implemented in [`assemble_fn_pointer_candidates`](https://github.com/rust-lang/rust/blob/8c32e313cccf7df531e2d49ffb8227bb92304aee/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs#L553-L585).

I did not include "has variadic", since that also requires unsafe and extern "C" and is thus covered by the other rules, AFAIK. Could also add that to CYA, though.

Fixes https://github.com/rust-lang/reference/issues/1968