### PR TITLE
Enable folding of chapter listing in navigation sidebar

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -10,6 +10,10 @@ git-repository-url = "https://github.com/rust-lang/reference/"
 edit-url-template = "https://github.com/rust-lang/reference/edit/master/{path}"
 smart-punctuation = true
 
+[output.html.fold]
+enable = true
+level = 0
+
 [output.html.search.chapter]
 "test-summary.md" = { enable = false }
 "grammar.md" = { enable = false }


### PR DESCRIPTION
We have many chapters and subchapters.  Listing all of the subchapters in the navigation sidebar by default can make it difficult to see the high level structure of the Reference and can inhibit rapid navigation based on that hierarchical structure.

Fortunately, mdbook has an option to fold the chapter listing.  This causes only the top-level chapters to be shown by default while giving the user the ability to unfold individual chapters.  Let's turn on that option.

cc @ehuss