### PR TITLE
fix(css): Correctly specify grammar-literal-bg

### DIFF
--- a/mdbook-spec/src/grammar/parser.rs
+++ b/mdbook-spec/src/grammar/parser.rs
@@ -382,7 +382,7 @@ impl Parser<'_> {
                     xs.push(x);
                     self.index += 1;
                 }
-                _ => bail!(self, "expected 4 uppercase hexidecimal digits after `U+`"),
+                _ => bail!(self, "expected 4 uppercase hexadecimal digits after `U+`"),
             }
         }
         Ok(ExpressionKind::Unicode(String::from_utf8(xs).unwrap()))

--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -150,7 +150,7 @@ r[const-eval.const-expr.borrows]
   >
   > ```rust
   > // The borrow is of a variable local to the initializer, therefore
-  > // this place expresssion is transient.
+  > // this place expression is transient.
   > const C: () = { let mut x = 0; _ = &mut x; };
   > ```
   >

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -1355,7 +1355,7 @@ r[asm.rules.x86-df]
 
 r[asm.rules.x86-x87]
 - On x86, the x87 floating-point register stack must remain unchanged unless all of the `st([0-7])` registers have been marked as clobbered with `out("st(0)") _, out("st(1)") _, ...`.
-  - If all x87 registers are clobbered then the x87 register stack is guaranteed to be empty upon entering the assembly code. Assembly code must ensure that the x87 register stack is also empty when exiting the asssembly code.
+  - If all x87 registers are clobbered then the x87 register stack is guaranteed to be empty upon entering the assembly code. Assembly code must ensure that the x87 register stack is also empty when exiting the assembly code.
 
 ```rust
 # #[cfg(target_arch = "x86_64")]

--- a/theme/reference.css
+++ b/theme/reference.css
@@ -260,7 +260,7 @@ dfn {
     padding-left: 0;
     padding-right: 0;
 }
-/* required to accomodate above, somehow... */
+/* required to accommodate above, somehow... */
 #menu-bar {
     margin-left: 0;
 }
@@ -315,7 +315,7 @@ hr {
 }
 
 /* This is quite dumb, ugh.
-   CSS doesn't allow margin colapsing between grid items and anything else
+   CSS doesn't allow margin collapsing between grid items and anything else
    (src: <https://stackoverflow.com/a/37837971>), which means that the margins
    of li's children are not collapsed with ul's margins, adding too much margins.
 

--- a/theme/reference.css
+++ b/theme/reference.css
@@ -15,7 +15,7 @@
     --alert-warning-color: #9a6700;
     --alert-edition-color: #1a7f37;
     --alert-example-color: #8250df;
-    --gramar-literal-bg: #fafafa;
+    --grammar-literal-bg: #fafafa;
 }
 .rust {
     --alert-note-color: #023b95;
@@ -40,7 +40,7 @@
     --alert-warning-color: #f0b72f;
     --alert-edition-color: #2bd853;
     --alert-example-color: #d3abff;
-    --gramar-literal-bg: #191f26;
+    --grammar-literal-bg: #191f26;
 }
 .coal, .navy, .ayu {
     --grammar-comment-color: lch(from var(--quote-bg) calc(l + 50) 0 0);


### PR DESCRIPTION
Some themes refer to `--gramar-literal-bg` rather than `--grammar-literal-bg`.

I found this when running [`typos`](https://github.com/crate-ci/typos) on the Reference out of curiosity after seeing rust-lang/rust has adopted it.  Since I was already creating a PR, I went ahead and included the other corrections.  If there is interest in adding a CI job to check this on every commit, like rust-lang/rust, I can set that up.