### PR TITLE
Consistently use sentence case

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ we welcome PRs to fix them. Additionally, larger editing jobs that help remove
 the number of parentheticals, remove comma splices, italicize term definitions
 and other similar tasks are helpful.
 
-## Adding Examples and Glossary Entries
+## Adding examples and glossary entries
 
 Examples are great. Many people will only read examples and ignore the prose.
 Ideally, every facet of every feature will have an example.
@@ -41,7 +41,7 @@ Likewise, the reference has a glossary. It doesn't need to explain every facet
 of every feature nor contain every definition, but it does need to be expanded
 upon. Ideally entries in the glossary link to the associated documentation.
 
-## Adding Documentation
+## Adding documentation
 
 There are a lot of features that are not documented at all or are documented
 poorly. This is the hardest, but definitely most valuable. Pick an unassigned

--- a/docs/review-policy.md
+++ b/docs/review-policy.md
@@ -17,7 +17,7 @@ Team members are given permission to merge changes from other contributors in th
 - Minor changes to the tooling may be made with a review from a team member. This includes bug fixes, minor additions that are unlikely to have objections, and additions that have already been discussed.
 - Major changes, such as a change in how content is authored, or major changes to how the tooling works should be approved by the team without blocking objections.
 
-## Review Process Flowchart
+## Review process flowchart
 
 When reviewing a pull request, ask yourself the following questions:
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -13,8 +13,8 @@
     - [Tokens](tokens.md)
 
 - [Macros](macros.md)
-    - [Macros By Example](macros-by-example.md)
-    - [Procedural Macros](procedural-macros.md)
+    - [Macros by example](macros-by-example.md)
+    - [Procedural macros](procedural-macros.md)
 
 - [Crates and source files](crates-and-source-files.md)
 
@@ -35,7 +35,7 @@
     - [Implementations](items/implementations.md)
     - [External blocks](items/external-blocks.md)
     - [Generic parameters](items/generics.md)
-    - [Associated Items](items/associated-items.md)
+    - [Associated items](items/associated-items.md)
 
 - [Attributes](attributes.md)
     - [Testing](attributes/testing.md)
@@ -43,7 +43,7 @@
     - [Diagnostics](attributes/diagnostics.md)
     - [Code generation](attributes/codegen.md)
     - [Limits](attributes/limits.md)
-    - [Type System](attributes/type_system.md)
+    - [Type system](attributes/type_system.md)
     - [Debugger](attributes/debugger.md)
 
 - [Statements and expressions](statements-and-expressions.md)
@@ -91,10 +91,10 @@
         - [Impl trait type](types/impl-trait.md)
         - [Type parameters](types/parameters.md)
         - [Inferred type](types/inferred.md)
-    - [Dynamically Sized Types](dynamically-sized-types.md)
+    - [Dynamically sized types](dynamically-sized-types.md)
     - [Type layout](type-layout.md)
     - [Interior mutability](interior-mutability.md)
-    - [Subtyping and Variance](subtyping.md)
+    - [Subtyping and variance](subtyping.md)
     - [Trait and lifetime bounds](trait-bounds.md)
     - [Type coercions](type-coercions.md)
     - [Destructors](destructors.md)
@@ -125,15 +125,15 @@
     - [Behavior considered undefined](behavior-considered-undefined.md)
     - [Behavior not considered unsafe](behavior-not-considered-unsafe.md)
 
-- [Constant Evaluation](const_eval.md)
+- [Constant evaluation](const_eval.md)
 
-- [Application Binary Interface](abi.md)
+- [Application binary interface](abi.md)
 
 - [The Rust runtime](runtime.md)
 
 - [Appendices](appendices.md)
     - [Grammar summary](grammar.md)
-    - [Macro Follow-Set Ambiguity Formal Specification](macro-ambiguity.md)
+    - [Macro follow-set ambiguity formal specification](macro-ambiguity.md)
     - [Influences](influences.md)
     - [Test summary](test-summary.md)
     - [Glossary](glossary.md)

--- a/src/abi.md
+++ b/src/abi.md
@@ -1,5 +1,5 @@
 r[abi]
-# Application Binary Interface (ABI)
+# Application binary interface (ABI)
 
 r[abi.intro]
 This section documents features that affect the ABI of the compiled output of

--- a/src/attributes.md
+++ b/src/attributes.md
@@ -107,7 +107,7 @@ fn some_unused_variables() {
 ```
 
 r[attributes.meta]
-## Meta Item Attribute Syntax
+## Meta item attribute syntax
 
 r[attributes.meta.intro]
 A "meta item" is the syntax used for the [Attr] rule by most [built-in

--- a/src/attributes/diagnostics.md
+++ b/src/attributes/diagnostics.md
@@ -102,7 +102,7 @@ pub mod m3 {
 > `rustc` allows setting lint levels on the [command-line][rustc-lint-cli], and also supports [setting caps][rustc-lint-caps] on the lints that are reported.
 
 r[attributes.diagnostics.lint.reason]
-### Lint Reasons
+### Lint reasons
 
 All lint attributes support an additional `reason` parameter, to give context why
 a certain attribute was added. This reason will be displayed as part of the lint

--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -71,7 +71,7 @@ r[cfg.option-key-uniqueness]
 Keys do not need to be unique. For example, both `feature = "std"` and `feature = "serde"` can be set at the same time.
 
 r[cfg.options.set]
-## Set Configuration Options
+## Set configuration options
 
 r[cfg.options.general]
 Which configuration options are set is determined statically during the

--- a/src/crates-and-source-files.md
+++ b/src/crates-and-source-files.md
@@ -75,7 +75,7 @@ apply to the crate as a whole.
 ```
 
 r[crate.main]
-## Main Functions
+## Main functions
 
 r[crate.main.general]
 A crate that contains a `main` [function] can be compiled to an executable.

--- a/src/dynamically-sized-types.md
+++ b/src/dynamically-sized-types.md
@@ -1,5 +1,5 @@
 r[dynamic-sized]
-# Dynamically Sized Types
+# Dynamically sized types
 
 r[dynamic-sized.intro]
 Most types have a fixed size that is known at compile time and implement the trait [`Sized`][sized]. A type with a size that is known only at run-time is called a _dynamically sized type_ (_DST_) or, informally, an unsized type.  [Slices], [trait objects], and [str] are examples of <abbr title="dynamically sized types">DSTs</abbr>.

--- a/src/expressions.md
+++ b/src/expressions.md
@@ -147,7 +147,7 @@ assert_eq!(
 > Since this is applied recursively, these expressions are also evaluated from innermost to outermost, ignoring siblings until there are no inner subexpressions.
 
 r[expr.place-value]
-## Place Expressions and Value Expressions
+## Place expressions and value expressions
 
 r[expr.place-value.intro]
 Expressions are divided into two main categories: place expressions and value expressions;
@@ -334,7 +334,7 @@ x; // OK
 ```
 
 r[expr.implicit-borrow]
-### Implicit Borrows
+### Implicit borrows
 
 r[expr.implicit-borrow-intro]
 Certain expressions will treat an expression as a place expression by implicitly borrowing it.
@@ -366,13 +366,13 @@ Implicit borrows may be taken in the following expressions:
 * Arguments to [`format_args!`] except the format string.
 
 r[expr.overload]
-## Overloading Traits
+## Overloading traits
 
 Many of the following operators and expressions can also be overloaded for other types using traits in `std::ops` or `std::cmp`.
 These traits also exist in `core::ops` and `core::cmp` with the same names.
 
 r[expr.attr]
-## Expression Attributes
+## Expression attributes
 
 r[expr.attr.restriction]
 [Outer attributes] before an expression are allowed only in a few specific cases:

--- a/src/expressions/call-expr.md
+++ b/src/expressions/call-expr.md
@@ -35,7 +35,7 @@ let name: &'static str = (|| "Rust")();
 ```
 
 r[expr.call.desugar]
-## Disambiguating Function Calls
+## Disambiguating function calls
 
 r[expr.call.desugar.fully-qualified]
 All function calls are sugar for a more explicit [fully-qualified syntax].

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -345,7 +345,7 @@ assert_eq!(true, !false);
 ```
 
 r[expr.arith-logic]
-## Arithmetic and Logical Binary Operators
+## Arithmetic and logical binary operators
 
 r[expr.arith-logic.syntax]
 ```grammar,expressions
@@ -408,7 +408,7 @@ assert_eq!(-10 >> 2, -3);
 ```
 
 r[expr.cmp]
-## Comparison Operators
+## Comparison operators
 
 r[expr.cmp.syntax]
 ```grammar,expressions

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -1522,7 +1522,7 @@ extern "sysv64-unwind" fn may_panic() {
 > - [ImperialViolet - CFI directives in assembly files](https://www.imperialviolet.org/2017/01/18/cfi.html)
 
 r[asm.validity]
-### Correctness and Validity
+### Correctness and validity
 
 r[asm.validity.necessary-but-not-sufficient]
 In addition to all of the previous rules, the string argument to `asm!` must ultimately become---
@@ -1548,7 +1548,7 @@ Programmers should exercise appropriate care, as invoking this `unsafe` capabili
 assuming the responsibility of not violating rules of both the compiler or the architecture.
 
 r[asm.directives]
-### Directives Support
+### Directives support
 
 r[asm.directives.subset-supported]
 Inline assembly supports a subset of the directives supported by both GNU AS and LLVM's internal assembler, given as follows.
@@ -1630,10 +1630,10 @@ assert_eq!(s, "Hello World!");
 ```
 
 r[asm.target-specific-directives]
-#### Target Specific Directive Support
+#### Target specific directive support
 
 r[asm.target-specific-directives.dwarf-unwinding]
-##### Dwarf Unwinding
+##### Dwarf unwinding
 
 The following directives are supported on ELF targets that support DWARF unwind info:
 
@@ -1660,7 +1660,7 @@ The following directives are supported on ELF targets that support DWARF unwind 
 - `.cfi_window_save`
 
 r[asm.target-specific-directives.structured-exception-handling]
-##### Structured Exception Handling
+##### Structured exception handling
 
 On targets with structured exception Handling, the following additional directives are guaranteed to be supported:
 

--- a/src/interior-mutability.md
+++ b/src/interior-mutability.md
@@ -1,5 +1,5 @@
 r[interior-mut]
-# Interior Mutability
+# Interior mutability
 
 r[interior-mut.intro]
 Sometimes a type needs to be mutated while having multiple aliases. In Rust this

--- a/src/items/associated-items.md
+++ b/src/items/associated-items.md
@@ -1,5 +1,5 @@
 r[items.associated]
-# Associated Items
+# Associated items
 
 r[items.associated.syntax]
 ```grammar,items
@@ -223,7 +223,7 @@ Attributes on method parameters follow the same rules and restrictions as
 [regular function parameters].
 
 r[items.associated.type]
-## Associated Types
+## Associated types
 
 r[items.associated.type.intro]
 *Associated types* are [type aliases] associated with another type.
@@ -347,7 +347,7 @@ fn main() {
 }
 ```
 
-### Associated Types Container Example
+### Associated types container example
 
 Consider the following example of a `Container` trait. Notice that the type is
 available for use in the method signatures:
@@ -461,7 +461,7 @@ trait StaticReturn {
 ```
 
 r[items.associated.const]
-## Associated Constants
+## Associated constants
 
 r[items.associated.const.intro]
 *Associated constants* are [constants] associated with a type.
@@ -512,7 +512,7 @@ fn main() {
 }
 ```
 
-### Associated Constants Examples
+### Associated constants examples
 
 A basic example:
 

--- a/src/items/constant-items.md
+++ b/src/items/constant-items.md
@@ -83,7 +83,7 @@ r[items.const.expr-omission]
 The constant expression may only be omitted in a [trait definition].
 
 r[items.const.destructor]
-## Constants with Destructors
+## Constants with destructors
 
 Constants can contain destructors. Destructors are run when the value goes out
 of scope.

--- a/src/items/extern-crates.md
+++ b/src/items/extern-crates.md
@@ -61,7 +61,7 @@ extern crate hello_world; // hyphen replaced with an underscore
 ```
 
 r[items.extern-crate.underscore]
-## Underscore Imports
+## Underscore imports
 
 r[items.extern-crate.underscore.intro]
 An external crate dependency can be declared without binding its name in scope

--- a/src/items/implementations.md
+++ b/src/items/implementations.md
@@ -33,7 +33,7 @@ There are two types of implementations:
 - [trait] implementations
 
 r[items.impl.inherent]
-## Inherent Implementations
+## Inherent implementations
 
 r[items.impl.inherent.intro]
 An inherent implementation is defined as the sequence of the `impl` keyword,
@@ -98,7 +98,7 @@ fn main() {
 ```
 
 r[items.impl.trait]
-## Trait Implementations
+## Trait implementations
 
 r[items.impl.trait.intro]
 A _trait implementation_ is defined like an inherent implementation except that
@@ -158,7 +158,7 @@ impl Shape for Circle {
 ```
 
 r[items.impl.trait.coherence]
-### Trait Implementation Coherence
+### Trait implementation coherence
 
 r[items.impl.trait.coherence.intro]
 A trait implementation is considered incoherent if either the orphan rules check fails
@@ -200,7 +200,7 @@ special. The `T` in `Box<T>` is not considered covered, and `Box<LocalType>`
 is considered local.
 
 r[items.impl.generics]
-## Generic Implementations
+## Generic implementations
 
 r[items.impl.generics.intro]
 An implementation can take [generic parameters], which can be used in the rest
@@ -299,7 +299,7 @@ impl<'a> HasAssocType for Struct {
 ```
 
 r[items.impl.attributes]
-## Attributes on Implementations
+## Attributes on implementations
 
 Implementations may contain outer [attributes] before the `impl` keyword and
 inner [attributes] inside the brackets that contain the associated items. Inner

--- a/src/items/modules.md
+++ b/src/items/modules.md
@@ -56,7 +56,7 @@ the syntax and make use of the `unsafe` keyword, before removing it from the
 token stream.
 
 r[items.mod.outlined]
-## Module Source Filenames
+## Module source filenames
 
 r[items.mod.outlined.intro]
 A module without a body is loaded from an external file. When the module does
@@ -147,7 +147,7 @@ mod thread {
 ```
 
 r[items.mod.attributes]
-## Attributes on Modules
+## Attributes on modules
 
 r[items.mod.attributes.intro]
 Modules, like all items, accept outer attributes. They also accept inner

--- a/src/items/static-items.md
+++ b/src/items/static-items.md
@@ -151,7 +151,7 @@ Mutable statics have the same restrictions as normal statics, except that the
 type does not have to implement the `Sync` trait.
 
 r[items.static.alternate]
-## Using Statics or Consts
+## Using statics or consts
 
 It can be confusing whether or not you should use a constant item or a static
 item. Constants should, in general, be preferred over statics unless one of the

--- a/src/items/use-declarations.md
+++ b/src/items/use-declarations.md
@@ -313,7 +313,7 @@ r[items.use.glob.edition2018]
 > In the 2015 edition, paths are relative to the crate root, so an import such as `use *;` is valid, and it means to import everything from the crate root. This cannot be used in the crate root itself.
 
 r[items.use.as-underscore]
-## Underscore Imports
+## Underscore imports
 
 r[items.use.as-underscore.intro]
 Items can be imported without binding to a name by using an underscore with

--- a/src/macro-ambiguity.md
+++ b/src/macro-ambiguity.md
@@ -1,12 +1,12 @@
 r[macro.ambiguity]
-# Appendix: Macro Follow-Set Ambiguity Formal Specification
+# Appendix: Macro follow-set ambiguity formal specification
 
 This page documents the formal specification of the follow rules for [Macros
 By Example]. They were originally specified in [RFC 550], from which the bulk
 of this text is copied, and expanded upon in subsequent RFCs.
 
 r[macro.ambiguity.convention]
-## Definitions & Conventions
+## Definitions & conventions
 
 r[macro.ambiguity.convention.defs]
   - `macro`: anything invocable as `foo!(...)` in source code.
@@ -108,7 +108,7 @@ purposes of the formalism, we will treat `$v:vis` as actually being
 `$($v:vis)?`, with a requirement that the matcher match an empty fragment.
 
 r[macro.ambiguity.invariant]
-### The Matcher Invariants
+### The matcher invariants
 
 r[macro.ambiguity.invariant.list]
 To be valid, a matcher must meet the following three invariants. The definitions

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -1,5 +1,5 @@
 r[macro.decl]
-# Macros By Example
+# Macros by example
 
 r[macro.decl.syntax]
 ```grammar,macros
@@ -221,7 +221,7 @@ compiler knows how to expand them properly:
     repetitions.
 
 r[macro.decl.scope]
-## Scoping, Exporting, and Importing
+## Scoping, exporting, and importing
 
 r[macro.decl.scope.intro]
 For historical reasons, the scoping of macros by example does not work entirely
@@ -250,7 +250,7 @@ self::lazy_static!{} // Path-based lookup ignores our macro, finds imported one.
 ```
 
 r[macro.decl.scope.textual]
-### Textual Scope
+### Textual scope
 
 r[macro.decl.scope.textual.intro]
 Textual scope is based largely on the order that things appear in source files,
@@ -369,7 +369,7 @@ Macros to be imported with `#[macro_use]` must be exported with
 `#[macro_export]`, which is described below.
 
 r[macro.decl.scope.path]
-### Path-Based Scope
+### Path-based scope
 
 r[macro.decl.scope.path.intro]
 By default, a macro has no path-based scope. However, if it has the
@@ -523,7 +523,7 @@ macro_rules! helper {
 ```
 
 r[macro.decl.follow-set]
-## Follow-set Ambiguity Restrictions
+## Follow-set ambiguity restrictions
 
 r[macro.decl.follow-set.intro]
 The parser used by the macro system is reasonably powerful, but it is limited in

--- a/src/macros.md
+++ b/src/macros.md
@@ -13,7 +13,7 @@ There are two ways to define new macros:
   attributes using functions that operate on input tokens.
 
 r[macro.invocation]
-## Macro Invocation
+## Macro invocation
 
 r[macro.invocation.syntax]
 ```grammar,macros

--- a/src/paths.md
+++ b/src/paths.md
@@ -16,7 +16,7 @@ x::y::z;
 ## Types of paths
 
 r[paths.simple]
-### Simple Paths
+### Simple paths
 
 r[paths.simple.syntax]
 ```grammar,paths

--- a/src/procedural-macros.md
+++ b/src/procedural-macros.md
@@ -1,5 +1,5 @@
 r[macro.proc]
-# Procedural Macros
+# Procedural macros
 
 r[macro.proc.intro]
 *Procedural macros* allow creating syntax extensions as execution of a function.

--- a/src/special-types-and-traits.md
+++ b/src/special-types-and-traits.md
@@ -64,7 +64,7 @@ is considered to own a `T` for the purposes of [variance], [drop check], and
 [auto traits](#auto-traits).
 
 r[lang-types.ops]
-## Operator Traits
+## Operator traits
 
 The traits in [`std::ops`] and [`std::cmp`] are used to overload [operators],
 [indexing expressions], and [call expressions].

--- a/src/statements.md
+++ b/src/statements.md
@@ -146,7 +146,7 @@ if true {
 ```
 
 r[statement.attribute]
-## Attributes on Statements
+## Attributes on statements
 
 Statements accept [outer attributes].
 The attributes that have meaning on a statement are [`cfg`], and [the lint check attributes].

--- a/src/subtyping.md
+++ b/src/subtyping.md
@@ -1,5 +1,5 @@
 r[subtype]
-# Subtyping and Variance
+# Subtyping and variance
 
 r[subtype.intro]
 Subtyping is implicit and can occur at any stage in type checking or

--- a/src/type-coercions.md
+++ b/src/type-coercions.md
@@ -187,7 +187,7 @@ r[coerce.types.never]
 * `!` to any `T`
 
 r[coerce.unsize]
-### Unsized Coercions
+### Unsized coercions
 
 r[coerce.unsize.intro]
 The following coercions are called `unsized coercions`, since they

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -1,5 +1,5 @@
 r[layout]
-# Type Layout
+# Type layout
 
 r[layout.intro]
 The layout of a type is its size, alignment, and the relative offsets of its
@@ -15,7 +15,7 @@ across function boundaries. For function call ABI compatibility of types,
 see [here][fn-abi-compatibility].
 
 r[layout.properties]
-## Size and Alignment
+## Size and alignment
 
 All values have an alignment and size.
 
@@ -44,7 +44,7 @@ size and alignment, we refer to those shared values as the size of the type and
 the alignment of the type respectively.
 
 r[layout.primitive]
-## Primitive Data Layout
+## Primitive data layout
 
 r[layout.primitive.size]
 The size of most primitives is given in this table.
@@ -75,7 +75,7 @@ their size is 16, and on many 32-bit platforms, `i64`, `u64`, and `f64` are only
 aligned to 4 bytes, not 8.
 
 r[layout.pointer]
-## Pointers and References Layout
+## Pointers and references layout
 
 r[layout.pointer.intro]
 Pointers and references have the same layout. Mutability of the pointer or
@@ -92,14 +92,14 @@ at least equal to the size and alignment of a pointer.
 > Though you should not rely on this, all pointers to <abbr title="Dynamically Sized Types">DSTs</abbr> are currently twice the size of the size of `usize` and have the same alignment.
 
 r[layout.array]
-## Array Layout
+## Array layout
 
 An array of `[T; N]` has a size of `size_of::<T>() * N` and the same alignment
 of `T`. Arrays are laid out so that the zero-based `nth` element of the array
 is offset from the start of the array by `n * size_of::<T>()` bytes.
 
 r[layout.slice]
-## Slice Layout
+## Slice layout
 
 Slices have the same layout as the section of the array they slice.
 
@@ -112,7 +112,7 @@ r[layout.str]
 String slices are a UTF-8 representation of characters that have the same layout as slices of type `[u8]`. A reference `&str` has the same layout as a reference `&[u8]`.
 
 r[layout.tuple]
-## Tuple Layout
+## Tuple layout
 
 r[layout.tuple.general]
 Tuples are laid out according to the [`Rust` representation][`Rust`].
@@ -122,7 +122,7 @@ The exception to this is the unit tuple (`()`), which is guaranteed as a
 zero-sized type to have a size of 0 and an alignment of 1.
 
 r[layout.trait-object]
-## Trait Object Layout
+## Trait object layout
 
 Trait objects have the same layout as the value the trait object is of.
 
@@ -130,7 +130,7 @@ Trait objects have the same layout as the value the trait object is of.
 > This is about the raw trait object types, not pointers (`&dyn Trait`, `Box<dyn Trait>`, etc.) to trait objects.
 
 r[layout.closure]
-## Closure Layout
+## Closure layout
 
 Closures have no layout guarantees.
 
@@ -196,7 +196,7 @@ representation will not change the layout of `Inner`.
 
 <a id="the-default-representation"></a>
 r[layout.repr.rust]
-### The `Rust` Representation
+### The `Rust` representation
 
 r[layout.repr.rust.intro]
 The `Rust` representation is the default representation for nominal types
@@ -231,7 +231,7 @@ r[layout.repr.rust.unspecified]
 There are no other guarantees of data layout made by this representation.
 
 r[layout.repr.c]
-### The `C` Representation
+### The `C` representation
 
 r[layout.repr.c.intro]
 The `C` representation is designed for dual purposes. One purpose is for
@@ -434,7 +434,7 @@ for [zero-variant enums] to have a primitive representation. Combining
 two primitive representations together is an error.
 
 r[layout.repr.primitive.enum]
-#### Primitive Representation of Field-less Enums
+#### Primitive representation of field-less enums
 
 For [field-less enums], primitive representations set the size and alignment to
 be the same as the primitive type of the same name. For example, a field-less
@@ -442,7 +442,7 @@ enum with a `u8` representation can only have discriminants between 0 and 255
 inclusive.
 
 r[layout.repr.primitive.adt]
-#### Primitive Representation of Enums With Fields
+#### Primitive representation of enums with fields
 
 The representation of a primitive representation enum is a `repr(C)` union of
 `repr(C)` structs for each variant with a field. The first field of each struct
@@ -629,7 +629,7 @@ was wrapped in a newtype `struct` with the same `align` modifier.
 > ```
 
 r[layout.repr.transparent]
-### The `transparent` Representation
+### The `transparent` representation
 
 r[layout.repr.transparent.constraint-field]
 The `transparent` representation can only be used on a [`struct`][structs]

--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -95,7 +95,7 @@ r[type.closure.async.input]
 
 Async closures always capture all input arguments, regardless of whether or not they are used within the body.
 
-## Capture Precision
+## Capture precision
 
 r[type.closure.capture.precision.capture-path]
 A *capture path* is a sequence starting with a variable from the environment followed by zero or more place projections that were applied to that variable.
@@ -594,7 +594,7 @@ Because captures are often by reference, the following general rules arise:
 [derived]: ../attributes/derive.md
 
 r[type.closure.drop-order]
-## Drop Order
+## Drop order
 
 If a closure captures a field of a composite types such as structs, tuples, and enums by value, the field's lifetime would now be tied to the closure. As a result, it is possible for disjoint fields of a composite types to be dropped at different times.
 

--- a/src/types/pointer.md
+++ b/src/types/pointer.md
@@ -71,7 +71,7 @@ r[type.pointer.raw.constructor]
 Raw pointers can be created directly using `&raw const` for `*const` pointers and `&raw mut` for `*mut` pointers.
 
 r[type.pointer.smart]
-## Smart Pointers
+## Smart pointers
 
 The standard library contains additional 'smart pointer' types beyond references and raw pointers.
 

--- a/src/types/trait-object.md
+++ b/src/types/trait-object.md
@@ -95,7 +95,7 @@ In this example, the trait `Printable` occurs as a trait object in both the
 type signature of `print`, and the cast expression in `main`.
 
 r[type.trait-object.lifetime-bounds]
-## Trait Object Lifetime Bounds
+## Trait object lifetime bounds
 
 Since a trait object can contain references, the lifetimes of those references
 need to be expressed as part of the trait object. This lifetime is written as

--- a/src/visibility-and-privacy.md
+++ b/src/visibility-and-privacy.md
@@ -1,5 +1,5 @@
 r[vis]
-# Visibility and Privacy
+# Visibility and privacy
 
 r[vis.syntax]
 ```grammar,items
@@ -236,7 +236,7 @@ fn main() { bar() }
 > This syntax only adds another restriction to the visibility of an item. It does not guarantee that the item is visible within all parts of the specified scope. To access an item, all of its parent items up to the current scope must still be visible as well.
 
 r[vis.reexports]
-## Re-exporting and Visibility
+## Re-exporting and visibility
 
 r[vis.reexports.intro]
 Rust allows publicly re-exporting items through a `pub use` directive. Because


### PR DESCRIPTION
Part of our style guide is to use sentence case for headings. The Reference was very inconsistent with this. This updates all the headings to use sentence case.