### PR TITLE
Clarify that "or it is dropped" is meant restrictively

### DIFF
--- a/src/destructors.md
+++ b/src/destructors.md
@@ -3,7 +3,7 @@ r[destructors]
 
 r[destructors.intro]
 When an [initialized]&#32;[variable] or [temporary] goes out of
-[scope](#drop-scopes), its *destructor* is run, or it is *dropped*. [Assignment]
+[scope](#drop-scopes), its *destructor* is run or it is *dropped*. [Assignment]
 also runs the destructor of its left-hand operand, if it's initialized. If a
 variable has been partially initialized, only its initialized fields are
 dropped.


### PR DESCRIPTION
The introduction of the *Destructors* chapter says:

> When an initialized variable or temporary goes out of scope, its *destructor* is run, or it is *dropped*.

Grammatically, the final comma there suggests that the clause "or it is dropped" is non-restrictive -- i.e., that it could be removed from the sentence without changing its meaning.  It's as though we had written:

> When an initialized variable or temporary goes out of scope, its *destructor* is run, or in other words, it is *dropped*.

That's not what we mean here currently, as discussed in [rust-lang/reference#1078], so the comma is incorrectly placed.

Note that this isn't necessarily the final step in clarifying this. There's more we should probably do.  But it is a step in the right direction, so let's take it.

[rust-lang/reference#1078]: https://github.com/rust-lang/reference/issues/1078

cc @ehuss @joshtriplett https://github.com/rust-lang/reference/issues/1078