### PR TITLE
Clarify struct pattern binding shorthand

### DIFF
--- a/src/patterns.md
+++ b/src/patterns.md
@@ -810,7 +810,7 @@ r[patterns.struct.constraint-union]
 A struct pattern used to match a union must specify exactly one field (see [Pattern matching on unions]).
 
 r[patterns.struct.binding-shorthand]
-The `ref` and/or `mut` [IDENTIFIER] syntax matches any value and binds it to a variable with the same name as the given field.
+The [IDENTIFIER] syntax matches any value and binds it to a variable with the same name as the given field. It is a shorthand for `fieldname: fieldname`. The `ref` and `mut` qualifiers can be included with the behavior as described in [patterns.ident.ref].
 
 ```rust
 # struct Struct {
@@ -820,7 +820,7 @@ The `ref` and/or `mut` [IDENTIFIER] syntax matches any value and binds it to a v
 # }
 # let struct_value = Struct{a: 10, b: 'X', c: false};
 #
-let Struct{a: x, b: y, c: z} = struct_value;          // destructure all fields
+let Struct { a, b, c } = struct_value;
 ```
 
 r[patterns.struct.refutable]


### PR DESCRIPTION
The existing text was slightly confusing with the way it worded "ref and/or mut", and wasn't quite clear what it was referring to. I pulled that out into a separate sentence. This also adds a sentence to make it very clear that this is a shorthand.

This is somewhat a duplicate of
patterns.destructure.named-field-shorthand, but it seems fine to me to have that.

This also reworks the example. The current example didn't fit this section at all, and it's not entirely clear to me what the original intention was here. Maybe that was intended for the destructuring section? Either way, I just made this example fit this rule.