### PR TITLE
Fix grammar of `ConstParam`

### DIFF
--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -13,7 +13,7 @@ TypeParam -> IDENTIFIER ( `:` TypeParamBounds? )? ( `=` Type )?
 
 ConstParam ->
     `const` IDENTIFIER `:` Type
-    ( `=` BlockExpression | IDENTIFIER | `-`?LiteralExpression )?
+    ( `=` ( BlockExpression | IDENTIFIER | `-`?LiteralExpression ) )?
 ```
 
 r[items.generics.syntax.intro]


### PR DESCRIPTION
The grammar for `ConstParam` in https://doc.rust-lang.org/reference/items/generics.html#grammar-ConstParam was specified as:

```grammar
ConstParam →
    'const' IDENTIFIER : Type
    ( '=' BlockExpression | IDENTIFIER | '-'? LiteralExpression )?
```

This implies that `IDENTIFIER` and `'-'? LiteralExpression` may not be preceded by `=`, but this is obviously not the case.