### PR TITLE
Add support to grammar for single line comments

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -27,7 +27,9 @@ BACKTICK -> U+0060
 
 LF -> U+000A
 
-Production -> `@root`? Name ` ->` Expression
+Production ->
+    ( Comment LF )*
+    `@root`? Name ` ->` Expression
 
 Name -> <Alphanumeric or `_`>+
 
@@ -55,6 +57,7 @@ Expr1 ->
       Unicode
     | NonTerminal
     | Break
+    | Comment
     | Terminal
     | Charset
     | Prose
@@ -66,6 +69,8 @@ Unicode -> `U+` [`A`-`Z` `0`-`9`]4..4
 NonTerminal -> Name
 
 Break -> LF ` `+
+
+Comment -> `//` ~[LF]+
 
 Terminal -> BACKTICK ~[LF]+ BACKTICK
 
@@ -96,6 +101,7 @@ The general format is a series of productions separated by blank lines. The expr
 | Unicode | U+0060 | A single unicode character. |
 | NonTerminal | FunctionParameters | A reference to another production by name. |
 | Break | | This is used internally by the renderer to detect line breaks and indentation. |
+| Comment | // Single line comment. | A comment extending to the end of the line. |
 | Terminal | \`example\` | This is a sequence of exact characters, surrounded by backticks |
 | Charset | [ \`A\`-\`Z\` \`0\`-\`9\` \`_\` ] | A choice from a set of characters, space separated. There are three different forms. |
 | CharacterRange | [ \`A\`-\`Z\` ] | A range of characters, each character should be in backticks.

--- a/mdbook-spec/src/grammar.rs
+++ b/mdbook-spec/src/grammar.rs
@@ -22,6 +22,8 @@ pub struct Grammar {
 #[derive(Debug)]
 pub struct Production {
     name: String,
+    /// Comments and breaks that precede the production name.
+    comments: Vec<Expression>,
     /// Category is from the markdown lang string, and defines how it is
     /// grouped and organized on the summary page.
     category: String,
@@ -70,6 +72,8 @@ enum ExpressionKind {
     ///
     /// Used by the renderer to help format and structure the grammar.
     Break(usize),
+    /// `// Single line comment.`
+    Comment(String),
     /// ``[`A`-`Z` `_` LF]``
     Charset(Vec<Characters>),
     /// ``~[` ` LF]``
@@ -135,6 +139,7 @@ impl Expression {
             ExpressionKind::Terminal(_)
             | ExpressionKind::Prose(_)
             | ExpressionKind::Break(_)
+            | ExpressionKind::Comment(_)
             | ExpressionKind::Unicode(_) => {}
             ExpressionKind::Charset(set) => {
                 for ch in set {

--- a/mdbook-spec/src/grammar/render_markdown.rs
+++ b/mdbook-spec/src/grammar/render_markdown.rs
@@ -45,6 +45,9 @@ impl Production {
             .get(&self.name)
             .map(|path| path.to_string())
             .unwrap_or_else(|| format!("missing"));
+        for expr in &self.comments {
+            expr.render_markdown(cx, output);
+        }
         write!(
             output,
             "<span class=\"grammar-text grammar-production\" id=\"{id}\" \
@@ -77,6 +80,7 @@ impl Expression {
             | ExpressionKind::Terminal(_)
             | ExpressionKind::Prose(_)
             | ExpressionKind::Break(_)
+            | ExpressionKind::Comment(_)
             | ExpressionKind::Charset(_)
             | ExpressionKind::NegExpression(_)
             | ExpressionKind::Unicode(_) => &self.kind,
@@ -162,6 +166,9 @@ impl Expression {
             ExpressionKind::Break(indent) => {
                 output.push_str("\\\n");
                 output.push_str(&"&nbsp;".repeat(*indent));
+            }
+            ExpressionKind::Comment(s) => {
+                write!(output, "<span class=\"grammar-comment\">// {s}</span>").unwrap();
             }
             ExpressionKind::Charset(set) => charset_render_markdown(cx, set, output),
             ExpressionKind::NegExpression(e) => {

--- a/src/notation.md
+++ b/src/notation.md
@@ -27,6 +27,7 @@ The following notations are used by the *Lexer* and *Syntax* grammar snippets:
 | U+xxxx            | U+0060                        | A single unicode character                |
 | \<text\>          | \<any ASCII char except CR\>  | An English description of what should be matched |
 | Rule <sub>suffix</sub> | IDENTIFIER_OR_KEYWORD <sub>_except `crate`_</sub> | A modification to the previous rule |
+| // Comment. | // Single line comment. | A comment extending to the end of the line. |
 
 Sequences have a higher precedence than `|` alternation.
 

--- a/theme/reference.css
+++ b/theme/reference.css
@@ -441,11 +441,11 @@ main > .rule {
 
     main > .rule > a.rule-link::before {
         content: "[*]";
-    } 
-    
+    }
+
     .test-link > a::before {
         content: "[T]";
-    } 
+    }
 }
 
 /* Align rules to various siblings */

--- a/theme/reference.css
+++ b/theme/reference.css
@@ -1,5 +1,54 @@
 /* Custom CSS for the Rust Specification. */
 
+/* Per-theme variables. */
+:root {
+    --railroad-background-color: hsl(30, 20%, 95%);
+    --railroad-background-image:
+        linear-gradient(to right, rgba(30, 30, 30, .05) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(30, 30, 30, .05) 1px, transparent 1px);
+    --railroad-path-stroke: black;
+    --railroad-rect-stroke: black;
+    --railroad-rect-fill: hsl(-290, 70%, 90%);
+}
+.light {
+    --alert-note-color: #0969da;
+    --alert-warning-color: #9a6700;
+    --alert-edition-color: #1a7f37;
+    --alert-example-color: #8250df;
+    --gramar-literal-bg: #fafafa;
+}
+.rust {
+    --alert-note-color: #023b95;
+    --alert-warning-color: #603700;
+    --alert-edition-color: #008200;
+    --alert-example-color: #8250df;
+    --grammar-literal-bg: #dedede;
+}
+.coal, .navy {
+    --alert-note-color: #4493f8;
+    --alert-warning-color: #d29922;
+    --alert-edition-color: #3fb950;
+    --alert-example-color: #ab7df8;
+    --grammar-literal-bg: #1d1f21;
+}
+.ayu {
+    --alert-note-color: #74b9ff;
+    --alert-warning-color: #f0b72f;
+    --alert-edition-color: #2bd853;
+    --alert-example-color: #d3abff;
+    --gramar-literal-bg: #191f26;
+}
+.coal, .navy, .ayu {
+    --railroad-background-color: hsl(230, 10%, 20%);
+    --railroad-background-image:
+        linear-gradient(to right, rgba(150, 150, 150, .05) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(150, 150, 150, .05) 1px, transparent 1px);
+    --railroad-path-stroke: hsl(200, 10%, 60%);
+    --railroad-text-fill: hsl(230, 30%, 80%);
+    --railroad-rect-stroke: hsl(200, 10%, 50%);
+    --railroad-rect-fill: hsl(230, 20%, 20%);
+}
+
 /*
 .parenthetical class used to keep e.g. "less-than symbol (<)" from wrapping
 the end parenthesis onto its own line. Use in a span between the last word and
@@ -58,31 +107,6 @@ See mdbook-spec/src/admonitions.rs.
     margin-right: 8px;
 }
 
-.light .alert {
-    --alert-note-color: #0969da;
-    --alert-warning-color: #9a6700;
-    --alert-edition-color: #1a7f37;
-    --alert-example-color: #8250df;
-}
-.ayu .alert {
-    --alert-note-color: #74b9ff;
-    --alert-warning-color: #f0b72f;
-    --alert-edition-color: #2bd853;
-    --alert-example-color: #d3abff;
-}
-.rust .alert {
-    --alert-note-color: #023b95;
-    --alert-warning-color: #603700;
-    --alert-edition-color: #008200;
-    --alert-example-color: #8250df;
-}
-.coal .alert,
-.navy .alert {
-    --alert-note-color: #4493f8;
-    --alert-warning-color: #d29922;
-    --alert-edition-color: #3fb950;
-    --alert-example-color: #ab7df8;
-}
 .alert-note blockquote {
     border-inline-start-color: var(--alert-note-color);
 }
@@ -596,20 +620,8 @@ main > .rule {
     color: var(--inline-code-color);
 }
 
-.light .grammar-literal {
-    background-color: #fafafa;
-}
-.rust .grammar-literal {
-    background-color: #dedede;
-}
-.coal .grammar-literal {
-    background-color: #1d1f21;
-}
-.navy .grammar-literal {
-    background-color: #1d1f21;
-}
-.ayu .grammar-literal {
-    background-color: #191f26;
+.grammar-literal {
+    background-color: var(--grammar-literal-bg);
 }
 
 .grammar-production:target, .railroad-production:target {
@@ -651,25 +663,6 @@ main > .rule {
 /* This is used to toggle the hidden status of the railroad diagrams. */
 .grammar-hidden {
     display: none;
-}
-
-:root {
-    --railroad-background-color: hsl(30, 20%, 95%);
-    --railroad-background-image: linear-gradient(to right, rgba(30, 30, 30, .05) 1px, transparent 1px),
-        linear-gradient(to bottom, rgba(30, 30, 30, .05) 1px, transparent 1px);
-    --railroad-path-stroke: black;
-    --railroad-rect-stroke: black;
-    --railroad-rect-fill: hsl(-290, 70%, 90%);
-}
-
-.coal, .navy, .ayu {
-    --railroad-background-color: hsl(230, 10%, 20%);
-    --railroad-background-image: linear-gradient(to right, rgba(150, 150, 150, .05) 1px, transparent 1px),
-        linear-gradient(to bottom, rgba(150, 150, 150, .05) 1px, transparent 1px);
-    --railroad-path-stroke: hsl(200, 10%, 60%);
-    --railroad-text-fill: hsl(230, 30%, 80%);
-    --railroad-rect-stroke: hsl(200, 10%, 50%);
-    --railroad-rect-fill: hsl(230, 20%, 20%);
 }
 
 svg.railroad {

--- a/theme/reference.css
+++ b/theme/reference.css
@@ -24,6 +24,10 @@
     --alert-example-color: #8250df;
     --grammar-literal-bg: #dedede;
 }
+.light, .rust {
+    --grammar-comment-color: lch(from var(--quote-bg) calc(l - 50) 0 0);
+    --inline-code-color: var(--grammar-comment-color);
+}
 .coal, .navy {
     --alert-note-color: #4493f8;
     --alert-warning-color: #d29922;
@@ -39,6 +43,8 @@
     --gramar-literal-bg: #191f26;
 }
 .coal, .navy, .ayu {
+    --grammar-comment-color: lch(from var(--quote-bg) calc(l + 50) 0 0);
+    --inline-code-color: var(--grammar-comment-color);
     --railroad-background-color: hsl(230, 10%, 20%);
     --railroad-background-image:
         linear-gradient(to right, rgba(150, 150, 150, .05) 1px, transparent 1px),
@@ -607,6 +613,15 @@ main > .rule {
 /* English words inside the grammar. */
 .grammar-text {
     font-family: "Open Sans", sans-serif;
+}
+
+/* Comments inside the grammar. */
+.grammar-comment {
+    font-family: "Open Sans", sans-serif;
+    color: var(--grammar-comment-color);
+}
+.grammar-comment code.hljs {
+    background: var(--grammar-literal-bg);
 }
 
 /* Places a box around literals to differentiate from other grammar punctuation like | and ( . */

--- a/theme/reference.css
+++ b/theme/reference.css
@@ -470,7 +470,7 @@ main > .rule {
         2.5em * var(--h2-em-mult) - 16px
         /* half of the font size difference */
         + (1em * var(--h2-em-mult) - 1em) / 2
-    )
+    );
 }
 .rule:has(+ h3, + .tests-popup + h3) {
     /* multiplying by this turns h3's em into .rule's em*/
@@ -484,7 +484,7 @@ main > .rule {
         2.5em * var(--h3-em-mult) - 16px
         /* half of the font size difference */
         + (1em * var(--h3-em-mult) - 1em) / 2
-    )
+    );
 }
 
 .rule:has(+ h4, + .tests-popup + h4) {
@@ -499,7 +499,7 @@ main > .rule {
         2em * var(--h4-em-mult) - 16px
         /* half of the font size difference */
         + (1em * var(--h4-em-mult) - 1em) / 2
-    )
+    );
 }
 
 .rule:has(+ h5, + .tests-popup + h5) {
@@ -514,7 +514,7 @@ main > .rule {
         2em * var(--h5-em-mult) - 16px
         /* half of the font size difference */
         + (1em * var(--h5-em-mult) - 1em) / 2
-    )
+    );
 }
 
 .rule:has(+ h6, + .tests-popup + h6) {
@@ -529,7 +529,7 @@ main > .rule {
         2em * var(--h6-em-mult) - 16px
         /* half of the font size difference */
         + (1em * var(--h6-em-mult) - 1em) / 2
-    )
+    );
 }
 
 /* Sets the color for [!HISTORY] blockquote admonitions. */
@@ -597,10 +597,10 @@ main > .rule {
 }
 
 .light .grammar-literal {
-    background-color: #fafafa
+    background-color: #fafafa;
 }
 .rust .grammar-literal {
-    background-color: #dedede
+    background-color: #dedede;
 }
 .coal .grammar-literal {
     background-color: #1d1f21;
@@ -609,7 +609,7 @@ main > .rule {
     background-color: #1d1f21;
 }
 .ayu .grammar-literal {
-    background-color: #191f26
+    background-color: #191f26;
 }
 
 .grammar-production:target, .railroad-production:target {


### PR DESCRIPTION
Sometimes it would be useful in the grammar to be able to add comments inline.  Let's allow this.

We'll treat these comments as expressions and add special handling to allow these on lines ahead of the production name.

For now we'll render these only in the Markdown and not in the railroad diagrams.

---

This is best reviewed commit by commit.

cc @ehuss