### PR TITLE
Pluralize "syntax diagrams"

### DIFF
--- a/theme/reference.js
+++ b/theme/reference.js
@@ -66,9 +66,9 @@ function update_railroad() {
     const buttons = document.querySelectorAll('.grammar-toggle-railroad');
     buttons.forEach(button => {
         if (grammarRailroad) {
-            button.innerText = "Hide syntax diagram";
+            button.innerText = "Hide syntax diagrams";
         } else {
-            button.innerText = "Show syntax diagram";
+            button.innerText = "Show syntax diagrams";
         }
     });
 }


### PR DESCRIPTION
These buttons show/hide multiple diagrams (all diagrams in the book, really), so it makes sense it probably should be plural.

Closes https://github.com/rust-lang/reference/issues/1842