### PR TITLE
use "tuple enum variant" more consistently

### DIFF
--- a/src/attributes/type_system.md
+++ b/src/attributes/type_system.md
@@ -131,13 +131,8 @@ let message = Message::Quit;
 r[attributes.type-system.non_exhaustive.match]
 There are limitations when matching on non-exhaustive types outside of the defining crate:
 
-- When pattern matching on a non-exhaustive variant ([`struct`][struct] or [`enum` variant][enum]),
-  a [StructPattern] must be used which must include a `..`. A tuple enum variant's constructor's
-  [visibility] is reduced to be no greater than `pub(crate)`.
-- When pattern matching on a non-exhaustive [`enum`][enum], matching on a variant does not
-  contribute towards the exhaustiveness of the arms.
-
-The following examples of matching do not compile when outside the defining crate:
+- When pattern matching on a non-exhaustive variant ([`struct`][struct] or [`enum` variant][enum]), a [StructPattern] must be used which must include a `..`. A tuple enum variant's constructor's [visibility] is reduced to be no greater than `pub(crate)`.
+- When pattern matching on a non-exhaustive [`enum`][enum], matching on a variant does not contribute towards the exhaustiveness of the arms. The following examples of matching do not compile when outside the defining crate:
 
 <!-- ignore: requires external crates -->
 ```rust, ignore

--- a/src/attributes/type_system.md
+++ b/src/attributes/type_system.md
@@ -124,7 +124,7 @@ let message = Message::Send { from: 0, to: 1, contents: "foo".to_string(), };
 let message = Message::Reaction(0);
 
 // Cannot construct an instance of `Message::Quit`; if this were converted to
-// a tuple-variant `upstream` then this would fail to compile.
+// a tuple enum variant `upstream`, this would fail to compile.
 let message = Message::Quit;
 ```
 
@@ -132,7 +132,7 @@ r[attributes.type-system.non_exhaustive.match]
 There are limitations when matching on non-exhaustive types outside of the defining crate:
 
 - When pattern matching on a non-exhaustive variant ([`struct`][struct] or [`enum` variant][enum]),
-  a [StructPattern] must be used which must include a `..`. A tuple variant's constructor's
+  a [StructPattern] must be used which must include a `..`. A tuple enum variant's constructor's
   [visibility] is reduced to be no greater than `pub(crate)`.
 - When pattern matching on a non-exhaustive [`enum`][enum], matching on a variant does not
   contribute towards the exhaustiveness of the arms.

--- a/src/destructors.md
+++ b/src/destructors.md
@@ -483,7 +483,7 @@ expression which is one of the following:
 * The operand(s) of an extending [array][array expression], [cast][cast
   expression], [braced struct][struct expression], or [tuple][tuple expression]
   expression.
-* The arguments to an extending [tuple struct] or [tuple variant] constructor expression.
+* The arguments to an extending [tuple struct] or [tuple enum variant] constructor expression.
 * The final expression of an extending [block expression] except for an [async block expression].
 * The final expression of an extending [`if`] expression's consequent, `else if`, or `else` block.
 * An arm expression of an extending [`match`] expression.
@@ -675,7 +675,7 @@ There is one additional case to be aware of: when a panic reaches a [non-unwindi
 [tuple pattern]: patterns.md#tuple-patterns
 [tuple struct pattern]: patterns.md#tuple-struct-patterns
 [tuple struct]: type.struct.tuple
-[tuple variant]: type.enum.declaration
+[tuple enum variant]: type.enum.declaration
 
 [array expression]: expressions/array-expr.md#array-expressions
 [array repeat operands]: expr.array.repeat-operand

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -280,7 +280,7 @@ r[items.fn.const]
 ## Const functions
 
 r[items.fn.const.intro]
-Functions qualified with the `const` keyword are [const functions], as are [tuple struct] and [tuple variant] constructors. _Const functions_  can be called from within [const contexts].
+Functions qualified with the `const` keyword are [const functions], as are [tuple struct] and [tuple enum variant] constructors. _Const functions_  can be called from within [const contexts].
 
 r[items.fn.const.extern]
 Const functions may use the [`extern`] function qualifier.
@@ -468,7 +468,7 @@ fn foo_oof(#[some_inert_attribute] arg: u8) {
 [const contexts]: ../const_eval.md#const-context
 [const functions]: ../const_eval.md#const-functions
 [tuple struct]: structs.md
-[tuple variant]: enumerations.md
+[tuple enum variant]: enumerations.md
 [`extern`]: #extern-function-qualifier
 [external block]: external-blocks.md
 [path]: ../paths.md

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -629,7 +629,7 @@ TUPLE_INDEX -> DEC_LITERAL | BIN_LITERAL | OCT_LITERAL | HEX_LITERAL
 
 r[lex.token.literal.int.tuple-field.intro]
 A tuple index is used to refer to the fields of [tuples], [tuple structs], and
-[tuple variants].
+[tuple enum variants].
 
 r[lex.token.literal.int.tuple-field.eq]
 Tuple indices are compared with the literal token directly. Tuple indices
@@ -1074,7 +1074,7 @@ r[lex.token.reserved-guards.edition2024]
 [trait bounds]: trait-bounds.md
 [tuple index]: expressions/tuple-expr.md#tuple-indexing-expressions
 [tuple structs]: items/structs.md
-[tuple variants]: items/enumerations.md
+[tuple enum variants]: items/enumerations.md
 [tuples]: types/tuple.md
 [unary minus operator]: expressions/operator-expr.md#negation-operators
 [use declarations]: items/use-declarations.md

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -628,8 +628,7 @@ TUPLE_INDEX -> DEC_LITERAL | BIN_LITERAL | OCT_LITERAL | HEX_LITERAL
 ```
 
 r[lex.token.literal.int.tuple-field.intro]
-A tuple index is used to refer to the fields of [tuples], [tuple structs], and
-[tuple enum variants].
+A tuple index is used to refer to the fields of [tuples], [tuple structs], and [tuple enum variants].
 
 r[lex.token.literal.int.tuple-field.eq]
 Tuple indices are compared with the literal token directly. Tuple indices


### PR DESCRIPTION
spent too long looking for the meaning of "tuple variant", so this should hopefully help others avoid that