### PR TITLE
Link out to the notation from grammar summary

### DIFF
--- a/src/grammar.md
+++ b/src/grammar.md
@@ -1,5 +1,7 @@
 # Grammar summary
 
-The following is a summary of the grammar production rules.
+The following is a summary of the [grammar production rules].
 
 {{ grammar-summary }}
+
+[grammar production rules]: notation.md

--- a/src/grammar.md
+++ b/src/grammar.md
@@ -1,7 +1,5 @@
 # Grammar summary
 
-The following is a summary of the [grammar production rules].
+The following is a summary of the grammar production rules. For details on the syntax of this grammar, see *[notation.grammar.syntax]*.
 
 {{ grammar-summary }}
-
-[grammar production rules]: notation.md

--- a/src/input-format.md
+++ b/src/input-format.md
@@ -1,6 +1,19 @@
 r[input]
 # Input format
 
+r[input.syntax]
+```grammar,lexer
+@root CHAR -> <a Unicode scalar value>
+
+NUL -> U+0000
+
+TAB -> U+0009
+
+LF -> U+000A
+
+CR -> U+000D
+```
+
 r[input.intro]
 This chapter describes how a source file is interpreted as a sequence of tokens.
 

--- a/src/notation.md
+++ b/src/notation.md
@@ -50,27 +50,8 @@ r[notation.grammar.visualizations]
 
 Below each grammar block is a button to toggle the display of a [syntax diagram]. A square element is a non-terminal rule, and a rounded rectangle is a terminal.
 
-[syntax diagram]: https://en.wikipedia.org/wiki/Syntax_diagram
-
-r[notation.grammar.common]
-### Common productions
-
-The following are common definitions used in the grammar.
-
-r[input.syntax]
-```grammar,lexer
-@root CHAR -> <a Unicode scalar value>
-
-NUL -> U+0000
-
-TAB -> U+0009
-
-LF -> U+000A
-
-CR -> U+000D
-```
-
 [binary operators]: expressions/operator-expr.md#arithmetic-and-logical-binary-operators
 [keywords]: keywords.md
+[syntax diagram]: https://en.wikipedia.org/wiki/Syntax_diagram
 [tokens]: tokens.md
 [unary operators]: expressions/operator-expr.md#borrow-operators

--- a/src/notation.md
+++ b/src/notation.md
@@ -1,6 +1,10 @@
+r[notation]
 # Notation
 
+r[notation.grammar]
 ## Grammar
+
+r[notation.grammar.syntax]
 
 The following notations are used by the *Lexer* and *Syntax* grammar snippets:
 
@@ -26,7 +30,8 @@ The following notations are used by the *Lexer* and *Syntax* grammar snippets:
 
 Sequences have a higher precedence than `|` alternation.
 
-## String table productions
+r[notation.grammar.string-tables]
+### String table productions
 
 Some rules in the grammar &mdash; notably [unary operators], [binary
 operators], and [keywords] &mdash; are given in a simplified form: as a listing
@@ -40,13 +45,15 @@ When such a string in `monospace` font occurs inside the grammar,
 it is an implicit reference to a single member of such a string table
 production. See [tokens] for more information.
 
-## Grammar visualizations
+r[notation.grammar.visualizations]
+### Grammar visualizations
 
 Below each grammar block is a button to toggle the display of a [syntax diagram]. A square element is a non-terminal rule, and a rounded rectangle is a terminal.
 
 [syntax diagram]: https://en.wikipedia.org/wiki/Syntax_diagram
 
-## Common productions
+r[notation.grammar.common]
+### Common productions
 
 The following are common definitions used in the grammar.
 


### PR DESCRIPTION
As a reference, users are likely to jump in at random points and it can then be hard to know where to look for information on grammars.

While it would likely be overkill to link to the notation wherever there is a grammar, the grammary summary page seems like a reasonable place to at least include a link.