### PR TITLE
RISC-V: Add vector state registers

### DIFF
--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -1343,7 +1343,7 @@ r[asm.rules.preserved-registers]
     - Floating-point status (`FPSR` register).
   - RISC-V
     - Floating-point exception flags in `fcsr` (`fflags`).
-    - Vector extension state (`vtype`, `vl`, `vcsr`).
+    - Vector extension state (`vtype`, `vl`, `vxsat`, and `vxrm`).
   - LoongArch
     - Floating-point condition flags in `$fcc[0-7]`.
   - s390x


### PR DESCRIPTION
`vxsat` (vector fixed-point saturation flag) and `vxrm` (vector fixed-point rounding mode) are subset, readable/writable mirrors of the `vcsr` register.  Still, adding them to the default preserved register list will improve clarity.

*   `vcsr`
    *   Bit 0–0 mirror: `vxsat`
    *   Bit 1–2 mirror: `vxrm`

Note that, the reason `vxrm` (rounding mode register which normally the developer writes) is in the list is, it is not preserved across calls on all ratified ABIs.

Quoting `asm.rules.preserves_flags`,
> As a general rule, the flags covered by `preserves_flags` are those which are not preserved when performing a function call.