### PR TITLE
Add triagebot range-diff feature

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -9,6 +9,9 @@ allow-unauthenticated = [
 
 [no-mentions]
 
+# When rebasing, this will add a diff link in a comment.
+[range-diff]
+
 [issue-links]
 check-commits = false
 


### PR DESCRIPTION
This adds a comment on a PR when the author rebases to have a link to a better diff.