### PR TITLE
Specify lifetime extension of `match` arms and `if` consequent/`else` block tail expressions

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -47,7 +47,7 @@ See <https://rust-lang.github.io/mdBook/format/theme/syntax-highlighting.html#su
 
 Rust examples are tested via rustdoc, and should include the appropriate annotations:
 
-* `edition2015` or `edition2018` --- If it is edition-specific (see `book.toml` for the default).
+* `edition2015`, `edition2018`, etc. --- If it is edition-specific (see `book.toml` for the default).
 * `no_run` --- The example should compile successfully, but should not be executed.
 * `should_panic` --- The example should compile and run, but produce a panic.
 * `compile_fail` --- The example is expected to fail to compile.

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -54,6 +54,8 @@ Rust examples are tested via rustdoc, and should include the appropriate annotat
 * `ignore` --- The example shouldn't be built or tested. This should be avoided if possible. Usually this is only necessary when the testing framework does not support it (such as external crates or modules, or a proc-macro), or it contains pseudo-code which is not valid Rust. An HTML comment such as `<!-- ignore: requires extern crate -->` should be placed before the example to explain why it is ignored.
 * `Exxxx` --- If the example is expected to fail to compile with a specific error code, include that code so that rustdoc will check that the expected code is used.
 
+When demonstrating success cases, many such cases may be included in a single code block. For failure cases, however, each example must appear in a separate code block so that the tests can ensure that each case indeed fails and fails with the appropriate error code or codes.
+
 See the [rustdoc documentation] for more detail.
 
 [rustdoc documentation]: https://doc.rust-lang.org/rustdoc/documentation-tests.html

--- a/src/destructors.md
+++ b/src/destructors.md
@@ -435,6 +435,8 @@ expression which is one of the following:
   expression.
 * The arguments to an extending [tuple struct] or [tuple variant] constructor expression.
 * The final expression of any extending [block expression].
+* The arm(s) of an extending [`match`] expression.
+* The final expressions of an extending [`if`] expression's consequent, `else if`, and `else` blocks.
 
 So the borrow expressions in `&mut 0`, `(&1, &mut 2)`, and `Some(&mut 3)`
 are all extending expressions. The borrows in `&0 + &1` and `f(&mut 0)` are not.
@@ -458,6 +460,10 @@ let x = (&*&temp(),);
 # x;
 let x = { [Some(&temp()) ] };
 # x;
+let x = match () { _ => &temp() };
+# x;
+let x = if true { &temp() } else { &temp() };
+# x;
 let ref x = temp();
 # x;
 let ref x = *&temp();
@@ -476,6 +482,8 @@ Here are some examples where expressions don't have extended temporary scopes:
 let x = std::convert::identity(&temp()); // ERROR
 # x;
 let x = (&temp()).use_temp();  // ERROR
+# x;
+let x = match &temp() { x => x }; // ERROR
 # x;
 ```
 

--- a/src/destructors.md
+++ b/src/destructors.md
@@ -444,6 +444,11 @@ are all extending expressions. The borrows in `&0 + &1` and `f(&mut 0)` are not.
 The operand of any extending borrow expression has its temporary scope
 extended.
 
+> [!NOTE]
+> `rustc` does not treat [array repeat operands] of extending [array] expressions as extending expressions. Whether it should is an open question.
+>
+> For details, see [Rust issue #146092](https://github.com/rust-lang/rust/issues/146092).
+
 #### Examples
 
 Here are some examples where expressions have extended temporary scopes:
@@ -594,6 +599,7 @@ There is one additional case to be aware of: when a panic reaches a [non-unwindi
 [tuple variant]: type.enum.declaration
 
 [array expression]: expressions/array-expr.md#array-expressions
+[array repeat operands]: expr.array.repeat-operand
 [async block expression]: expr.block.async
 [block expression]: expressions/block-expr.md
 [borrow expression]: expressions/operator-expr.md#borrow-operators


### PR DESCRIPTION
This is present in the compiler [here](https://github.com/rust-lang/rust/blob/5ab69249f36678c0a770a08d3d1b28a8103349ff/compiler/rustc_hir_analysis/src/check/region.rs#L605-L606), but was not yet present in the Reference.

Based on https://github.com/rust-lang/reference/pull/1979; the first commit is the commit from that PR.