### PR TITLE
Clarify `use $crate` restriction

### DIFF
--- a/src/items/use-declarations.md
+++ b/src/items/use-declarations.md
@@ -375,7 +375,18 @@ r[items.use.restrictions.duplicate-name]
 * As with any item definition, `use` imports cannot create duplicate bindings of the same name in the same namespace in a module or block.
 
 r[items.use.restrictions.macro-crate]
-* `use` paths with `$crate` are not allowed in a [`macro_rules`] expansion.
+* `use $crate` is not allowed in a [`macro_rules`] expansion.
+
+  ```rust,compile_fail
+  macro_rules! example {
+      () => {
+          use $crate;  // ERROR: `$crate` may not be imported
+          use $crate as foo; // ERROR: `$crate` may not be imported
+      };
+  }
+
+  example!{}
+  ```
 
 r[items.use.restrictions.variant]
 * `use` paths cannot refer to enum variants through a [type alias]. For example:


### PR DESCRIPTION
The previous wording for this restriction was pretty confusing to me. I don't remember what I was thinking when I wrote it, and I can't find any historical explanation either. `use` paths can use `$crate` as long as they have more than one segment (`use $crate::foo` is obviously OK).

I have rewritten this to make it clear it is specifically about `use $crate`. One could say that restriction is already covered by the previous point that says `use crate;` requires an `as`, but for some reason `use $crate as foo` doesn't work either. So I have left this as a separate rule for now.

cc https://github.com/rust-lang/rust/pull/146972#discussion_r2376951695 for context.