### PR TITLE
Follow edition formatting for keywords

### DIFF
--- a/src/keywords.md
+++ b/src/keywords.md
@@ -27,10 +27,13 @@ r[lex.keywords.strict.list]
 The following keywords are in all editions:
 
 - `as`
+- `async`
+- `await`
 - `break`
 - `const`
 - `continue`
 - `crate`
+- `dyn`
 - `else`
 - `enum`
 - `extern`
@@ -63,11 +66,12 @@ The following keywords are in all editions:
 - `while`
 
 r[lex.keywords.strict.edition2018]
-The following keywords were added beginning in the 2018 edition.
-
-- `async`
-- `await`
-- `dyn`
+> [!EDITION-2018]
+> The following keywords were added in the 2018 edition:
+>
+> - `async`
+> - `await`
+> - `dyn`
 
 r[lex.keywords.reserved]
 ## Reserved keywords
@@ -84,23 +88,23 @@ r[lex.keywords.reserved.list]
 - `box`
 - `do`
 - `final`
+- `gen`
 - `macro`
 - `override`
 - `priv`
+- `try`
 - `typeof`
 - `unsized`
 - `virtual`
 - `yield`
 
 r[lex.keywords.reserved.edition2018]
-The following keywords are reserved beginning in the 2018 edition.
-
-- `try`
+> [!EDITION-2018]
+> The `try` keyword was added as a reserved keyword in the 2018 edition.
 
 r[lex.keywords.reserved.edition2024]
-The following keywords are reserved beginning in the 2024 edition.
-
-- `gen`
+> [!EDITION-2024]
+> The `gen` keyword was added as a reserved keyword in the 2024 edition.
 
 r[lex.keywords.weak]
 ## Weak keywords


### PR DESCRIPTION
This updates the keywords chapter to follow our style guide where the main text is supposed to describe the current edition, with admonitions that describe differences to previous editions.