### PR TITLE
Fix field-less `repr(C)` enum docs

### DIFF
--- a/src/items/enumerations.md
+++ b/src/items/enumerations.md
@@ -117,6 +117,9 @@ Each enum instance has a _discriminant_: an integer logically associated to it t
 r[items.enum.discriminant.type]
 Enums without a [primitive representation] have discriminants of type `isize`. However, the compiler may use a smaller type (or another means of distinguishing variants) in the actual memory layout.
 
+r[items.enum.discriminant.type-primitive]
+Enums with a [primitive representation] have discriminants of the type named by the representation. This also applies to enums that combine the `C` representation with a primitive representation (see [layout.repr.primitive-c]). For example, an enum with a `u8` representation can only have discriminant values between 0 and 255 inclusive.
+
 ### Assigning discriminant values
 
 r[items.enum.discriminant.explicit]

--- a/src/items/enumerations.md
+++ b/src/items/enumerations.md
@@ -115,7 +115,7 @@ r[items.enum.discriminant.intro]
 Each enum instance has a _discriminant_: an integer logically associated to it that is used to determine which variant it holds.
 
 r[items.enum.discriminant.type]
-Enums without a [primitive representation] have discriminants of type `isize`. However, the compiler may use a smaller type (or another means of distinguishing variants) in the actual memory layout.
+Enums without a [primitive representation] have discriminants of type `isize`. However, the compiler may use a smaller type or another means of distinguishing variants in the actual memory layout.
 
 ```rust
 # use core::mem::size_of;

--- a/src/items/enumerations.md
+++ b/src/items/enumerations.md
@@ -117,8 +117,38 @@ Each enum instance has a _discriminant_: an integer logically associated to it t
 r[items.enum.discriminant.type]
 Enums without a [primitive representation] have discriminants of type `isize`. However, the compiler may use a smaller type (or another means of distinguishing variants) in the actual memory layout.
 
+```rust
+# use core::mem::size_of;
+enum E {
+    V1 = 0isize, // OK: `isize` is the discriminant type.
+    V2,
+}
+
+assert!(size_of::<E>() <= size_of::<isize>());
+```
+
+```rust,compile_fail,E0308
+enum E {
+    V = 0u8, // ERROR: Expected `isize`, found `u8`.
+}
+```
+
 r[items.enum.discriminant.type-primitive]
-Enums with a [primitive representation] have discriminants of the type named by the representation. This also applies to enums that combine the `C` representation with a primitive representation (see [layout.repr.primitive-c]). For example, an enum with a `u8` representation can only have discriminant values between 0 and 255 inclusive.
+Enums with a [primitive representation] have discriminants of the type named by the representation. This also applies to enums that combine the `C` representation with a primitive representation (see [layout.repr.primitive-c]).
+
+```rust
+#[repr(u8)]
+enum E {
+    V = 0u8, // OK: `u8` is the discriminant type.
+}
+```
+
+```rust,compile_fail,E0308
+#[repr(u8)]
+enum E {
+    V = 0isize, // ERROR: Expected `u8`, found `isize`.
+}
+```
 
 ### Assigning discriminant values
 

--- a/src/items/enumerations.md
+++ b/src/items/enumerations.md
@@ -114,8 +114,8 @@ r[items.enum.discriminant]
 r[items.enum.discriminant.intro]
 Each enum instance has a _discriminant_: an integer logically associated to it that is used to determine which variant it holds.
 
-r[items.enum.discriminant.repr-rust]
-Under the [`Rust` representation], the discriminant is interpreted as an `isize` value. However, the compiler is allowed to use a smaller type (or another means of distinguishing variants) in its actual memory layout.
+r[items.enum.discriminant.type]
+Enums without a [primitive representation] have discriminants of type `isize`. However, the compiler may use a smaller type (or another means of distinguishing variants) in the actual memory layout.
 
 ### Assigning discriminant values
 
@@ -357,7 +357,6 @@ enum E {
 [numeric cast]: ../expressions/operator-expr.md#semantics
 [path expression]: ../expressions/path-expr.md
 [primitive representation]: ../type-layout.md#primitive-representations
-[`Rust` representation]: ../type-layout.md#the-rust-representation
 [struct expression]: ../expressions/struct-expr.md
 [struct]: structs.md
 [type namespace]: ../names/namespaces.md

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -282,10 +282,12 @@ assert_eq!(std::mem::align_of::<SizeRoundedUp>(), 4); // From a
 r[layout.repr.c.enum]
 #### `#[repr(C)]` Field-less Enums
 
-For [field-less enums], the `C` representation has the size and alignment of the default `enum` size and alignment for the target platform's C ABI.
+For [field-less enums], the `C` representation requires the discriminant values to be representable by the `int` type in the target platform's C ABI. Nevertheless, the type of the discriminant is `isize`. The size and alignment of the enum then match that of a C enum with the same discriminant values (and without a fixed underlying type).
 
 > [!NOTE]
 > The enum representation in C is implementation defined, so this is really a "best guess". In particular, this may be incorrect when the C code of interest is compiled with certain flags.
+>
+> For maximum portability, it is always preferred to set the size and alignment explicitly using a [primitive representation](#r-layout.repr.primitive.enum) on the Rust side, and a fixed underlying type on the C side.
 
 > [!WARNING]
 > There are crucial differences between an `enum` in the C language and Rust's [field-less enums] with this representation. An `enum` in C is mostly a `typedef` plus some named constants; in other words, an object of an `enum` type can hold any integer value. For example, this is often used for bitflags in `C`. In contrast, Rust’s [field-less enums] can only legally hold the discriminant values, everything else is [undefined behavior]. Therefore, using a field-less enum in FFI to model a C `enum` is often wrong.
@@ -366,7 +368,7 @@ Primitive representations can only be applied to enumerations and have different
 r[layout.repr.primitive.enum]
 #### Primitive representation of field-less enums
 
-For [field-less enums], primitive representations set the size and alignment to be the same as the primitive type of the same name. For example, a field-less enum with a `u8` representation can only have discriminants between 0 and 255 inclusive.
+For [field-less enums], primitive representations set the type of the discriminants to the primitive type of the same name. Furthermore, the enum's size and alignment are guaranteed to match that type. For example, a field-less enum with a `u8` representation has discriminants of type `u8` and hence can only have discriminants between 0 and 255 inclusive.
 
 r[layout.repr.primitive.adt]
 #### Primitive representation of enums with fields

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -282,7 +282,7 @@ assert_eq!(std::mem::align_of::<SizeRoundedUp>(), 4); // From a
 r[layout.repr.c.enum]
 #### `#[repr(C)]` Field-less Enums
 
-For [field-less enums], the `C` representation requires the discriminant values to either all be representable by the `int` type in the target platform's C ABI, or to all be representable by the `unsigned int` type. Nevertheless, the type of the discriminant is `isize`. The size and alignment of the enum then match that of a C enum with the same discriminant values (and without a fixed underlying type).
+For [field-less enums], the `C` representation requires the discriminant values to either all be representable by the `int` type in the target platform's C ABI, or to all be representable by the `unsigned int` type. Nevertheless, the type of the discriminant is `isize`. The size and alignment of the enum then match that of a C enum with the same discriminant values (and without a fixed underlying type). Crucially, the equivalent C type is determined based on the discriminant values *after* they have been cast to `isize`.
 
 > [!NOTE]
 > The enum representation in C is implementation defined, so this is really a "best guess". In particular, this may be incorrect when the C code of interest is compiled with certain flags.

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -282,7 +282,7 @@ assert_eq!(std::mem::align_of::<SizeRoundedUp>(), 4); // From a
 r[layout.repr.c.enum]
 #### `#[repr(C)]` Field-less Enums
 
-For [field-less enums], the `C` representation requires the discriminant values to be representable by the `int` type in the target platform's C ABI. Nevertheless, the type of the discriminant is `isize`. The size and alignment of the enum then match that of a C enum with the same discriminant values (and without a fixed underlying type).
+For [field-less enums], the `C` representation requires the discriminant values to either all be representable by the `int` type in the target platform's C ABI, or to all be representable by the `unsigned int` type. Nevertheless, the type of the discriminant is `isize`. The size and alignment of the enum then match that of a C enum with the same discriminant values (and without a fixed underlying type).
 
 > [!NOTE]
 > The enum representation in C is implementation defined, so this is really a "best guess". In particular, this may be incorrect when the C code of interest is compiled with certain flags.

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -382,7 +382,7 @@ A [field-less enum] with the `C` representation has the same size and alignment 
 > [!NOTE]
 > The enum representation in C is implementation defined, so this is really a "best guess". In particular, this may be incorrect when the C code of interest is compiled with certain flags.
 >
-> For maximum portability, it is always preferred to set the size and alignment explicitly using a [primitive representation](#r-layout.repr.primitive.enum) on the Rust side, and a fixed underlying type on the C side.
+> For maximum portability, it is always preferred to set the size and alignment explicitly using a [primitive representation] on the Rust side, and a fixed underlying type on the C side.
 
 > [!WARNING]
 > There are crucial differences between an `enum` in the C language and Rust's [field-less enums] with this representation. An `enum` in C is mostly a `typedef` plus some named constants; in other words, an object of an `enum` type can hold any integer value. For example, this is often used for bitflags in `C`. In contrast, Rust’s [field-less enums] can only legally hold the discriminant values, everything else is [undefined behavior]. Therefore, using a field-less enum in FFI to model a C `enum` is often wrong.

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -367,7 +367,14 @@ assert_eq!(std::mem::offset_of!(SizeRoundedUp, b), 0);
 r[layout.repr.c.enum]
 #### `#[repr(C)]` Field-less Enums
 
-For [field-less enums], the `C` representation requires the discriminant values to either all be representable by the `int` type in the target platform's C ABI, or to all be representable by the `unsigned int` type. Nevertheless, the type of the discriminant is `isize`. The size and alignment of the enum then match that of a C enum with the same discriminant values (and without a fixed underlying type). Crucially, the equivalent C type is determined based on the discriminant values *after* they have been cast to `isize`.
+r[layout.repr.c.enum.discriminant]
+For a [field-less enum] with the `C` representation, the discriminant values must either all be representable by the `int` type in the target platform's C ABI or all be representable by its `unsigned int` type.
+
+> [!NOTE]
+> `repr(C)` enums without a primitive representation have discriminant values of type `isize`. See [items.enum.discriminant.type]. The size and alignment are determined from the discriminant values (according to the rule below) *after* they have been cast to `isize`.
+
+r[layout.repr.c.enum.size-align]
+A [field-less enum] with the `C` representation has the same size and alignment as a C enum with the same discriminant values and no fixed underlying type.
 
 > [!NOTE]
 > The enum representation in C is implementation defined, so this is really a "best guess". In particular, this may be incorrect when the C code of interest is compiled with certain flags.
@@ -643,6 +650,7 @@ Because this representation delegates type layout to another type, it cannot be 
 [`Copy`]: std::marker::Copy
 [dynamically sized types]: dynamically-sized-types.md
 [enums]: items/enumerations.md
+[field-less enum]: items.enum.fieldless
 [field-less enums]: items/enumerations.md#field-less-enum
 [field-struct-like variant]: EnumVariantStruct
 [fn-abi-compatibility]: ../core/primitive.fn.md#abi-compatibility

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -367,7 +367,7 @@ assert_eq!(std::mem::offset_of!(SizeRoundedUp, b), 0);
 r[layout.repr.c.enum]
 #### `#[repr(C)]` Field-less Enums
 
-For [field-less enums], the `C` representation requires the discriminant values to either all be representable by the `int` type in the target platform's C ABI, or to all be representable by the `unsigned int` type. Nevertheless, the type of the discriminant is `isize`. The size and alignment of the enum then match that of a C enum with the same discriminant values (and without a fixed underlying type).
+For [field-less enums], the `C` representation requires the discriminant values to either all be representable by the `int` type in the target platform's C ABI, or to all be representable by the `unsigned int` type. Nevertheless, the type of the discriminant is `isize`. The size and alignment of the enum then match that of a C enum with the same discriminant values (and without a fixed underlying type). Crucially, the equivalent C type is determined based on the discriminant values *after* they have been cast to `isize`.
 
 > [!NOTE]
 > The enum representation in C is implementation defined, so this is really a "best guess". In particular, this may be incorrect when the C code of interest is compiled with certain flags.

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -382,7 +382,7 @@ A [field-less enum] with the `C` representation has the same size and alignment 
 > [!NOTE]
 > The enum representation in C is implementation defined, so this is really a "best guess". In particular, this may be incorrect when the C code of interest is compiled with certain flags.
 >
-> For maximum portability, prefer setting the size and alignment explicitly using a [primitive representation] on the Rust side and a fixed underlying type on the C side.
+> For maximum portability, prefer setting the size and alignment explicitly using a [primitive representation] on the Rust side and a fixed underlying type (introduced in C23) on the C side.
 
 > [!WARNING]
 > There are crucial differences between an `enum` in the C language and Rust's [field-less enums] with this representation. An `enum` in C is mostly a `typedef` plus some named constants; in other words, an object of an `enum` type can hold any integer value. For example, this is often used for bitflags in `C`. In contrast, Rust’s [field-less enums] can only legally hold the discriminant values, everything else is [undefined behavior]. Therefore, using a field-less enum in FFI to model a C `enum` is often wrong.

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -192,6 +192,35 @@ r[layout.repr.rust.enum-empty-zst]
 r[layout.repr.rust.enum-struct-like-zst]
 For [enums] (without a [primitive representation] specified) with a single [field-struct-like variant], a single [unit-struct-like variant], or a single [tuple-struct-like variant] and where the struct-like thing has no fields or where all of the fields are [zero sized], the enums themselves are [zero sized].
 
+```rust
+# use core::mem::size_of;
+enum E1 {
+    V {},
+}
+
+enum E2 {
+    V { f: () },
+}
+
+enum E3 {
+    V,
+}
+
+enum E4 {
+    V(),
+}
+
+enum E5 {
+    V(()),
+}
+
+assert_eq!(size_of::<E1>(), 0);
+assert_eq!(size_of::<E2>(), 0);
+assert_eq!(size_of::<E3>(), 0);
+assert_eq!(size_of::<E4>(), 0);
+assert_eq!(size_of::<E5>(), 0);
+```
+
 r[layout.repr.rust.unspecified]
 There are no other guarantees of data layout made by this representation.
 
@@ -378,6 +407,22 @@ For a [field-less enum] with the `C` representation, the discriminant values mus
 
 r[layout.repr.c.enum.size-align]
 A [field-less enum] with the `C` representation has the same size and alignment as a C enum with the same discriminant values and no fixed underlying type.
+
+```rust
+# use core::ffi::c_int;
+# use core::mem::{align_of, size_of};
+#[repr(C)]
+enum E {
+    V1,
+    V2,
+}
+
+#[cfg(target_arch = "x86_64")]
+{
+    assert_eq!(size_of::<E>(), size_of::<c_int>());
+    assert_eq!(align_of::<E>(), align_of::<c_int>());
+}
+```
 
 > [!NOTE]
 > The enum representation in C is implementation defined, so this is really a "best guess". In particular, this may be incorrect when the C code of interest is compiled with certain flags.

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -382,7 +382,7 @@ A [field-less enum] with the `C` representation has the same size and alignment 
 > [!NOTE]
 > The enum representation in C is implementation defined, so this is really a "best guess". In particular, this may be incorrect when the C code of interest is compiled with certain flags.
 >
-> For maximum portability, it is always preferred to set the size and alignment explicitly using a [primitive representation] on the Rust side, and a fixed underlying type on the C side.
+> For maximum portability, prefer setting the size and alignment explicitly using a [primitive representation] on the Rust side and a fixed underlying type on the C side.
 
 > [!WARNING]
 > There are crucial differences between an `enum` in the C language and Rust's [field-less enums] with this representation. An `enum` in C is mostly a `typedef` plus some named constants; in other words, an object of an `enum` type can hold any integer value. For example, this is often used for bitflags in `C`. In contrast, Rust’s [field-less enums] can only legally hold the discriminant values, everything else is [undefined behavior]. Therefore, using a field-less enum in FFI to model a C `enum` is often wrong.

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -367,10 +367,12 @@ assert_eq!(std::mem::offset_of!(SizeRoundedUp, b), 0);
 r[layout.repr.c.enum]
 #### `#[repr(C)]` Field-less Enums
 
-For [field-less enums], the `C` representation has the size and alignment of the default `enum` size and alignment for the target platform's C ABI.
+For [field-less enums], the `C` representation requires the discriminant values to be representable by the `int` type in the target platform's C ABI. Nevertheless, the type of the discriminant is `isize`. The size and alignment of the enum then match that of a C enum with the same discriminant values (and without a fixed underlying type).
 
 > [!NOTE]
 > The enum representation in C is implementation defined, so this is really a "best guess". In particular, this may be incorrect when the C code of interest is compiled with certain flags.
+>
+> For maximum portability, it is always preferred to set the size and alignment explicitly using a [primitive representation](#r-layout.repr.primitive.enum) on the Rust side, and a fixed underlying type on the C side.
 
 > [!WARNING]
 > There are crucial differences between an `enum` in the C language and Rust's [field-less enums] with this representation. An `enum` in C is mostly a `typedef` plus some named constants; in other words, an object of an `enum` type can hold any integer value. For example, this is often used for bitflags in `C`. In contrast, Rust’s [field-less enums] can only legally hold the discriminant values, everything else is [undefined behavior]. Therefore, using a field-less enum in FFI to model a C `enum` is often wrong.
@@ -451,7 +453,7 @@ Primitive representations can only be applied to enumerations and have different
 r[layout.repr.primitive.enum]
 #### Primitive representation of field-less enums
 
-For [field-less enums], primitive representations set the size and alignment to be the same as the primitive type of the same name. For example, a field-less enum with a `u8` representation can only have discriminants between 0 and 255 inclusive.
+For [field-less enums], primitive representations set the type of the discriminants to the primitive type of the same name. Furthermore, the enum's size and alignment are guaranteed to match that type. For example, a field-less enum with a `u8` representation has discriminants of type `u8` and hence can only have discriminants between 0 and 255 inclusive.
 
 r[layout.repr.primitive.adt]
 #### Primitive representation of enums with fields

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -367,7 +367,7 @@ assert_eq!(std::mem::offset_of!(SizeRoundedUp, b), 0);
 r[layout.repr.c.enum]
 #### `#[repr(C)]` Field-less Enums
 
-For [field-less enums], the `C` representation requires the discriminant values to be representable by the `int` type in the target platform's C ABI. Nevertheless, the type of the discriminant is `isize`. The size and alignment of the enum then match that of a C enum with the same discriminant values (and without a fixed underlying type).
+For [field-less enums], the `C` representation requires the discriminant values to either all be representable by the `int` type in the target platform's C ABI, or to all be representable by the `unsigned int` type. Nevertheless, the type of the discriminant is `isize`. The size and alignment of the enum then match that of a C enum with the same discriminant values (and without a fixed underlying type).
 
 > [!NOTE]
 > The enum representation in C is implementation defined, so this is really a "best guess". In particular, this may be incorrect when the C code of interest is compiled with certain flags.

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -373,6 +373,9 @@ For a [field-less enum] with the `C` representation, the discriminant values mus
 > [!NOTE]
 > `repr(C)` enums without a primitive representation have discriminant values of type `isize`. See [items.enum.discriminant.type]. The size and alignment are determined from the discriminant values (according to the rule below) *after* they have been cast to `isize`.
 
+> [!NOTE]
+> `rustc` accepts enums whose discriminant values do not meet this requirement but lints against them. This will become an error in the future.
+
 r[layout.repr.c.enum.size-align]
 A [field-less enum] with the `C` representation has the same size and alignment as a C enum with the same discriminant values and no fixed underlying type.
 

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -463,7 +463,10 @@ Primitive representations can only be applied to enumerations and have different
 r[layout.repr.primitive.enum]
 #### Primitive representation of field-less enums
 
-For [field-less enums], primitive representations set the type of the discriminants to the primitive type of the same name. Furthermore, the enum's size and alignment are guaranteed to match that type. For example, a field-less enum with a `u8` representation has discriminants of type `u8` and hence can only have discriminants between 0 and 255 inclusive.
+A [field-less enum] with a primitive representation has the same size and alignment as the primitive type of the same name.
+
+> [!NOTE]
+> Enums with a primitive representation have discriminant values of the type named by the representation. See [items.enum.discriminant.type-primitive].
 
 r[layout.repr.primitive.adt]
 #### Primitive representation of enums with fields


### PR DESCRIPTION
The docs for field-less repr(C) enums are wrong in the sense that they say "the `C` representation has the size and alignment of the default `enum` size and alignment for the target platform's C ABI" which implies that there's a single size and alignment (determined by the target) that all repr(C) enums share -- which isn't true. The size of the enum depends on the discriminant values and is intended to mimic what the default C compiler for the target would do with an enum that has the same discriminant values.

Also, it seems worth mentioning the type that the discriminant expressions of an enum are type-checked at: that's `isize` for all enums expect those with primitive representation.

This PR presupposes that we are going ahead with https://github.com/rust-lang/rust/pull/147017 and documents things as-if the FCW added there was already a hard error. This is mostly because otherwise it's unclear what we should document as the logic before that bug doesn't always match the target's C compiler (see https://github.com/rust-lang/rust/pull/146504).