### PR TITLE
specify s390x target features

### DIFF
--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -509,9 +509,9 @@ Feature               | Implicitly Enables  | Description
 r[attributes.codegen.target_feature.s390x]
 #### `s390x`
 
-On this platform the usage of `#[target_feature]` functions follows the [above restrictions][attributes.codegen.target_feature.safety-restrictions].
+On `s390x` targets, use of functions with the `#[target_feature]` attribute follows the [above restrictions][attributes.codegen.target_feature.safety-restrictions].
 
-Further documentation on these features can be found in the "Additions to z/Architecture" section of Chapter 1 of the [Principles of Operation].
+Further documentation on these features can be found in the "Additions to z/Architecture" section of Chapter 1 of the *[z/Architecture Principles of Operation]*.
 
 Feature                                | Implicitly Enables                    | Description
 ---------------------------------------|---------------------------------------|---------------------
@@ -528,7 +528,7 @@ Feature                                | Implicitly Enables                    |
 `miscellaneous-extensions-3`           |                                       | miscellaneous extensions 3
 `miscellaneous-extensions-4`           |                                       | miscellaneous extensions 4
 
-[Principles of Operation]: https://publibfp.dhe.ibm.com/epubs/pdf/a227832d.pdf
+[z/Architecture Principles of Operation]: https://publibfp.dhe.ibm.com/epubs/pdf/a227832d.pdf
 
 r[attributes.codegen.target_feature.info]
 ### Additional information

--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -506,6 +506,30 @@ Feature               | Implicitly Enables  | Description
 [tail-call]: https://github.com/webassembly/tail-call
 [multivalue]: https://github.com/webassembly/multi-value
 
+r[attributes.codegen.target_feature.s390x]
+#### `s390x`
+
+On this platform the usage of `#[target_feature]` functions follows the [above restrictions][attributes.codegen.target_feature.safety-restrictions].
+
+Further documentation on these features can be found in the "Additions to z/Architecture" section of Chapter 1 of the [Principles of Operation].
+
+Feature                                | Implicitly Enables                    | Description
+---------------------------------------|---------------------------------------|---------------------
+`vector`                               |                                       | 128-bit vector instructions
+`vector-enhancements-1`                | `vector`                              | vector enhancements 1
+`vector-enhancements-2`                | `vector-enhancements-1`               | vector enhancements 2
+`vector-enhancements-3`                | `vector-enhancements-2`               | vector enhancements 3
+`vector-packed-decimal`                | `vector`                              | vector packed-decimal
+`vector-packed-decimal-enhancement`    | `vector-packed-decimal`               | vector packed-decimal enhancement
+`vector-packed-decimal-enhancement-2`  | `vector-packed-decimal-enhancement-2` | vector packed-decimal enhancement 2
+`vector-packed-decimal-enhancement-3`  | `vector-packed-decimal-enhancement-3` | vector packed-decimal enhancement 3
+`nnp-assist`                           | `vector`                              | nnp assist
+`miscellaneous-extensions-2`           |                                       | miscellaneous extensions 2
+`miscellaneous-extensions-3`           |                                       | miscellaneous extensions 3
+`miscellaneous-extensions-4`           |                                       | miscellaneous extensions 4
+
+[Principles of Operation]: https://publibfp.dhe.ibm.com/epubs/pdf/a227832d.pdf
+
 r[attributes.codegen.target_feature.info]
 ### Additional information
 
@@ -516,8 +540,7 @@ that this option is not affected by the `target_feature` attribute, and is
 only driven by the features enabled for the entire crate.
 
 r[attributes.codegen.target_feature.remark-rt]
-See the [`is_x86_feature_detected`] or [`is_aarch64_feature_detected`] macros
-in the standard library for runtime feature detection on these platforms.
+Whether a feature is enabled can be checked at runtime using a platform-specific macro from the standard library, for instance [`is_x86_feature_detected`] or [`is_aarch64_feature_detected`].
 
 > [!NOTE]
 > `rustc` has a default set of features enabled for each target and CPU. The CPU may be chosen with the [`-C target-cpu`] flag. Individual features may be enabled or disabled for an entire crate with the [`-C target-feature`] flag.


### PR DESCRIPTION
updating the reference to account for stabilization of these features https://github.com/rust-lang/rust/pull/145656.

I'm not aware of any easily linkable per-feature documentation, though I've asked around whether anything that would fit this format exists. 

@rustbot label +S-waiting-on-stabilization