### PR TITLE
generalise paragraph

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -194,7 +194,7 @@ The color and styling is defined in [`theme/reference.css`](https://github.com/r
 
 ## Style
 
-Idioms and styling to avoid:
+Idioms and styling:
 
 * Use American English spelling.
 * Use Oxford commas.


### PR DESCRIPTION
"Avoid" was used because all entries before 1b57f6ca48f51a760d84df4d42b8f5927668f3c1 were about things to avoid