### PR TITLE
clean up and properly test temporary lifetime extension in doctests

### DIFF
--- a/src/destructors.md
+++ b/src/destructors.md
@@ -448,15 +448,18 @@ Here are some examples where expressions have extended temporary scopes:
 
 ```rust
 # fn temp() {}
-# trait Use { fn use_temp(&self) -> &Self { self } }
-# impl Use for () {}
 // The temporary that stores the result of `temp()` lives in the same scope
 // as x in these cases.
 let x = &temp();
+# x;
 let x = &temp() as &dyn Send;
+# x;
 let x = (&*&temp(),);
+# x;
 let x = { [Some(&temp()) ] };
+# x;
 let ref x = temp();
+# x;
 let ref x = *&temp();
 # x;
 ```
@@ -471,6 +474,7 @@ Here are some examples where expressions don't have extended temporary scopes:
 // end of the let statement in these cases.
 
 let x = std::convert::identity(&temp()); // ERROR
+# x;
 let x = (&temp()).use_temp();  // ERROR
 # x;
 ```


### PR DESCRIPTION
- Removes an unused trait and impl from the successful tests.
- Adds a use following each assignment to test lifetime extension. Previously all but the last assignment were shadowed before use, so the temporary lifetimes were untested.