### PR TITLE
Move punctuation index to an appendix, and expand for other syntaxes

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -35,6 +35,7 @@ use-boolean-and = true
 "/items/traits.html#object-safety" = "traits.html#dyn-compatibility"
 "/lifetime-elision.html#static-lifetime-elision" = "lifetime-elision.html#const-and-static-elision"
 "/macros-by-example.html#path-based-scope" = "macros-by-example.html#the-macro_export-attribute"
+"/patterns.html#rest-patterns" = "patterns.html#rest-pattern"
 "/procedural-macros.html#attribute-macros" = "procedural-macros.html#the-proc_macro_attribute-attribute"
 "/procedural-macros.html#derive-macros" = "procedural-macros.html#the-proc_macro_derive-attribute"
 "/procedural-macros.html#function-like-procedural-macros" = "procedural-macros.html#the-proc_macro-attribute"

--- a/book.toml
+++ b/book.toml
@@ -18,8 +18,9 @@ level = 0
 use-boolean-and = true
 
 [output.html.search.chapter]
-"test-summary.md" = { enable = false }
 "grammar.md" = { enable = false }
+"syntax-index.md" = { enable = false }
+"test-summary.md" = { enable = false }
 
 [output.html.redirect]
 "/crates-and-source-files.html#preludes-and-no_std" = "names/preludes.html"

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -133,6 +133,7 @@
 
 - [Appendices](appendices.md)
     - [Grammar summary](grammar.md)
+    - [Syntax index](syntax-index.md)
     - [Macro follow-set ambiguity formal specification](macro-ambiguity.md)
     - [Influences](influences.md)
     - [Test summary](test-summary.md)

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -93,7 +93,7 @@ Destructuring breaks up a value into its component pieces.
 The syntax used is almost the same as when creating such values.
 
 r[patterns.destructure.wildcard]
-In a pattern whose [scrutinee] expression has a `struct`, `enum` or `tuple` type, a [wildcard pattern](#wildcard-pattern) (`_`) stands in for a *single* data field, whereas an [et cetera](#grammar-StructPatternEtCetera) or [rest pattern](#rest-patterns) (`..`) stands in for *all* the remaining fields of a particular variant.
+In a pattern whose [scrutinee] expression has a `struct`, `enum` or `tuple` type, a [wildcard pattern](#wildcard-pattern) (`_`) stands in for a *single* data field, whereas an [et cetera](#grammar-StructPatternEtCetera) or [rest pattern][patterns.rest] (`..`) stands in for *all* the remaining fields of a particular variant.
 
 r[patterns.destructure.named-field-shorthand]
 When destructuring a data structure with named (but not numbered) fields, it is allowed to write `fieldname` as a shorthand for `fieldname: fieldname`.
@@ -421,7 +421,7 @@ r[patterns.wildcard.refutable]
 The wildcard pattern is always irrefutable.
 
 r[patterns.rest]
-## Rest patterns
+## Rest pattern
 
 r[patterns.rest.syntax]
 ```grammar,patterns
@@ -470,7 +470,8 @@ if let [.., penultimate, _] = slice {
 }
 
 # let tuple = (1, 2, 3, 4, 5);
-// Rest patterns may also be used in tuple and tuple struct patterns.
+// The rest pattern may also be used in tuple and tuple
+// struct patterns.
 match tuple {
     (1, .., y, z) => println!("y={} z={}", y, z),
     (.., 5) => println!("tail must be 5"),
@@ -974,7 +975,7 @@ r[patterns.slice.refutable-array]
 Slice patterns are irrefutable when matching an array as long as each element is irrefutable.
 
 r[patterns.slice.refutable-slice]
-When matching a slice, it is irrefutable only in the form with a single `..` [rest pattern](#rest-patterns) or [identifier pattern](#identifier-patterns) with the `..` rest pattern as a subpattern.
+When matching a slice, it is irrefutable only in the form with a single `..` [rest pattern][patterns.rest] or [identifier pattern](#identifier-patterns) with the `..` rest pattern as a subpattern.
 
 r[patterns.slice.restriction]
 Within a slice, a range pattern without both lower and upper bound must be enclosed in parentheses, as in `(a..)`, to clarify it is intended to match against a single slice element.

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -4,6 +4,66 @@ This appendix provides an index of tokens and common forms with links to where t
 
 ## Keywords
 
+| Keyword       | Usage |
+|---------------|-------|
+| `_`           | [wildcard patterns], [inferred types], unnamed items in [constants], [extern crates], [use declarations], [destructuring assignment] |
+| `abstract`    | [reserved keyword] |
+| `as`          | [extern crate alias], [use alias], [type cast expressions], [qualified paths] |
+| `async`       | [async functions], [async blocks], [async closures] |
+| `await`       | [await expressions] |
+| `become`      | [reserved keyword] |
+| `box`         | [reserved keyword] |
+| `break`       | [break expressions] |
+| `const`       | [const functions], [const items], [const generics], [const blocks], [raw borrow operator], [raw pointer type], [const assembly operands] |
+| `continue`    | [continue expressions] |
+| `crate`       | [extern crates], [visibility], [paths] |
+| `do`          | [reserved keyword] |
+| `dyn`         | [trait objects] |
+| `else`        | [let statements], [if expressions] |
+| `enum`        | [enumerations] |
+| `extern`      | [extern crate], [extern function qualifier], [external blocks], [extern function pointer types] |
+| `false`       | [boolean type], [boolean expressions], [configuration predicates] |
+| `final`       | [reserved keyword] |
+| `fn`          | [functions], [function pointer types] |
+| `for`         | [trait implementations], [iterator loops], [higher-ranked trait bounds] |
+| `gen`         | [reserved keyword] |
+| `if`          | [if expressions], [match guards] |
+| `impl`        | [inherent impls], [trait impls], [impl traits] |
+| `in`          | [visibility], [iterator loops], [assembly operands] |
+| `let`         | [let statements], [`if let` patterns] |
+| `loop`        | [infinite loops] |
+| `macro_rules` | [macros by example] |
+| `macro`       | [reserved keyword] |
+| `match`       | [match expressions] |
+| `mod`         | [modules] |
+| `move`        | [closure expressions], [async blocks] |
+| `mut`         | [borrow expressions], [identifier patterns], [reference patterns], [struct patterns], [reference types], [raw pointer types], [self parameters], [static items] |
+| `override`    | [reserved keyword] |
+| `priv`        | [reserved keyword] |
+| `pub`         | [visibility] |
+| `raw`         | [borrow expressions], [raw assembly] |
+| `ref`         | [identifier patterns], [struct patterns] |
+| `return`      | [return expressions] |
+| `safe`        | [external block functions], [external block statics] |
+| `self`        | [extern crates][items.extern-crate.self], [self parameters], [visibility], [`self` paths] |
+| `Self`        | [`Self` type paths], [use bounds] |
+| `static`      | [static items], [`'static` lifetimes] |
+| `struct`      | [structs] |
+| `super`       | [super paths], [visibility] |
+| `trait`       | [trait items] |
+| `true`        | [boolean type], [boolean expressions], [configuration predicates] |
+| `try`         | [reserved keyword] |
+| `type`        | [type aliases] |
+| `typeof`      | [reserved keyword] |
+| `union`       | [union items] |
+| `unsafe`      | [unsafe attributes], [unsafe modules], [unsafe functions], [unsafe static items], [unsafe external blocks], [unsafe external functions], [unsafe external statics], [unsafe traits], [unsafe trait implementations] |
+| `unsized`     | [reserved keyword] |
+| `use`         | [use items], [use bounds] |
+| `virtual`     | [reserved keyword] |
+| `where`       | [where clauses] |
+| `while`       | [predicate loops] |
+| `yield`       | [reserved keyword] |
+
 ## Operators and punctuation
 
 | Symbol | Name        | Usage |
@@ -55,49 +115,124 @@ This appendix provides an index of tokens and common forms with links to where t
 | `?`    | Question    | [try propagation expressions][question], [questionably sized][sized], [macro Kleene matcher] |
 | `~`    | Tilde       | The tilde operator has been unused since before Rust 1.0, but its token may still be used. |
 
+[`'static` lifetimes]: bound
+[`if let` patterns]: expr.if.let
+[`self` paths]: paths.qualifiers.mod-self
+[`Self` type paths]: paths.qualifiers.type-self
 [arith]: expr.arith-logic
 [array types]: type.array
+[assembly operands]: asm.operand-type.supported-operands.in
 [assignment]: expr.assign
+[async blocks]: expr.block.async
+[async closures]: expr.closure.async
+[async functions]: items.fn.async
+[await expressions]: expr.await
+[boolean expressions]: expr.literal
+[boolean type]: type.bool
+[borrow expressions]: expr.operator.borrow
 [borrow]: expr.operator.borrow
+[break expressions]: expr.loop.break
+[closure expressions]: expr.closure
 [closures]: expr.closure
 [comparison]: expr.cmp
 [compound]: expr.compound-assign
+[configuration predicates]: cfg
+[const assembly operands]: asm.operand-type.supported-operands.const
+[const blocks]: expr.block.const
+[const functions]: const-eval.const-fn
+[const generics]: items.generics.const
+[const items]: items.const
 [constants]: items.const
+[continue expressions]: expr.loop.continue
 [dereference]: expr.deref
 [destructuring assignment]: expr.placeholder
+[enumerations]: items.enum
+[extern crate alias]: items.extern-crate.as
+[extern crate]: items.extern-crate
 [extern crates]: items.extern-crate
+[extern function pointer types]: type.fn-pointer.qualifiers
+[extern function qualifier]: items.fn.extern
 [extern]: items.extern
+[external block functions]: items.extern.fn
+[external block statics]: items.extern.static
+[external blocks]: items.extern
 [field]: expr.field
 [function pointer type]: type.fn-pointer
+[function pointer types]: type.fn-pointer
 [functions]: items.fn
 [generics]: items.generics
 [glob imports]: items.use.glob
+[higher-ranked trait bounds]: bound.higher-ranked
+[identifier patterns]: patterns.ident
+[if expressions]: expr.if
 [if let]: expr.if.let
+[impl traits]: type.impl-trait
 [inferred types]: type.inferred
+[infinite loops]: expr.loop.infinite
+[inherent impls]: items.impl.inherent
+[iterator loops]: expr.loop.for
+[keywords chapter]: lex.keywords
 [lazy-bool]: expr.bool-logic
 [let statements]: statement.let
 [macro calls]: macro.invocation
 [macro Kleene matcher]: macro.decl.repetition
+[macros by example]: macro.decl
 [macros]: macro.decl
+[match expressions]: expr.match
+[match guards]: expr.match.guard
 [match]: expr.match
+[modules]: items.mod
 [negation]: expr.negate
 [negative impls]: items.impl
 [never type]: type.never
 [or patterns]: patterns.or
+[predicate loops]: expr.loop.while
+[qualified paths]: paths.qualified
 [question]: expr.try
 [range patterns]: patterns.range
+[raw assembly]: asm.options.supported-options.raw
+[raw borrow operator]: expr.borrow.raw
+[raw pointer type]: type.pointer.raw
+[raw pointer types]: type.pointer.raw
 [raw pointers]: type.pointer.raw
 [reference patterns]: patterns.ref
+[reference types]: type.pointer.reference
 [references]: type.pointer.reference
+[reserved keyword]: lex.keywords.reserved
 [rest patterns]: patterns.rest
+[return expressions]: expr.return
+[self parameters]: items.fn.params.self-pat
 [sized]: bound.sized
+[static items]: items.static
 [struct expressions]: expr.struct
 [struct patterns]: patterns.struct
+[structs]: items.struct
 [subpattern binding]: patterns.ident.scrutinized
+[super paths]: paths.qualifiers.super
 [trait bounds]: bound
+[trait implementations]: items.impl.trait
+[trait impls]: items.impl.trait
+[trait items]: items.traits
+[trait objects]: type.trait-object
 [tuple index]: expr.tuple-index
+[type aliases]: items.type
+[type cast expressions]: expr.as
+[union items]: items.union
+[unsafe attributes]: attributes.safety
+[unsafe external blocks]: unsafe.extern
+[unsafe external functions]: items.extern.fn.safety
+[unsafe external statics]: items.extern.static.safety
+[unsafe functions]: unsafe.fn
+[unsafe modules]: items.mod.unsafe
+[unsafe static items]: items.static.mut.safety
+[unsafe trait implementations]: items.impl.trait.safety
+[unsafe traits]: items.traits.safety
+[use alias]: items.use.forms.as
 [use bounds]: bound.use
 [use declarations]: items.use
+[use items]: items.use
 [variadic functions]: items.extern.variadic
+[visibility]: vis
+[where clauses]: items.generics.where
 [while let]: expr.loop.while.let
 [wildcard patterns]: patterns.wildcard

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -16,7 +16,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `^`    | Caret       | [bitwise and logical XOR][arith] |
 | `!`    | Not         | [bitwise and logical NOT][negation], [macro calls][macros], [inner attributes][attributes], [never type], [negative impls] |
 | `&`    | And         | [bitwise and logical AND][arith], [borrow], [references], [reference patterns] |
-| <code>\|</code> | Or | [bitwise and logical OR][arith], [closures], patterns in [match], [if let], [while let] |
+| <code>\|</code> | Or | [bitwise and logical OR][arith], [closures], [or patterns], [if let], [while let] |
 | `&&`   | AndAnd      | [lazy AND][lazy-bool], [borrow], [references], [reference patterns] |
 | <code>\|\|</code> | OrOr | [lazy OR][lazy-bool], [closures] |
 | `<<`   | Shl         | [shift left][arith], [nested generics][generics] |
@@ -80,6 +80,7 @@ This appendix provides an index of tokens and common forms with links to where t
 [negation]: expressions/operator-expr.md#negation-operators
 [negative impls]: items/implementations.md
 [never type]: types/never.md
+[or patterns]: patterns.or
 [paths]: paths.md
 [patterns]: patterns.md
 [question]: expressions/operator-expr.md#the-try-propagation-expression

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -56,7 +56,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `type`        | [type aliases] |
 | `typeof`      | [reserved keyword] |
 | `union`       | [union items] |
-| `unsafe`      | [unsafe attributes], [unsafe modules], [unsafe functions], [unsafe static items], [unsafe external blocks], [unsafe external functions], [unsafe external statics], [unsafe traits], [unsafe trait implementations] |
+| `unsafe`      | [unsafe attributes], [unsafe modules], [unsafe functions], [unsafe external blocks], [unsafe external functions], [unsafe external statics], [unsafe traits], [unsafe trait implementations] |
 | `unsized`     | [reserved keyword] |
 | `use`         | [use items], [use bounds] |
 | `virtual`     | [reserved keyword] |
@@ -443,7 +443,6 @@ This appendix provides an index of tokens and common forms with links to where t
 [unsafe external statics]: items.extern.static.safety
 [unsafe functions]: unsafe.fn
 [unsafe modules]: items.mod.unsafe
-[unsafe static items]: items.static.mut.safety
 [unsafe trait implementations]: items.impl.trait.safety
 [unsafe traits]: items.traits.safety
 [use bounds]: bound.use

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -150,7 +150,7 @@ This appendix provides an index of tokens and common forms with links to where t
 |-------------------------------------------|-------|
 | `ident!(…)`<br>`ident!{…}`<br>`ident![…]` | [macro invocations] |
 | `$ident`                                  | [macro fragment substitution] |
-| `$ident:kind`                             | [macro fragment specifier] |
+| `$ident:kind`                             | [macro matcher fragment specifier] |
 | `$(…)…`                                   | [macro repetition] |
 
 ## Attributes
@@ -354,10 +354,10 @@ This appendix provides an index of tokens and common forms with links to where t
 [lifetimes and loop labels]: lex.token.life
 [literal patterns]: patterns.literal
 [macro calls]: macro.invocation
-[macro fragment specifier]: macro.decl.meta.specifier
 [macro fragment substitution]: macro.decl.meta.transcription
 [macro invocations]: macro.invocation
 [macro Kleene matcher]: macro.decl.repetition
+[macro matcher fragment specifier]: macro.decl.meta.specifier
 [macro repetition]: macro.decl.repetition
 [macros by example]: macro.decl
 [macros]: macro.decl

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -149,7 +149,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | Syntax                                    | Usage |
 |-------------------------------------------|-------|
 | `ident!(…)`<br>`ident!{…}`<br>`ident![…]` | [macro invocations] |
-| `$ident`                                  | [macro fragment substitution] |
+| `$ident`                                  | [macro metavariable] |
 | `$ident:kind`                             | [macro matcher fragment specifier] |
 | `$(…)…`                                   | [macro repetition] |
 
@@ -354,10 +354,10 @@ This appendix provides an index of tokens and common forms with links to where t
 [lifetimes and loop labels]: lex.token.life
 [literal patterns]: patterns.literal
 [macro calls]: macro.invocation
-[macro fragment substitution]: macro.decl.meta.transcription
 [macro invocations]: macro.invocation
 [macro Kleene matcher]: macro.decl.repetition
 [macro matcher fragment specifier]: macro.decl.meta.specifier
+[macro metavariable]: macro.decl.meta
 [macro repetition]: macro.decl.repetition
 [macros by example]: macro.decl
 [macros]: macro.decl

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -164,7 +164,7 @@ This appendix provides an index of tokens and common forms with links to where t
 
 | Expression                | Usage |
 |---------------------------|-------|
-| <code>\|…\| expr</code>   | [closures] |
+| <code>\|…\| expr</code><br><code>\|…\| -> Type { … }</code> | [closures] |
 | `ident::…`                | [paths] |
 | `::crate_name::…`         | [explicit crate paths] |
 | `crate::…`                | [crate-relative paths] |

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -56,7 +56,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `type`        | [type aliases] |
 | `typeof`      | [reserved keyword] |
 | `union`       | [union items] |
-| `unsafe`      | [unsafe attributes], [unsafe modules], [unsafe functions], [unsafe external blocks], [unsafe external functions], [unsafe external statics], [unsafe traits], [unsafe trait implementations] |
+| `unsafe`      | [unsafe blocks], [unsafe attributes], [unsafe modules], [unsafe functions], [unsafe external blocks], [unsafe external functions], [unsafe external statics], [unsafe traits], [unsafe trait implementations] |
 | `unsized`     | [reserved keyword] |
 | `use`         | [use items], [use bounds] |
 | `virtual`     | [reserved keyword] |
@@ -438,6 +438,7 @@ This appendix provides an index of tokens and common forms with links to where t
 [unions]: items.union
 [unit]: type.tuple.unit
 [unsafe attributes]: attributes.safety
+[unsafe blocks]: expr.block.unsafe
 [unsafe external blocks]: unsafe.extern
 [unsafe external functions]: items.extern.fn.safety
 [unsafe external statics]: items.extern.static.safety

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -28,7 +28,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `for`         | [trait implementations], [iterator loops], [higher-ranked trait bounds] |
 | `gen`         | [reserved keyword] |
 | `if`          | [if expressions], [match guards] |
-| `impl`        | [inherent impls], [trait impls], [impl trait types] |
+| `impl`        | [inherent impls], [trait impls], [impl trait types], [anonymous type parameters] |
 | `in`          | [visibility], [iterator loops], [assembly operands] |
 | `let`         | [let statements], [`if let` patterns] |
 | `loop`        | [infinite loops] |
@@ -238,7 +238,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `(Type, …)`                           | [tuple types] |
 | `[Type, …]`                           | [slice types] |
 | `(Type)`                              | [parenthesized types] |
-| `impl Trait`                          | [impl trait types] |
+| `impl Trait`                          | [impl trait types], [anonymous type parameters] |
 | `dyn Trait`                           | [trait object types] |
 | `ident`<br>`ident::…`                 | [type paths] (can refer to structs, enums, unions, aliases, traits, generics, etc.) |
 | `&Type`<br>`&mut Type`                | [reference types] |
@@ -271,6 +271,7 @@ This appendix provides an index of tokens and common forms with links to where t
 [`if let` patterns]: expr.if.let
 [`self` paths]: paths.qualifiers.mod-self
 [`Self` type paths]: paths.qualifiers.type-self
+[anonymous type parameters]: type.impl-trait.param
 [arith]: expr.arith-logic
 [array and slice indexing expressions]: expr.array.index
 [array expressions]: expr.array
@@ -337,7 +338,7 @@ This appendix provides an index of tokens and common forms with links to where t
 [identifiers]: ident
 [if expressions]: expr.if
 [if let]: expr.if.let
-[impl trait types]: type.impl-trait
+[impl trait types]: type.impl-trait.return
 [implementations]: items.impl
 [inferred const]: items.generics.const.inferred
 [inferred type]: type.inferred

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -8,13 +8,13 @@ This appendix provides an index of tokens and common forms with links to where t
 
 | Symbol | Name        | Usage |
 |--------|-------------|-------|
-| `+`    | Plus        | [addition][arith], [trait bounds], [macro Kleene matcher][macros] |
+| `+`    | Plus        | [addition][arith], [trait bounds], [macro Kleene matcher] |
 | `-`    | Minus       | [subtraction][arith], [negation] |
-| `*`    | Star        | [multiplication][arith], [dereference], [raw pointers], [macro Kleene matcher][macros], [use wildcards] |
+| `*`    | Star        | [multiplication][arith], [dereference], [raw pointers], [macro Kleene matcher], [glob imports] |
 | `/`    | Slash       | [division][arith] |
 | `%`    | Percent     | [remainder][arith] |
 | `^`    | Caret       | [bitwise and logical XOR][arith] |
-| `!`    | Not         | [bitwise and logical NOT][negation], [macro calls][macros], [inner attributes][attributes], [never type], [negative impls] |
+| `!`    | Not         | [bitwise and logical NOT][negation], [macro calls], [inner attributes][attributes], [never type], [negative impls] |
 | `&`    | And         | [bitwise and logical AND][arith], [borrow], [references], [reference patterns] |
 | <code>\|</code> | Or | [bitwise and logical OR][arith], [closures], [or patterns], [if let], [while let] |
 | `&&`   | AndAnd      | [lazy AND][lazy-bool], [borrow], [references], [reference patterns] |
@@ -40,9 +40,9 @@ This appendix provides an index of tokens and common forms with links to where t
 | `<=`   | Le          | [less than or equal to][comparison] |
 | `@`    | At          | [subpattern binding] |
 | `.`    | Dot         | [field access][field], [tuple index] |
-| `..`   | DotDot      | [range][range], [struct expressions], [patterns], [range patterns][rangepat] |
-| `...`  | DotDotDot   | [variadic functions][extern], [range patterns] |
-| `..=`  | DotDotEq    | [inclusive range][range], [range patterns] |
+| `..`   | DotDot      | [range expressions][expr.range], [struct expressions], [rest patterns], [range patterns], [struct patterns] |
+| `...`  | DotDotDot   | [variadic functions], [range patterns] |
+| `..=`  | DotDotEq    | [inclusive range expressions][expr.range], [range patterns] |
 | `,`    | Comma       | various separators |
 | `;`    | Semi        | terminator for various items and statements, [array types] |
 | `:`    | Colon       | various separators |
@@ -52,52 +52,52 @@ This appendix provides an index of tokens and common forms with links to where t
 | `<-`   | LArrow      | The left arrow symbol has been unused since before Rust 1.0, but it is still treated as a single token. |
 | `#`    | Pound       | [attributes] |
 | `$`    | Dollar      | [macros] |
-| `?`    | Question    | [try propagation expressions][question], [questionably sized][sized], [macro Kleene matcher][macros] |
+| `?`    | Question    | [try propagation expressions][question], [questionably sized][sized], [macro Kleene matcher] |
 | `~`    | Tilde       | The tilde operator has been unused since before Rust 1.0, but its token may still be used. |
 
-[arith]: expressions/operator-expr.md#arithmetic-and-logical-binary-operators
-[array types]: types/array.md
-[assignment]: expressions/operator-expr.md#assignment-expressions
-[attributes]: attributes.md
-[borrow]: expressions/operator-expr.md#borrow-operators
-[closures]: expressions/closure-expr.md
-[comparison]: expressions/operator-expr.md#comparison-operators
-[compound]: expressions/operator-expr.md#compound-assignment-expressions
-[constants]: items/constant-items.md
-[dereference]: expressions/operator-expr.md#the-dereference-operator
-[destructuring assignment]: expressions/underscore-expr.md
-[extern crates]: items/extern-crates.md
-[extern]: items/external-blocks.md
-[field]: expressions/field-expr.md
-[function pointer type]: types/function-pointer.md
-[functions]: items/functions.md
-[generics]: items/generics.md
-[if let]: expressions/if-expr.md#if-let-patterns
-[inferred types]: types/inferred.md
-[lazy-bool]: expressions/operator-expr.md#lazy-boolean-operators
+[arith]: expr.arith-logic
+[array types]: type.array
+[assignment]: expr.assign
+[borrow]: expr.operator.borrow
+[closures]: expr.closure
+[comparison]: expr.cmp
+[compound]: expr.compound-assign
+[constants]: items.const
+[dereference]: expr.deref
+[destructuring assignment]: expr.placeholder
+[extern crates]: items.extern-crate
+[extern]: items.extern
+[field]: expr.field
+[function pointer type]: type.fn-pointer
+[functions]: items.fn
+[generics]: items.generics
+[glob imports]: items.use.glob
+[if let]: expr.if.let
+[inferred types]: type.inferred
+[lazy-bool]: expr.bool-logic
 [let statements]: statement.let
-[macros]: macros-by-example.md
-[match]: expressions/match-expr.md
-[negation]: expressions/operator-expr.md#negation-operators
-[negative impls]: items/implementations.md
-[never type]: types/never.md
+[macro calls]: macro.invocation
+[macro Kleene matcher]: macro.decl.repetition
+[macros]: macro.decl
+[match]: expr.match
+[negation]: expr.negate
+[negative impls]: items.impl
+[never type]: type.never
 [or patterns]: patterns.or
-[paths]: paths.md
-[patterns]: patterns.md
-[question]: expressions/operator-expr.md#the-try-propagation-expression
-[range patterns]: patterns.md#range-patterns
-[range]: expressions/range-expr.md
-[rangepat]: patterns.md#range-patterns
-[raw pointers]: types/pointer.md#raw-pointers-const-and-mut
-[reference patterns]: patterns.md#reference-patterns
-[references]: types/pointer.md
-[sized]: trait-bounds.md#sized
-[struct expressions]: expressions/struct-expr.md
-[subpattern binding]: patterns.md#identifier-patterns
-[trait bounds]: trait-bounds.md
-[tuple index]: expressions/tuple-expr.md#tuple-indexing-expressions
+[question]: expr.try
+[range patterns]: patterns.range
+[raw pointers]: type.pointer.raw
+[reference patterns]: patterns.ref
+[references]: type.pointer.reference
+[rest patterns]: patterns.rest
+[sized]: bound.sized
+[struct expressions]: expr.struct
+[struct patterns]: patterns.struct
+[subpattern binding]: patterns.ident.scrutinized
+[trait bounds]: bound
+[tuple index]: expr.tuple-index
 [use bounds]: bound.use
-[use declarations]: items/use-declarations.md
-[use wildcards]: items/use-declarations.md
-[while let]: expressions/loop-expr.md#while-let-patterns
-[wildcard patterns]: patterns.md#wildcard-pattern
+[use declarations]: items.use
+[variadic functions]: items.extern.variadic
+[while let]: expr.loop.while.let
+[wildcard patterns]: patterns.wildcard

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -6,7 +6,7 @@ This appendix provides an index of tokens and common forms with links to where t
 
 | Keyword       | Usage |
 |---------------|-------|
-| `_`           | [wildcard patterns], [inferred types], unnamed items in [constants], [extern crates], [use declarations], [destructuring assignment] |
+| `_`           | [wildcard pattern], [inferred type], unnamed items in [constants], [extern crates], [use declarations], [destructuring assignment] |
 | `abstract`    | [reserved keyword] |
 | `as`          | [extern crate alias], [use alias], [type cast expressions], [qualified paths] |
 | `async`       | [async functions], [async blocks], [async closures] |
@@ -255,7 +255,7 @@ This appendix provides an index of tokens and common forms with links to where t
 |-----------------------------------|-------|
 | `"foo"`, `'a'`, `123`, `2.4`, …   | [literal patterns] |
 | `ident`                           | [identifier patterns] |
-| `_`                               | [wildcard patterns] |
+| `_`                               | [wildcard pattern] |
 | `..`                              | [rest patterns] |
 | `&pattern`<br>`&mut pattern`      | [reference patterns] |
 | `path{…}`                         | [struct patterns] |
@@ -342,7 +342,6 @@ This appendix provides an index of tokens and common forms with links to where t
 [impl traits]: type.impl-trait
 [implementations]: items.impl
 [inferred type]: type.inferred
-[inferred types]: type.inferred
 [infinite loop expressions]: expr.loop.infinite
 [infinite loops]: expr.loop.infinite
 [inherent impls]: items.impl.inherent
@@ -454,4 +453,4 @@ This appendix provides an index of tokens and common forms with links to where t
 [visibility]: vis
 [where clauses]: items.generics.where
 [while let]: expr.loop.while.let
-[wildcard patterns]: patterns.wildcard
+[wildcard pattern]: patterns.wildcard

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -126,6 +126,24 @@ This appendix provides an index of tokens and common forms with links to where t
 | `/*!…*/` | [inner block doc comment][comments] |
 | `/**…*/` | [outer block doc comment][comments] |
 
+## Other tokens
+
+| Token        | Usage |
+|--------------|-------|
+| `ident`      | [identifiers] |
+| `r#ident`    | [raw identifiers] |
+| `'ident`     | [lifetimes and loop labels] |
+| `'r#ident`   | [raw lifetimes and loop labels] |
+| `…u8`, `…i32`, `…f64`, `…usize`, … | [number literals] |
+| `"…"`        | [string literals] |
+| `r"…"`, `r#"…"#`, `r##"…"##`, … | [raw string literals] |
+| `b"…"`       | [byte string literals] |
+| `br"…"`, `br#"…"#`, `br##"…"##`, … | [raw byte string literals] |
+| `'…'`        | [character literals] |
+| `b'…'`       | [byte literals] |
+| `c"…"`       | [C string literals] |
+| `cr"…"`, `cr#"…"#`, `cr##"…"##`, … | [raw C string literals] |
+
 [`'static` lifetimes]: bound
 [`if let` patterns]: expr.if.let
 [`self` paths]: paths.qualifiers.mod-self
@@ -143,6 +161,10 @@ This appendix provides an index of tokens and common forms with links to where t
 [borrow expressions]: expr.operator.borrow
 [borrow]: expr.operator.borrow
 [break expressions]: expr.loop.break
+[byte literals]: lex.token.byte
+[byte string literals]: lex.token.str-byte
+[C string literals]: lex.token.str-c
+[character literals]: lex.token.literal.char
 [closure expressions]: expr.closure
 [closures]: expr.closure
 [comparison]: expr.cmp
@@ -175,6 +197,7 @@ This appendix provides an index of tokens and common forms with links to where t
 [glob imports]: items.use.glob
 [higher-ranked trait bounds]: bound.higher-ranked
 [identifier patterns]: patterns.ident
+[identifiers]: ident
 [if expressions]: expr.if
 [if let]: expr.if.let
 [impl traits]: type.impl-trait
@@ -185,6 +208,7 @@ This appendix provides an index of tokens and common forms with links to where t
 [keywords chapter]: lex.keywords
 [lazy-bool]: expr.bool-logic
 [let statements]: statement.let
+[lifetimes and loop labels]: lex.token.life
 [macro calls]: macro.invocation
 [macro Kleene matcher]: macro.decl.repetition
 [macros by example]: macro.decl
@@ -196,6 +220,7 @@ This appendix provides an index of tokens and common forms with links to where t
 [negation]: expr.negate
 [negative impls]: items.impl
 [never type]: type.never
+[number literals]: lex.token.literal.num
 [or patterns]: patterns.or
 [predicate loops]: expr.loop.while
 [qualified paths]: paths.qualified
@@ -203,9 +228,14 @@ This appendix provides an index of tokens and common forms with links to where t
 [range patterns]: patterns.range
 [raw assembly]: asm.options.supported-options.raw
 [raw borrow operator]: expr.borrow.raw
+[raw byte string literals]: lex.token.str-byte-raw
+[raw C string literals]: lex.token.str-c-raw
+[raw identifiers]: ident.raw
+[raw lifetimes and loop labels]: lex.token.life
 [raw pointer type]: type.pointer.raw
 [raw pointer types]: type.pointer.raw
 [raw pointers]: type.pointer.raw
+[raw string literals]: lex.token.literal.str-raw
 [reference patterns]: patterns.ref
 [reference types]: type.pointer.reference
 [references]: type.pointer.reference
@@ -215,6 +245,7 @@ This appendix provides an index of tokens and common forms with links to where t
 [self parameters]: items.fn.params.self-pat
 [sized]: bound.sized
 [static items]: items.static
+[string literals]: lex.token.literal.str
 [struct expressions]: expr.struct
 [struct patterns]: patterns.struct
 [structs]: items.struct

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -31,7 +31,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | <code>\|=</code> | OrEq | [bitwise OR assignment][compound] |
 | `<<=`  | ShlEq       | [shift left assignment][compound] |
 | `>>=`  | ShrEq       | [shift right assignment][compound], [nested generics][generics] |
-| `=`    | Eq          | [assignment], [attributes], various type definitions |
+| `=`    | Eq          | [assignment], [let statements], [attributes], various type definitions |
 | `==`   | EqEq        | [equal][comparison] |
 | `!=`   | Ne          | [not equal][comparison] |
 | `>`    | Gt          | [greater than][comparison], [generics], [paths], [use bounds] |
@@ -75,6 +75,7 @@ This appendix provides an index of tokens and common forms with links to where t
 [if let]: expressions/if-expr.md#if-let-patterns
 [inferred types]: types/inferred.md
 [lazy-bool]: expressions/operator-expr.md#lazy-boolean-operators
+[let statements]: statement.let
 [macros]: macros-by-example.md
 [match]: expressions/match-expr.md
 [negation]: expressions/operator-expr.md#negation-operators

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -175,7 +175,6 @@ This appendix provides an index of tokens and common forms with links to where t
 | `Trait::method(…)`<br>`Type::method(…)`<br>`<Type as Trait>::method(…)` | [disambiguated method calls] |
 | `Type<…>`                 | [generic arguments] (e.g. `Vec<u8>`) <!-- TODO: fix after generic args reorg --> |
 | `method::<…>(…)`<br>`path::<…>` | [generic arguments], aka turbofish |
-| `Type<ident=Type>`        | [explicit associated type bounds] (e.g. `Iterator<Item=T>`) <!-- undocumented https://github.com/rust-lang/reference/issues/24 --> |
 | `()`                      | [unit] |
 | `(expr)`                  | [parenthesized expressions] |
 | `(expr,)`                 | [single-element tuple expression] |
@@ -241,6 +240,8 @@ This appendix provides an index of tokens and common forms with links to where t
 | `impl Trait`                          | [impl trait types], [anonymous type parameters] |
 | `dyn Trait`                           | [trait object types] |
 | `ident`<br>`ident::…`                 | [type paths] (can refer to structs, enums, unions, aliases, traits, generics, etc.) |
+| `Trait<ident = Type>`                 | [associated type bindings] (e.g. `Iterator<Item = T>`) |
+| `Trait<ident: …>`                     | [associated type bounds] (e.g. `Iterator<Item: Send>`) |
 | `&Type`<br>`&mut Type`                | [reference types] |
 | `*mut Type`<br>`*const Type`          | [raw pointer types] |
 | `fn(…) -> Type`                       | [function pointer types] |
@@ -279,6 +280,8 @@ This appendix provides an index of tokens and common forms with links to where t
 [assembly operands]: asm.operand-type.supported-operands.in
 [assignment]: expr.assign
 [associated items]: items.associated
+[associated type bindings]: paths.expr
+[associated type bounds]: paths.expr
 [async blocks]: expr.block.async
 [async closures]: expr.closure.async
 [async functions]: items.fn.async
@@ -314,7 +317,6 @@ This appendix provides an index of tokens and common forms with links to where t
 [destructuring assignment]: expr.placeholder
 [disambiguated method calls]: expr.call.desugar
 [enumerations]: items.enum
-[explicit associated type bounds]: paths.expr
 [explicit crate paths]: paths.qualifiers.global-root
 [extern crate]: items.extern-crate
 [extern function pointer types]: type.fn-pointer.qualifiers

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -146,12 +146,12 @@ This appendix provides an index of tokens and common forms with links to where t
 
 ## Macros
 
-| Syntax                                    | Usage |
-|-------------------------------------------|-------|
-| `ident!(…)`<br>`ident!{…}`<br>`ident![…]` | [macro invocations] |
-| `$ident`                                  | [macro metavariable] |
-| `$ident:kind`                             | [macro matcher fragment specifier] |
-| `$(…)…`                                   | [macro repetition] |
+| Syntax                                     | Usage |
+|--------------------------------------------|-------|
+| `ident!(…)`<br>`ident! {…}`<br>`ident![…]` | [macro invocations] |
+| `$ident`                                   | [macro metavariable] |
+| `$ident:kind`                              | [macro matcher fragment specifier] |
+| `$(…)…`                                    | [macro repetition] |
 
 ## Attributes
 
@@ -182,7 +182,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `expr.0`, `expr.1`, …     | [tuple indexing expressions] |
 | `expr.ident`              | [field access expressions] |
 | `{…}`                     | [block expressions] |
-| `Type{…}`                 | [struct expressions] |
+| `Type {…}`                | [struct expressions] |
 | `Type(…)`                 | [tuple struct constructors] |
 | `[…]`                     | [array expressions] |
 | `[expr; len]`             | [repeat array expressions] |
@@ -261,7 +261,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `..`                              | [rest patterns] |
 | `a..`, `..b`, `a..b`, `a..=b`, `..=b` | [range patterns] |
 | `&pattern`<br>`&mut pattern`      | [reference patterns] |
-| `path{…}`                         | [struct patterns] |
+| `path {…}`                        | [struct patterns] |
 | `path(…)`                         | [tuple struct patterns] |
 | `(pattern, …)`                    | [tuple patterns] |
 | `(pattern)`                       | [grouped patterns] |

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -6,7 +6,7 @@ This appendix provides an index of tokens and common forms with links to where t
 
 | Keyword       | Usage |
 |---------------|-------|
-| `_`           | [wildcard pattern], [inferred const], [inferred type], unnamed items in [constants], [extern crates], [use declarations], [destructuring assignment] |
+| `_`           | [wildcard pattern], [inferred const], [inferred type], [placeholder lifetime], unnamed items in [constants], [extern crates], [use declarations], [destructuring assignment] |
 | `abstract`    | [reserved keyword] |
 | `as`          | [extern crate alias], [use alias], [type cast expressions], [qualified paths] |
 | `async`       | [async functions], [async blocks], [async closures] |
@@ -245,6 +245,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `*mut Type`<br>`*const Type`          | [raw pointer types] |
 | `fn(…) -> Type`                       | [function pointer types] |
 | `_`                                   | [inferred type], [inferred const] |
+| `'_`                                  | [placeholder lifetime] |
 | `!`                                   | [never type] |
 
 ## Patterns
@@ -378,6 +379,7 @@ This appendix provides an index of tokens and common forms with links to where t
 [parenthesized expressions]: expr.paren
 [parenthesized types]: type.name.parenthesized
 [path patterns]: patterns.path
+[placeholder lifetime]: lifetime-elision.function.explicit-placeholder
 [predicate loop expressions]: expr.loop.while
 [predicate loops]: expr.loop.while
 [primitive types]: type.kinds

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -202,7 +202,7 @@ This appendix provides an index of tokens and common forms with links to where t
 
 ## Items
 
-[Items] are declarations in a crate.
+[Items] are the components of a crate.
 
 | Item                          | Usage |
 |-------------------------------|-------|

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -34,8 +34,8 @@ This appendix provides an index of tokens and common forms with links to where t
 | `=`    | Eq          | [assignment], [attributes], various type definitions |
 | `==`   | EqEq        | [equal][comparison] |
 | `!=`   | Ne          | [not equal][comparison] |
-| `>`    | Gt          | [greater than][comparison], [generics], [paths] |
-| `<`    | Lt          | [less than][comparison], [generics], [paths] |
+| `>`    | Gt          | [greater than][comparison], [generics], [paths], [use bounds] |
+| `<`    | Lt          | [less than][comparison], [generics], [paths], [use bounds] |
 | `>=`   | Ge          | [greater than or equal to][comparison], [generics] |
 | `<=`   | Le          | [less than or equal to][comparison] |
 | `@`    | At          | [subpattern binding] |
@@ -95,6 +95,7 @@ This appendix provides an index of tokens and common forms with links to where t
 [subpattern binding]: patterns.md#identifier-patterns
 [trait bounds]: trait-bounds.md
 [tuple index]: expressions/tuple-expr.md#tuple-indexing-expressions
+[use bounds]: bound.use
 [use declarations]: items/use-declarations.md
 [use wildcards]: items/use-declarations.md
 [while let]: expressions/loop-expr.md#while-let-patterns

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -8,7 +8,7 @@ This appendix provides an index of tokens and common forms with links to where t
 |---------------|-------|
 | `_`           | [wildcard pattern], [inferred const], [inferred type], [placeholder lifetime], unnamed [constant items], [extern crates], [use declarations], [destructuring assignment] |
 | `abstract`    | [reserved keyword] |
-| `as`          | [extern crate alias], [use alias], [type cast expressions], [qualified paths] |
+| `as`          | [extern crate][items.extern-crate.as], [use declarations][items.use.forms.as], [type cast expressions], [qualified paths] |
 | `async`       | [async functions], [async blocks], [async closures] |
 | `await`       | [await expressions] |
 | `become`      | [reserved keyword] |
@@ -315,7 +315,6 @@ This appendix provides an index of tokens and common forms with links to where t
 [enumerations]: items.enum
 [explicit associated type bounds]: paths.expr
 [explicit crate paths]: paths.qualifiers.global-root
-[extern crate alias]: items.extern-crate.as
 [extern crate]: items.extern-crate
 [extern crates]: items.extern-crate
 [extern function pointer types]: type.fn-pointer.qualifiers
@@ -448,7 +447,6 @@ This appendix provides an index of tokens and common forms with links to where t
 [unsafe static items]: items.static.mut.safety
 [unsafe trait implementations]: items.impl.trait.safety
 [unsafe traits]: items.traits.safety
-[use alias]: items.use.forms.as
 [use bounds]: bound.use
 [use declarations]: items.use
 [use items]: items.use

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -226,7 +226,7 @@ This appendix provides an index of tokens and common forms with links to where t
 
 | Type                                  | Usage |
 |---------------------------------------|-------|
-| `bool`, `u8`, `f64`, `char`, `str`    | [primitive types] |
+| `bool`, `u8`, `f64`, `str`, …         | [primitive types] |
 | `for<…>`                              | [higher-ranked trait bounds] |
 | `T: U`                                | [trait bounds] |
 | `T: 'a`                               | [lifetime bounds] |

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -238,7 +238,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `(Type)`                              | [parenthesized types] |
 | `impl Trait`                          | [impl trait types], [anonymous type parameters] |
 | `dyn Trait`                           | [trait object types] |
-| `ident`<br>`ident::…`                 | [type paths] (can refer to structs, enums, unions, aliases, traits, generics, etc.) |
+| `ident`<br>`ident::…`                 | [type paths] (can refer to structs, enums, unions, type aliases, traits, generics, etc.) |
 | `Type<…>`<br>`Trait<…>`               | [generic arguments] (e.g. `Vec<u8>`) |
 | `Trait<ident = Type>`                 | [associated type bindings] (e.g. `Iterator<Item = T>`) |
 | `Trait<ident: …>`                     | [associated type bounds] (e.g. `Iterator<Item: Send>`) |

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -6,7 +6,7 @@ This appendix provides an index of tokens and common forms with links to where t
 
 | Keyword       | Usage |
 |---------------|-------|
-| `_`           | [wildcard pattern], [inferred const], [inferred type], [placeholder lifetime], unnamed [constant items], [extern crates], [use declarations], [destructuring assignment] |
+| `_`           | [wildcard pattern], [inferred const], [inferred type], [placeholder lifetime], unnamed [constant items], [extern crate], [use declarations], [destructuring assignment] |
 | `abstract`    | [reserved keyword] |
 | `as`          | [extern crate][items.extern-crate.as], [use declarations][items.use.forms.as], [type cast expressions], [qualified paths] |
 | `async`       | [async functions], [async blocks], [async closures] |
@@ -16,7 +16,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `break`       | [break expressions] |
 | `const`       | [const functions], [const items], [const generics], [const blocks], [raw borrow operator], [raw pointer type], [const assembly operands] |
 | `continue`    | [continue expressions] |
-| `crate`       | [extern crates], [visibility], [paths] |
+| `crate`       | [extern crate], [visibility], [paths] |
 | `do`          | [reserved keyword] |
 | `dyn`         | [trait objects] |
 | `else`        | [let statements], [if expressions] |
@@ -45,7 +45,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `ref`         | [identifier patterns], [struct patterns] |
 | `return`      | [return expressions] |
 | `safe`        | [external block functions], [external block statics] |
-| `self`        | [extern crates][items.extern-crate.self], [self parameters], [visibility], [`self` paths] |
+| `self`        | [extern crate][items.extern-crate.self], [self parameters], [visibility], [`self` paths] |
 | `Self`        | [`Self` type paths], [use bounds] |
 | `static`      | [static items], [`'static` lifetimes] |
 | `struct`      | [structs] |
@@ -316,7 +316,6 @@ This appendix provides an index of tokens and common forms with links to where t
 [explicit associated type bounds]: paths.expr
 [explicit crate paths]: paths.qualifiers.global-root
 [extern crate]: items.extern-crate
-[extern crates]: items.extern-crate
 [extern function pointer types]: type.fn-pointer.qualifiers
 [extern function qualifier]: items.fn.extern
 [extern]: items.extern

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -16,7 +16,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `^`    | Caret       | [bitwise and logical XOR][arith]
 | `!`    | Not         | [bitwise and logical NOT][negation], [macro calls][macros], [inner attributes][attributes], [never type], [negative impls]
 | `&`    | And         | [bitwise and logical AND][arith], [borrow], [references], [reference patterns]
-| <code>\|</code> | Or | [bitwise and logical OR][arith], [closures], patterns in [match], [if let], and [while let]
+| <code>\|</code> | Or | [bitwise and logical OR][arith], [closures], patterns in [match], [if let], [while let]
 | `&&`   | AndAnd      | [lazy AND][lazy-bool], [borrow], [references], [reference patterns]
 | <code>\|\|</code> | OrOr | [lazy OR][lazy-bool], [closures]
 | `<<`   | Shl         | [shift left][arith], [nested generics][generics]

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -144,6 +144,15 @@ This appendix provides an index of tokens and common forms with links to where t
 | `c"…"`       | [C string literals] |
 | `cr"…"`, `cr#"…"#`, `cr##"…"##`, … | [raw C string literals] |
 
+## Macros
+
+| Syntax                                    | Usage |
+|-------------------------------------------|-------|
+| `ident!(…)`<br>`ident!{…}`<br>`ident![…]` | [macro invocations] |
+| `$ident`                                  | [macro fragment substitution] |
+| `$ident:kind`                             | [macro fragment specifier] |
+| `$(…)…`                                   | [macro repetition] |
+
 [`'static` lifetimes]: bound
 [`if let` patterns]: expr.if.let
 [`self` paths]: paths.qualifiers.mod-self
@@ -210,7 +219,11 @@ This appendix provides an index of tokens and common forms with links to where t
 [let statements]: statement.let
 [lifetimes and loop labels]: lex.token.life
 [macro calls]: macro.invocation
+[macro fragment specifier]: macro.decl.meta.specifier
+[macro fragment substitution]: macro.decl.meta.transcription
+[macro invocations]: macro.invocation
 [macro Kleene matcher]: macro.decl.repetition
+[macro repetition]: macro.decl.repetition
 [macros by example]: macro.decl
 [macros]: macro.decl
 [match expressions]: expr.match

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -234,7 +234,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `T: ?Sized`                           | [relaxed trait bounds] |
 | `[Type; len]`                         | [array types] |
 | `(Type, …)`                           | [tuple types] |
-| `[Type, …]`                           | [slice types] |
+| `[Type]`                              | [slice types] |
 | `(Type)`                              | [parenthesized types] |
 | `impl Trait`                          | [impl trait types], [anonymous type parameters] |
 | `dyn Trait`                           | [trait object types] |

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -8,52 +8,52 @@ This appendix provides an index of tokens and common forms with links to where t
 
 | Symbol | Name        | Usage |
 |--------|-------------|-------|
-| `+`    | Plus        | [addition][arith], [trait bounds], [macro Kleene matcher][macros]
-| `-`    | Minus       | [subtraction][arith], [negation]
-| `*`    | Star        | [multiplication][arith], [dereference], [raw pointers], [macro Kleene matcher][macros], [use wildcards]
-| `/`    | Slash       | [division][arith]
-| `%`    | Percent     | [remainder][arith]
-| `^`    | Caret       | [bitwise and logical XOR][arith]
-| `!`    | Not         | [bitwise and logical NOT][negation], [macro calls][macros], [inner attributes][attributes], [never type], [negative impls]
-| `&`    | And         | [bitwise and logical AND][arith], [borrow], [references], [reference patterns]
-| <code>\|</code> | Or | [bitwise and logical OR][arith], [closures], patterns in [match], [if let], [while let]
-| `&&`   | AndAnd      | [lazy AND][lazy-bool], [borrow], [references], [reference patterns]
-| <code>\|\|</code> | OrOr | [lazy OR][lazy-bool], [closures]
-| `<<`   | Shl         | [shift left][arith], [nested generics][generics]
-| `>>`   | Shr         | [shift right][arith], [nested generics][generics]
-| `+=`   | PlusEq      | [addition assignment][compound]
-| `-=`   | MinusEq     | [subtraction assignment][compound]
-| `*=`   | StarEq      | [multiplication assignment][compound]
-| `/=`   | SlashEq     | [division assignment][compound]
-| `%=`   | PercentEq   | [remainder assignment][compound]
-| `^=`   | CaretEq     | [bitwise XOR assignment][compound]
-| `&=`   | AndEq       | [bitwise AND assignment][compound]
-| <code>\|=</code> | OrEq | [bitwise OR assignment][compound]
-| `<<=`  | ShlEq       | [shift left assignment][compound]
-| `>>=`  | ShrEq       | [shift right assignment][compound], [nested generics][generics]
-| `=`    | Eq          | [assignment], [attributes], various type definitions
-| `==`   | EqEq        | [equal][comparison]
-| `!=`   | Ne          | [not equal][comparison]
-| `>`    | Gt          | [greater than][comparison], [generics], [paths]
-| `<`    | Lt          | [less than][comparison], [generics], [paths]
-| `>=`   | Ge          | [greater than or equal to][comparison], [generics]
-| `<=`   | Le          | [less than or equal to][comparison]
-| `@`    | At          | [subpattern binding]
-| `.`    | Dot         | [field access][field], [tuple index]
-| `..`   | DotDot      | [range][range], [struct expressions], [patterns], [range patterns][rangepat]
-| `...`  | DotDotDot   | [variadic functions][extern], [range patterns]
-| `..=`  | DotDotEq    | [inclusive range][range], [range patterns]
-| `,`    | Comma       | various separators
-| `;`    | Semi        | terminator for various items and statements, [array types]
-| `:`    | Colon       | various separators
-| `::`   | PathSep     | [path separator][paths]
-| `->`   | RArrow      | [function return type][functions], [closure return type][closures], [function pointer type]
-| `=>`   | FatArrow    | [match arms][match], [macros]
-| `<-`   | LArrow      | The left arrow symbol has been unused since before Rust 1.0, but it is still treated as a single token.
-| `#`    | Pound       | [attributes]
-| `$`    | Dollar      | [macros]
-| `?`    | Question    | [try propagation expressions][question], [questionably sized][sized], [macro Kleene matcher][macros]
-| `~`    | Tilde       | The tilde operator has been unused since before Rust 1.0, but its token may still be used.
+| `+`    | Plus        | [addition][arith], [trait bounds], [macro Kleene matcher][macros] |
+| `-`    | Minus       | [subtraction][arith], [negation] |
+| `*`    | Star        | [multiplication][arith], [dereference], [raw pointers], [macro Kleene matcher][macros], [use wildcards] |
+| `/`    | Slash       | [division][arith] |
+| `%`    | Percent     | [remainder][arith] |
+| `^`    | Caret       | [bitwise and logical XOR][arith] |
+| `!`    | Not         | [bitwise and logical NOT][negation], [macro calls][macros], [inner attributes][attributes], [never type], [negative impls] |
+| `&`    | And         | [bitwise and logical AND][arith], [borrow], [references], [reference patterns] |
+| <code>\|</code> | Or | [bitwise and logical OR][arith], [closures], patterns in [match], [if let], [while let] |
+| `&&`   | AndAnd      | [lazy AND][lazy-bool], [borrow], [references], [reference patterns] |
+| <code>\|\|</code> | OrOr | [lazy OR][lazy-bool], [closures] |
+| `<<`   | Shl         | [shift left][arith], [nested generics][generics] |
+| `>>`   | Shr         | [shift right][arith], [nested generics][generics] |
+| `+=`   | PlusEq      | [addition assignment][compound] |
+| `-=`   | MinusEq     | [subtraction assignment][compound] |
+| `*=`   | StarEq      | [multiplication assignment][compound] |
+| `/=`   | SlashEq     | [division assignment][compound] |
+| `%=`   | PercentEq   | [remainder assignment][compound] |
+| `^=`   | CaretEq     | [bitwise XOR assignment][compound] |
+| `&=`   | AndEq       | [bitwise AND assignment][compound] |
+| <code>\|=</code> | OrEq | [bitwise OR assignment][compound] |
+| `<<=`  | ShlEq       | [shift left assignment][compound] |
+| `>>=`  | ShrEq       | [shift right assignment][compound], [nested generics][generics] |
+| `=`    | Eq          | [assignment], [attributes], various type definitions |
+| `==`   | EqEq        | [equal][comparison] |
+| `!=`   | Ne          | [not equal][comparison] |
+| `>`    | Gt          | [greater than][comparison], [generics], [paths] |
+| `<`    | Lt          | [less than][comparison], [generics], [paths] |
+| `>=`   | Ge          | [greater than or equal to][comparison], [generics] |
+| `<=`   | Le          | [less than or equal to][comparison] |
+| `@`    | At          | [subpattern binding] |
+| `.`    | Dot         | [field access][field], [tuple index] |
+| `..`   | DotDot      | [range][range], [struct expressions], [patterns], [range patterns][rangepat] |
+| `...`  | DotDotDot   | [variadic functions][extern], [range patterns] |
+| `..=`  | DotDotEq    | [inclusive range][range], [range patterns] |
+| `,`    | Comma       | various separators |
+| `;`    | Semi        | terminator for various items and statements, [array types] |
+| `:`    | Colon       | various separators |
+| `::`   | PathSep     | [path separator][paths] |
+| `->`   | RArrow      | [function return type][functions], [closure return type][closures], [function pointer type] |
+| `=>`   | FatArrow    | [match arms][match], [macros] |
+| `<-`   | LArrow      | The left arrow symbol has been unused since before Rust 1.0, but it is still treated as a single token. |
+| `#`    | Pound       | [attributes] |
+| `$`    | Dollar      | [macros] |
+| `?`    | Question    | [try propagation expressions][question], [questionably sized][sized], [macro Kleene matcher][macros] |
+| `~`    | Tilde       | The tilde operator has been unused since before Rust 1.0, but its token may still be used. |
 
 [arith]: expressions/operator-expr.md#arithmetic-and-logical-binary-operators
 [array types]: types/array.md

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -238,7 +238,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `(Type)`                              | [parenthesized types] |
 | `impl Trait`                          | [impl trait types], [anonymous type parameters] |
 | `dyn Trait`                           | [trait object types] |
-| `ident`<br>`ident::…`                 | [type paths] (can refer to structs, enums, unions, type aliases, traits, generics, etc.) |
+| `ident`<br>`ident::…`                 | [type paths] (can refer to [structs], [enumerations], [unions], [type aliases], [traits], [generics], etc.) |
 | `Type<…>`<br>`Trait<…>`               | [generic arguments] (e.g. `Vec<u8>`) |
 | `Trait<ident = Type>`                 | [associated type bindings] (e.g. `Iterator<Item = T>`) |
 | `Trait<ident: …>`                     | [associated type bounds] (e.g. `Iterator<Item: Send>`) |

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -176,7 +176,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `method::<…>(…)`<br>`path::<…>` | [generic arguments], aka turbofish |
 | `()`                      | [unit] |
 | `(expr)`                  | [parenthesized expressions] |
-| `(expr,)`                 | [single-element tuple expression] |
+| `(expr,)`                 | [single-element tuple expressions] |
 | `(expr, …)`               | [tuple expressions] |
 | `expr(expr, …)`           | [call expressions] |
 | `expr.0`, `expr.1`, …     | [tuple indexing expressions] |
@@ -406,7 +406,7 @@ This appendix provides an index of tokens and common forms with links to where t
 [rest patterns]: patterns.rest
 [return expressions]: expr.return
 [self parameters]: items.fn.params.self-pat
-[single-element tuple expression]: expr.tuple
+[single-element tuple expressions]: expr.tuple
 [sized]: bound.sized
 [slice patterns]: patterns.slice
 [slice types]: type.slice

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -115,6 +115,17 @@ This appendix provides an index of tokens and common forms with links to where t
 | `?`    | Question    | [try propagation expressions][question], [questionably sized][sized], [macro Kleene matcher] |
 | `~`    | Tilde       | The tilde operator has been unused since before Rust 1.0, but its token may still be used. |
 
+## Comments
+
+| Comment  | Usage |
+|----------|-------|
+| `//`     | [line comment][comments] |
+| `//!`    | [inner line comment][comments] |
+| `///`    | [outer line doc comment][comments] |
+| `/*…*/`  | [block comment][comments] |
+| `/*!…*/` | [inner block doc comment][comments] |
+| `/**…*/` | [outer block doc comment][comments] |
+
 [`'static` lifetimes]: bound
 [`if let` patterns]: expr.if.let
 [`self` paths]: paths.qualifiers.mod-self

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -258,6 +258,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `ident`                           | [identifier patterns] |
 | `_`                               | [wildcard pattern] |
 | `..`                              | [rest patterns] |
+| `a..`, `..b`, `a..b`, `a..=b`, `..=b` | [range patterns] |
 | `&pattern`<br>`&mut pattern`      | [reference patterns] |
 | `path{…}`                         | [struct patterns] |
 | `path(…)`                         | [tuple struct patterns] |

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -110,7 +110,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `->`   | RArrow      | [functions], [closures], [function pointer type] |
 | `=>`   | FatArrow    | [match arms][match], [macros] |
 | `<-`   | LArrow      | The left arrow symbol has been unused since before Rust 1.0, but it is still treated as a single token. |
-| `#`    | Pound       | [attributes] |
+| `#`    | Pound       | [attributes], [raw string literals], [raw byte string literals], [raw C string literals] |
 | `$`    | Dollar      | [macros] |
 | `?`    | Question    | [try propagation expressions][question], [questionably sized][sized], [macro Kleene matcher] |
 | `~`    | Tilde       | The tilde operator has been unused since before Rust 1.0, but its token may still be used. |

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -8,58 +8,53 @@ This appendix provides an index of tokens and common forms with links to where t
 
 | Symbol | Name        | Usage |
 |--------|-------------|-------|
-| `+`    | Plus        | [Addition][arith], [Trait Bounds], [Macro Kleene Matcher][macros]
-| `-`    | Minus       | [Subtraction][arith], [Negation]
-| `*`    | Star        | [Multiplication][arith], [Dereference], [Raw Pointers], [Macro Kleene Matcher][macros], [Use wildcards]
-| `/`    | Slash       | [Division][arith]
-| `%`    | Percent     | [Remainder][arith]
-| `^`    | Caret       | [Bitwise and Logical XOR][arith]
-| `!`    | Not         | [Bitwise and Logical NOT][negation], [Macro Calls][macros], [Inner Attributes][attributes], [Never Type], [Negative impls]
-| `&`    | And         | [Bitwise and Logical AND][arith], [Borrow], [References], [Reference patterns]
-| <code>\|</code> | Or | [Bitwise and Logical OR][arith], [Closures], Patterns in [match], [if let], and [while let]
-| `&&`   | AndAnd      | [Lazy AND][lazy-bool], [Borrow], [References], [Reference patterns]
-| <code>\|\|</code> | OrOr | [Lazy OR][lazy-bool], [Closures]
-| `<<`   | Shl         | [Shift Left][arith], [Nested Generics][generics]
-| `>>`   | Shr         | [Shift Right][arith], [Nested Generics][generics]
-| `+=`   | PlusEq      | [Addition assignment][compound]
-| `-=`   | MinusEq     | [Subtraction assignment][compound]
-| `*=`   | StarEq      | [Multiplication assignment][compound]
-| `/=`   | SlashEq     | [Division assignment][compound]
-| `%=`   | PercentEq   | [Remainder assignment][compound]
-| `^=`   | CaretEq     | [Bitwise XOR assignment][compound]
-| `&=`   | AndEq       | [Bitwise And assignment][compound]
-| <code>\|=</code> | OrEq | [Bitwise Or assignment][compound]
-| `<<=`  | ShlEq       | [Shift Left assignment][compound]
-| `>>=`  | ShrEq       | [Shift Right assignment][compound], [Nested Generics][generics]
-| `=`    | Eq          | [Assignment], [Attributes], Various type definitions
-| `==`   | EqEq        | [Equal][comparison]
-| `!=`   | Ne          | [Not Equal][comparison]
-| `>`    | Gt          | [Greater than][comparison], [Generics], [Paths]
-| `<`    | Lt          | [Less than][comparison], [Generics], [Paths]
-| `>=`   | Ge          | [Greater than or equal to][comparison], [Generics]
-| `<=`   | Le          | [Less than or equal to][comparison]
-| `@`    | At          | [Subpattern binding]
-| `.`    | Dot         | [Field access][field], [Tuple index]
-| `..`   | DotDot      | [Range][range], [Struct expressions], [Patterns], [Range Patterns][rangepat]
-| `...`  | DotDotDot   | [Variadic functions][extern], [Range patterns]
-| `..=`  | DotDotEq    | [Inclusive Range][range], [Range patterns]
-| `,`    | Comma       | Various separators
-| `;`    | Semi        | Terminator for various items and statements, [Array types]
-| `:`    | Colon       | Various separators
-| `::`   | PathSep     | [Path separator][paths]
-| `->`   | RArrow      | [Function return type][functions], [Closure return type][closures], [Function pointer type]
-| `=>`   | FatArrow    | [Match arms][match], [Macros]
-| `<-`   | LArrow      | The left arrow symbol has been unused since before Rust 1.0, but it is still treated as a single token
-| `#`    | Pound       | [Attributes]
-| `$`    | Dollar      | [Macros]
-| `?`    | Question    | [Try propagation expressions][question], [Questionably sized][sized], [Macro Kleene Matcher][macros]
-| `~`    | Tilde       | The tilde operator has been unused since before Rust 1.0, but its token may still be used
+| `+`    | Plus        | [addition][arith], [trait bounds], [macro Kleene matcher][macros]
+| `-`    | Minus       | [subtraction][arith], [negation]
+| `*`    | Star        | [multiplication][arith], [dereference], [raw pointers], [macro Kleene matcher][macros], [use wildcards]
+| `/`    | Slash       | [division][arith]
+| `%`    | Percent     | [remainder][arith]
+| `^`    | Caret       | [bitwise and logical XOR][arith]
+| `!`    | Not         | [bitwise and logical NOT][negation], [macro calls][macros], [inner attributes][attributes], [never type], [negative impls]
+| `&`    | And         | [bitwise and logical AND][arith], [borrow], [references], [reference patterns]
+| <code>\|</code> | Or | [bitwise and logical OR][arith], [closures], patterns in [match], [if let], and [while let]
+| `&&`   | AndAnd      | [lazy AND][lazy-bool], [borrow], [references], [reference patterns]
+| <code>\|\|</code> | OrOr | [lazy OR][lazy-bool], [closures]
+| `<<`   | Shl         | [shift left][arith], [nested generics][generics]
+| `>>`   | Shr         | [shift right][arith], [nested generics][generics]
+| `+=`   | PlusEq      | [addition assignment][compound]
+| `-=`   | MinusEq     | [subtraction assignment][compound]
+| `*=`   | StarEq      | [multiplication assignment][compound]
+| `/=`   | SlashEq     | [division assignment][compound]
+| `%=`   | PercentEq   | [remainder assignment][compound]
+| `^=`   | CaretEq     | [bitwise XOR assignment][compound]
+| `&=`   | AndEq       | [bitwise AND assignment][compound]
+| <code>\|=</code> | OrEq | [bitwise OR assignment][compound]
+| `<<=`  | ShlEq       | [shift left assignment][compound]
+| `>>=`  | ShrEq       | [shift right assignment][compound], [nested generics][generics]
+| `=`    | Eq          | [assignment], [attributes], various type definitions
+| `==`   | EqEq        | [equal][comparison]
+| `!=`   | Ne          | [not equal][comparison]
+| `>`    | Gt          | [greater than][comparison], [generics], [paths]
+| `<`    | Lt          | [less than][comparison], [generics], [paths]
+| `>=`   | Ge          | [greater than or equal to][comparison], [generics]
+| `<=`   | Le          | [less than or equal to][comparison]
+| `@`    | At          | [subpattern binding]
+| `.`    | Dot         | [field access][field], [tuple index]
+| `..`   | DotDot      | [range][range], [struct expressions], [patterns], [range patterns][rangepat]
+| `...`  | DotDotDot   | [variadic functions][extern], [range patterns]
+| `..=`  | DotDotEq    | [inclusive range][range], [range patterns]
+| `,`    | Comma       | various separators
+| `;`    | Semi        | terminator for various items and statements, [array types]
+| `:`    | Colon       | various separators
+| `::`   | PathSep     | [path separator][paths]
+| `->`   | RArrow      | [function return type][functions], [closure return type][closures], [function pointer type]
+| `=>`   | FatArrow    | [match arms][match], [macros]
+| `<-`   | LArrow      | The left arrow symbol has been unused since before Rust 1.0, but it is still treated as a single token.
+| `#`    | Pound       | [attributes]
+| `$`    | Dollar      | [macros]
+| `?`    | Question    | [try propagation expressions][question], [questionably sized][sized], [macro Kleene matcher][macros]
+| `~`    | Tilde       | The tilde operator has been unused since before Rust 1.0, but its token may still be used.
 
-[Inferred types]: types/inferred.md
-[Range patterns]: patterns.md#range-patterns
-[Reference patterns]: patterns.md#reference-patterns
-[Subpattern binding]: patterns.md#identifier-patterns
-[Wildcard patterns]: patterns.md#wildcard-pattern
 [arith]: expressions/operator-expr.md#arithmetic-and-logical-binary-operators
 [array types]: types/array.md
 [assignment]: expressions/operator-expr.md#assignment-expressions
@@ -78,6 +73,7 @@ This appendix provides an index of tokens and common forms with links to where t
 [functions]: items/functions.md
 [generics]: items/generics.md
 [if let]: expressions/if-expr.md#if-let-patterns
+[inferred types]: types/inferred.md
 [lazy-bool]: expressions/operator-expr.md#lazy-boolean-operators
 [macros]: macros-by-example.md
 [match]: expressions/match-expr.md
@@ -87,14 +83,18 @@ This appendix provides an index of tokens and common forms with links to where t
 [paths]: paths.md
 [patterns]: patterns.md
 [question]: expressions/operator-expr.md#the-try-propagation-expression
+[range patterns]: patterns.md#range-patterns
 [range]: expressions/range-expr.md
 [rangepat]: patterns.md#range-patterns
 [raw pointers]: types/pointer.md#raw-pointers-const-and-mut
+[reference patterns]: patterns.md#reference-patterns
 [references]: types/pointer.md
 [sized]: trait-bounds.md#sized
 [struct expressions]: expressions/struct-expr.md
+[subpattern binding]: patterns.md#identifier-patterns
 [trait bounds]: trait-bounds.md
 [tuple index]: expressions/tuple-expr.md#tuple-indexing-expressions
 [use declarations]: items/use-declarations.md
 [use wildcards]: items/use-declarations.md
 [while let]: expressions/loop-expr.md#while-let-patterns
+[wildcard patterns]: patterns.md#wildcard-pattern

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -112,7 +112,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `<-`   | LArrow      | The left arrow symbol has been unused since before Rust 1.0, but it is still treated as a single token. |
 | `#`    | Pound       | [attributes], [raw string literals], [raw byte string literals], [raw C string literals] |
 | `$`    | Dollar      | [macros] |
-| `?`    | Question    | [try propagation expressions][question], [questionably sized][sized], [macro Kleene matcher] |
+| `?`    | Question    | [try propagation expressions][question], [relaxed trait bounds], [macro Kleene matcher] |
 | `~`    | Tilde       | The tilde operator has been unused since before Rust 1.0, but its token may still be used. |
 
 ## Comments

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -100,7 +100,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `<=`   | Le          | [less than or equal to][comparison] |
 | `@`    | At          | [subpattern binding] |
 | `.`    | Dot         | [field access][field], [tuple index] |
-| `..`   | DotDot      | [range expressions][expr.range], [struct expressions], [rest patterns], [range patterns], [struct patterns] |
+| `..`   | DotDot      | [range expressions][expr.range], [struct expressions], [rest pattern], [range patterns], [struct patterns] |
 | `...`  | DotDotDot   | [variadic functions], [range patterns] |
 | `..=`  | DotDotEq    | [inclusive range expressions][expr.range], [range patterns] |
 | `,`    | Comma       | various separators |
@@ -258,7 +258,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `"foo"`, `'a'`, `123`, `2.4`, …   | [literal patterns] |
 | `ident`                           | [identifier patterns] |
 | `_`                               | [wildcard pattern] |
-| `..`                              | [rest patterns] |
+| `..`                              | [rest pattern] |
 | `a..`, `..b`, `a..b`, `a..=b`, `..=b` | [range patterns] |
 | `&pattern`<br>`&mut pattern`      | [reference patterns] |
 | `path {…}`                        | [struct patterns] |
@@ -403,7 +403,7 @@ This appendix provides an index of tokens and common forms with links to where t
 [relaxed trait bounds]: bound.sized
 [repeat array expressions]: expr.array
 [reserved keyword]: lex.keywords.reserved
-[rest patterns]: patterns.rest
+[rest pattern]: patterns.rest
 [return expressions]: expr.return
 [self parameters]: items.fn.params.self-pat
 [single-element tuple expressions]: expr.tuple

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -209,14 +209,14 @@ This appendix provides an index of tokens and common forms with links to where t
 | `mod ident;`<br>`mod ident {…}` | [modules] |
 | `use path;`                   | [use declarations] |
 | `fn ident(…) {…}`             | [functions] |
-| `type Type = Type`            | [type aliases] |
+| `type Type = Type;`           | [type aliases] |
 | `struct ident {…}`            | [structs] |
 | `enum ident {…}`              | [enumerations] |
 | `union ident {…}`             | [unions] |
 | `trait ident {…}`             | [traits] |
 | `impl Type {…}`<br>`impl Type for Trait {…}` | [implementations] |
-| `const ident = expr`          | [constant items] |
-| `static ident = expr`         | [static items] |
+| `const ident = expr;`         | [constant items] |
+| `static ident = expr;`        | [static items] |
 | `extern "C" {…}`              | [external blocks] |
 | `fn ident<…>(…) …`<br>`struct ident<…> {…}`<br>`enum ident<…> {…}`<br>`impl<…> Type<…> {…}` | [generic definitions] |
 

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -170,7 +170,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `crate::…`                | [crate-relative paths] |
 | `self::…`                 | [module-relative paths] |
 | `super::…`                | [parent module paths] |
-| `Type::…`<br>`<type as trait>::ident` | [associated items] |
+| `Type::…`<br>`<Type as Trait>::ident` | [associated items] |
 | `<Type>::…`               | [qualified paths] which can be used for types without names such as `<&T>::…`, `<[T]>::…`, etc. |
 | `Trait::method(…)`<br>`Type::method(…)`<br>`<Type as Trait>::method(…)` | [disambiguated method calls] |
 | `Type<…>`                 | [generic arguments] (e.g. `Vec<u8>`) <!-- TODO: fix after generic args reorg --> |

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -104,7 +104,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `...`  | DotDotDot   | [variadic functions], [range patterns] |
 | `..=`  | DotDotEq    | [inclusive range expressions][expr.range], [range patterns] |
 | `,`    | Comma       | various separators |
-| `;`    | Semi        | terminator for various items and statements, [array types] |
+| `;`    | Semi        | terminator for various items and statements, [array expressions], [array types] |
 | `:`    | Colon       | various separators |
 | `::`   | PathSep     | [path separator][paths] |
 | `->`   | RArrow      | [function return type][functions], [closure return type][closures], [function pointer type] |

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -6,7 +6,7 @@ This appendix provides an index of tokens and common forms with links to where t
 
 | Keyword       | Usage |
 |---------------|-------|
-| `_`           | [wildcard pattern], [inferred type], unnamed items in [constants], [extern crates], [use declarations], [destructuring assignment] |
+| `_`           | [wildcard pattern], [inferred const], [inferred type], unnamed items in [constants], [extern crates], [use declarations], [destructuring assignment] |
 | `abstract`    | [reserved keyword] |
 | `as`          | [extern crate alias], [use alias], [type cast expressions], [qualified paths] |
 | `async`       | [async functions], [async blocks], [async closures] |
@@ -244,7 +244,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `&Type`<br>`&mut Type`                | [reference types] |
 | `*mut Type`<br>`*const Type`          | [raw pointer types] |
 | `fn(…) -> Type`                       | [function pointer types] |
-| `_`                                   | [inferred type] |
+| `_`                                   | [inferred type], [inferred const] |
 | `!`                                   | [never type] |
 
 ## Patterns
@@ -341,6 +341,7 @@ This appendix provides an index of tokens and common forms with links to where t
 [impl trait types]: type.impl-trait
 [impl traits]: type.impl-trait
 [implementations]: items.impl
+[inferred const]: items.generics.const.inferred
 [inferred type]: type.inferred
 [infinite loop expressions]: expr.loop.infinite
 [infinite loops]: expr.loop.infinite

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -228,10 +228,10 @@ This appendix provides an index of tokens and common forms with links to where t
 |---------------------------------------|-------|
 | `bool`, `u8`, `f64`, `str`, …         | [primitive types] |
 | `for<…>`                              | [higher-ranked trait bounds] |
-| `T: U`                                | [trait bounds] |
-| `T: 'a`                               | [lifetime bounds] |
+| `T: TraitA + TraitB`                  | [trait bounds] |
+| `T: 'a + 'b`                          | [lifetime bounds] |
+| `T: TraitA + 'a`                      | [trait and lifetime bounds] |
 | `T: ?Sized`                           | [relaxed trait bounds] |
-| `'a + Trait`<br>`Trait + Trait`       | [compound type bounds] |
 | `[Type; len]`                         | [array types] |
 | `(Type, …)`                           | [tuple types] |
 | `[Type, …]`                           | [slice types] |
@@ -417,6 +417,7 @@ This appendix provides an index of tokens and common forms with links to where t
 [structs]: items.struct
 [subpattern binding]: patterns.ident.scrutinized
 [super paths]: paths.qualifiers.super
+[trait and lifetime bounds]: bound
 [trait bounds]: bound
 [trait implementations]: items.impl.trait
 [trait impls]: items.impl.trait

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -6,7 +6,7 @@ This appendix provides an index of tokens and common forms with links to where t
 
 | Keyword       | Usage |
 |---------------|-------|
-| `_`           | [wildcard pattern], [inferred const], [inferred type], [placeholder lifetime], unnamed items in [constants], [extern crates], [use declarations], [destructuring assignment] |
+| `_`           | [wildcard pattern], [inferred const], [inferred type], [placeholder lifetime], unnamed [constant items], [extern crates], [use declarations], [destructuring assignment] |
 | `abstract`    | [reserved keyword] |
 | `as`          | [extern crate alias], [use alias], [type cast expressions], [qualified paths] |
 | `async`       | [async functions], [async blocks], [async closures] |
@@ -306,7 +306,6 @@ This appendix provides an index of tokens and common forms with links to where t
 [const generics]: items.generics.const
 [const items]: items.const
 [constant items]: items.const
-[constants]: items.const
 [continue expressions]: expr.loop.continue
 [crate-relative paths]: paths.qualifiers.crate
 [dereference expressions]: expr.deref

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -107,7 +107,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `;`    | Semi        | terminator for various items and statements, [array expressions], [array types] |
 | `:`    | Colon       | various separators |
 | `::`   | PathSep     | [path separator][paths] |
-| `->`   | RArrow      | [function return type][functions], [closure return type][closures], [function pointer type] |
+| `->`   | RArrow      | [functions], [closures], [function pointer type] |
 | `=>`   | FatArrow    | [match arms][match], [macros] |
 | `<-`   | LArrow      | The left arrow symbol has been unused since before Rust 1.0, but it is still treated as a single token. |
 | `#`    | Pound       | [attributes] |

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -4,8 +4,8 @@ This appendix provides an index of tokens and common forms with links to where t
 
 ## Keywords
 
-| Keyword       | Usage |
-|---------------|-------|
+| Keyword       | Use |
+|---------------|-----|
 | `_`           | [wildcard pattern], [inferred const], [inferred type], [placeholder lifetime], [constant items], [extern crate], [use declarations], [destructuring assignment] |
 | `abstract`    | [reserved keyword] |
 | `as`          | [extern crate][items.extern-crate.as], [use declarations][items.use.forms.as], [type cast expressions], [qualified paths] |
@@ -66,8 +66,8 @@ This appendix provides an index of tokens and common forms with links to where t
 
 ## Operators and punctuation
 
-| Symbol | Name        | Usage |
-|--------|-------------|-------|
+| Symbol | Name        | Use |
+|--------|-------------|-----|
 | `+`    | Plus        | [addition][arith], [trait bounds], [macro Kleene matcher] |
 | `-`    | Minus       | [subtraction][arith], [negation] |
 | `*`    | Star        | [multiplication][arith], [dereference], [raw pointers], [macro Kleene matcher], [glob imports] |
@@ -117,8 +117,8 @@ This appendix provides an index of tokens and common forms with links to where t
 
 ## Comments
 
-| Comment  | Usage |
-|----------|-------|
+| Comment  | Use |
+|----------|-----|
 | `//`     | [line comment][comments] |
 | `//!`    | [inner line comment][comments] |
 | `///`    | [outer line doc comment][comments] |
@@ -128,8 +128,8 @@ This appendix provides an index of tokens and common forms with links to where t
 
 ## Other tokens
 
-| Token        | Usage |
-|--------------|-------|
+| Token        | Use |
+|--------------|-----|
 | `ident`      | [identifiers] |
 | `r#ident`    | [raw identifiers] |
 | `'ident`     | [lifetimes and loop labels] |
@@ -146,8 +146,8 @@ This appendix provides an index of tokens and common forms with links to where t
 
 ## Macros
 
-| Syntax                                     | Usage |
-|--------------------------------------------|-------|
+| Syntax                                     | Use |
+|--------------------------------------------|-----|
 | `ident!(…)`<br>`ident! {…}`<br>`ident![…]` | [macro invocations] |
 | `$ident`                                   | [macro metavariable] |
 | `$ident:kind`                              | [macro matcher fragment specifier] |
@@ -155,15 +155,15 @@ This appendix provides an index of tokens and common forms with links to where t
 
 ## Attributes
 
-| Syntax     | Usage |
-|------------|-------|
+| Syntax     | Use |
+|------------|-----|
 | `#[meta]`  | [outer attribute] |
 | `#![meta]` | [inner attribute] |
 
 ## Expressions
 
-| Expression                | Usage |
-|---------------------------|-------|
+| Expression                | Use |
+|---------------------------|-----|
 | <code>\|…\| expr</code><br><code>\|…\| -> Type { … }</code> | [closures] |
 | `ident::…`                | [paths] |
 | `::crate_name::…`         | [explicit crate paths] |
@@ -204,8 +204,8 @@ This appendix provides an index of tokens and common forms with links to where t
 
 [Items] are the components of a crate.
 
-| Item                          | Usage |
-|-------------------------------|-------|
+| Item                          | Use |
+|-------------------------------|-----|
 | `mod ident;`<br>`mod ident {…}` | [modules] |
 | `use path;`                   | [use declarations] |
 | `fn ident(…) {…}`             | [functions] |
@@ -224,8 +224,8 @@ This appendix provides an index of tokens and common forms with links to where t
 
 [Type expressions] are used to refer to types.
 
-| Type                                  | Usage |
-|---------------------------------------|-------|
+| Type                                  | Use |
+|---------------------------------------|-----|
 | `bool`, `u8`, `f64`, `str`, …         | [primitive types] |
 | `for<…>`                              | [higher-ranked trait bounds] |
 | `T: TraitA + TraitB`                  | [trait bounds] |
@@ -253,8 +253,8 @@ This appendix provides an index of tokens and common forms with links to where t
 
 [Patterns] are used to match values.
 
-| Pattern                           | Usage |
-|-----------------------------------|-------|
+| Pattern                           | Use |
+|-----------------------------------|-----|
 | `"foo"`, `'a'`, `123`, `2.4`, …   | [literal patterns] |
 | `ident`                           | [identifier patterns] |
 | `_`                               | [wildcard pattern] |

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -1,0 +1,100 @@
+# Syntax index
+
+This appendix provides an index of tokens and common forms with links to where those elements are defined.
+
+## Keywords
+
+## Operators and punctuation
+
+| Symbol | Name        | Usage |
+|--------|-------------|-------|
+| `+`    | Plus        | [Addition][arith], [Trait Bounds], [Macro Kleene Matcher][macros]
+| `-`    | Minus       | [Subtraction][arith], [Negation]
+| `*`    | Star        | [Multiplication][arith], [Dereference], [Raw Pointers], [Macro Kleene Matcher][macros], [Use wildcards]
+| `/`    | Slash       | [Division][arith]
+| `%`    | Percent     | [Remainder][arith]
+| `^`    | Caret       | [Bitwise and Logical XOR][arith]
+| `!`    | Not         | [Bitwise and Logical NOT][negation], [Macro Calls][macros], [Inner Attributes][attributes], [Never Type], [Negative impls]
+| `&`    | And         | [Bitwise and Logical AND][arith], [Borrow], [References], [Reference patterns]
+| <code>\|</code> | Or | [Bitwise and Logical OR][arith], [Closures], Patterns in [match], [if let], and [while let]
+| `&&`   | AndAnd      | [Lazy AND][lazy-bool], [Borrow], [References], [Reference patterns]
+| <code>\|\|</code> | OrOr | [Lazy OR][lazy-bool], [Closures]
+| `<<`   | Shl         | [Shift Left][arith], [Nested Generics][generics]
+| `>>`   | Shr         | [Shift Right][arith], [Nested Generics][generics]
+| `+=`   | PlusEq      | [Addition assignment][compound]
+| `-=`   | MinusEq     | [Subtraction assignment][compound]
+| `*=`   | StarEq      | [Multiplication assignment][compound]
+| `/=`   | SlashEq     | [Division assignment][compound]
+| `%=`   | PercentEq   | [Remainder assignment][compound]
+| `^=`   | CaretEq     | [Bitwise XOR assignment][compound]
+| `&=`   | AndEq       | [Bitwise And assignment][compound]
+| <code>\|=</code> | OrEq | [Bitwise Or assignment][compound]
+| `<<=`  | ShlEq       | [Shift Left assignment][compound]
+| `>>=`  | ShrEq       | [Shift Right assignment][compound], [Nested Generics][generics]
+| `=`    | Eq          | [Assignment], [Attributes], Various type definitions
+| `==`   | EqEq        | [Equal][comparison]
+| `!=`   | Ne          | [Not Equal][comparison]
+| `>`    | Gt          | [Greater than][comparison], [Generics], [Paths]
+| `<`    | Lt          | [Less than][comparison], [Generics], [Paths]
+| `>=`   | Ge          | [Greater than or equal to][comparison], [Generics]
+| `<=`   | Le          | [Less than or equal to][comparison]
+| `@`    | At          | [Subpattern binding]
+| `.`    | Dot         | [Field access][field], [Tuple index]
+| `..`   | DotDot      | [Range][range], [Struct expressions], [Patterns], [Range Patterns][rangepat]
+| `...`  | DotDotDot   | [Variadic functions][extern], [Range patterns]
+| `..=`  | DotDotEq    | [Inclusive Range][range], [Range patterns]
+| `,`    | Comma       | Various separators
+| `;`    | Semi        | Terminator for various items and statements, [Array types]
+| `:`    | Colon       | Various separators
+| `::`   | PathSep     | [Path separator][paths]
+| `->`   | RArrow      | [Function return type][functions], [Closure return type][closures], [Function pointer type]
+| `=>`   | FatArrow    | [Match arms][match], [Macros]
+| `<-`   | LArrow      | The left arrow symbol has been unused since before Rust 1.0, but it is still treated as a single token
+| `#`    | Pound       | [Attributes]
+| `$`    | Dollar      | [Macros]
+| `?`    | Question    | [Try propagation expressions][question], [Questionably sized][sized], [Macro Kleene Matcher][macros]
+| `~`    | Tilde       | The tilde operator has been unused since before Rust 1.0, but its token may still be used
+
+[Inferred types]: types/inferred.md
+[Range patterns]: patterns.md#range-patterns
+[Reference patterns]: patterns.md#reference-patterns
+[Subpattern binding]: patterns.md#identifier-patterns
+[Wildcard patterns]: patterns.md#wildcard-pattern
+[arith]: expressions/operator-expr.md#arithmetic-and-logical-binary-operators
+[array types]: types/array.md
+[assignment]: expressions/operator-expr.md#assignment-expressions
+[attributes]: attributes.md
+[borrow]: expressions/operator-expr.md#borrow-operators
+[closures]: expressions/closure-expr.md
+[comparison]: expressions/operator-expr.md#comparison-operators
+[compound]: expressions/operator-expr.md#compound-assignment-expressions
+[constants]: items/constant-items.md
+[dereference]: expressions/operator-expr.md#the-dereference-operator
+[destructuring assignment]: expressions/underscore-expr.md
+[extern crates]: items/extern-crates.md
+[extern]: items/external-blocks.md
+[field]: expressions/field-expr.md
+[function pointer type]: types/function-pointer.md
+[functions]: items/functions.md
+[generics]: items/generics.md
+[if let]: expressions/if-expr.md#if-let-patterns
+[lazy-bool]: expressions/operator-expr.md#lazy-boolean-operators
+[macros]: macros-by-example.md
+[match]: expressions/match-expr.md
+[negation]: expressions/operator-expr.md#negation-operators
+[negative impls]: items/implementations.md
+[never type]: types/never.md
+[paths]: paths.md
+[patterns]: patterns.md
+[question]: expressions/operator-expr.md#the-try-propagation-expression
+[range]: expressions/range-expr.md
+[rangepat]: patterns.md#range-patterns
+[raw pointers]: types/pointer.md#raw-pointers-const-and-mut
+[references]: types/pointer.md
+[sized]: trait-bounds.md#sized
+[struct expressions]: expressions/struct-expr.md
+[trait bounds]: trait-bounds.md
+[tuple index]: expressions/tuple-expr.md#tuple-indexing-expressions
+[use declarations]: items/use-declarations.md
+[use wildcards]: items/use-declarations.md
+[while let]: expressions/loop-expr.md#while-let-patterns

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -173,7 +173,6 @@ This appendix provides an index of tokens and common forms with links to where t
 | `Type::…`<br>`<Type as Trait>::ident` | [associated items] |
 | `<Type>::…`               | [qualified paths] which can be used for types without names such as `<&T>::…`, `<[T]>::…`, etc. |
 | `Trait::method(…)`<br>`Type::method(…)`<br>`<Type as Trait>::method(…)` | [disambiguated method calls] |
-| `Type<…>`                 | [generic arguments] (e.g. `Vec<u8>`) <!-- TODO: fix after generic args reorg --> |
 | `method::<…>(…)`<br>`path::<…>` | [generic arguments], aka turbofish |
 | `()`                      | [unit] |
 | `(expr)`                  | [parenthesized expressions] |
@@ -240,6 +239,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `impl Trait`                          | [impl trait types], [anonymous type parameters] |
 | `dyn Trait`                           | [trait object types] |
 | `ident`<br>`ident::…`                 | [type paths] (can refer to structs, enums, unions, aliases, traits, generics, etc.) |
+| `Type<…>`<br>`Trait<…>`               | [generic arguments] (e.g. `Vec<u8>`) |
 | `Trait<ident = Type>`                 | [associated type bindings] (e.g. `Iterator<Item = T>`) |
 | `Trait<ident: …>`                     | [associated type bounds] (e.g. `Iterator<Item: Send>`) |
 | `&Type`<br>`&mut Type`                | [reference types] |

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -153,6 +153,13 @@ This appendix provides an index of tokens and common forms with links to where t
 | `$ident:kind`                             | [macro fragment specifier] |
 | `$(…)…`                                   | [macro repetition] |
 
+## Attributes
+
+| Syntax     | Usage |
+|------------|-------|
+| `#[meta]`  | [outer attribute] |
+| `#![meta]` | [inner attribute] |
+
 [`'static` lifetimes]: bound
 [`if let` patterns]: expr.if.let
 [`self` paths]: paths.qualifiers.mod-self
@@ -213,6 +220,7 @@ This appendix provides an index of tokens and common forms with links to where t
 [inferred types]: type.inferred
 [infinite loops]: expr.loop.infinite
 [inherent impls]: items.impl.inherent
+[inner attribute]: attributes.inner
 [iterator loops]: expr.loop.for
 [keywords chapter]: lex.keywords
 [lazy-bool]: expr.bool-logic
@@ -235,6 +243,7 @@ This appendix provides an index of tokens and common forms with links to where t
 [never type]: type.never
 [number literals]: lex.token.literal.num
 [or patterns]: patterns.or
+[outer attribute]: attributes.outer
 [predicate loops]: expr.loop.while
 [qualified paths]: paths.qualified
 [question]: expr.try

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -28,7 +28,7 @@ This appendix provides an index of tokens and common forms with links to where t
 | `for`         | [trait implementations], [iterator loops], [higher-ranked trait bounds] |
 | `gen`         | [reserved keyword] |
 | `if`          | [if expressions], [match guards] |
-| `impl`        | [inherent impls], [trait impls], [impl traits] |
+| `impl`        | [inherent impls], [trait impls], [impl trait types] |
 | `in`          | [visibility], [iterator loops], [assembly operands] |
 | `let`         | [let statements], [`if let` patterns] |
 | `loop`        | [infinite loops] |
@@ -338,7 +338,6 @@ This appendix provides an index of tokens and common forms with links to where t
 [if expressions]: expr.if
 [if let]: expr.if.let
 [impl trait types]: type.impl-trait
-[impl traits]: type.impl-trait
 [implementations]: items.impl
 [inferred const]: items.generics.const.inferred
 [inferred type]: type.inferred

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -6,7 +6,7 @@ This appendix provides an index of tokens and common forms with links to where t
 
 | Keyword       | Usage |
 |---------------|-------|
-| `_`           | [wildcard pattern], [inferred const], [inferred type], [placeholder lifetime], unnamed [constant items], [extern crate], [use declarations], [destructuring assignment] |
+| `_`           | [wildcard pattern], [inferred const], [inferred type], [placeholder lifetime], [constant items], [extern crate], [use declarations], [destructuring assignment] |
 | `abstract`    | [reserved keyword] |
 | `as`          | [extern crate][items.extern-crate.as], [use declarations][items.use.forms.as], [type cast expressions], [qualified paths] |
 | `async`       | [async functions], [async blocks], [async closures] |

--- a/src/syntax-index.md
+++ b/src/syntax-index.md
@@ -160,18 +160,128 @@ This appendix provides an index of tokens and common forms with links to where t
 | `#[meta]`  | [outer attribute] |
 | `#![meta]` | [inner attribute] |
 
+## Expressions
+
+| Expression                | Usage |
+|---------------------------|-------|
+| <code>\|…\| expr</code>   | [closures] |
+| `ident::…`                | [paths] |
+| `::crate_name::…`         | [explicit crate paths] |
+| `crate::…`                | [crate-relative paths] |
+| `self::…`                 | [module-relative paths] |
+| `super::…`                | [parent module paths] |
+| `Type::…`<br>`<type as trait>::ident` | [associated items] |
+| `<Type>::…`               | [qualified paths] which can be used for types without names such as `<&T>::…`, `<[T]>::…`, etc. |
+| `Trait::method(…)`<br>`Type::method(…)`<br>`<Type as Trait>::method(…)` | [disambiguated method calls] |
+| `Type<…>`                 | [generic arguments] (e.g. `Vec<u8>`) <!-- TODO: fix after generic args reorg --> |
+| `method::<…>(…)`<br>`path::<…>` | [generic arguments], aka turbofish |
+| `Type<ident=Type>`        | [explicit associated type bounds] (e.g. `Iterator<Item=T>`) <!-- undocumented https://github.com/rust-lang/reference/issues/24 --> |
+| `()`                      | [unit] |
+| `(expr)`                  | [parenthesized expressions] |
+| `(expr,)`                 | [single-element tuple expression] |
+| `(expr, …)`               | [tuple expressions] |
+| `expr(expr, …)`           | [call expressions] |
+| `expr.0`, `expr.1`, …     | [tuple indexing expressions] |
+| `expr.ident`              | [field access expressions] |
+| `{…}`                     | [block expressions] |
+| `Type{…}`                 | [struct expressions] |
+| `Type(…)`                 | [tuple struct constructors] |
+| `[…]`                     | [array expressions] |
+| `[expr; len]`             | [repeat array expressions] |
+| `expr[..]`, `expr[a..]`, `expr[..b]`, `expr[a..b]`, `expr[a..=b]`, `expr[..=b]` | [array and slice indexing expressions] |
+| `if expr {…} else {…}`    | [if expressions] |
+| `match expr { pattern => {…} }` | [match expressions] |
+| `loop {…}`                | [infinite loop expressions] |
+| `while expr {…}`          | [predicate loop expressions] |
+| `for pattern in expr {…}` | [iterator loops] |
+| `&expr`<br>`&mut expr`    | [borrow expressions] |
+| `&raw const expr`<br>`&raw mut expr` | [raw borrow expressions] |
+| `*expr`                   | [dereference expressions] |
+| `expr?`                   | [try propagation expressions] |
+| `-expr`                   | [negation expressions] |
+| `!expr`                   | [bitwise and logical NOT expressions] |
+| `expr as Type`            | [type cast expressions] |
+
+## Items
+
+[Items] are declarations in a crate.
+
+| Item                          | Usage |
+|-------------------------------|-------|
+| `mod ident;`<br>`mod ident {…}` | [modules] |
+| `use path;`                   | [use declarations] |
+| `fn ident(…) {…}`             | [functions] |
+| `type Type = Type`            | [type aliases] |
+| `struct ident {…}`            | [structs] |
+| `enum ident {…}`              | [enumerations] |
+| `union ident {…}`             | [unions] |
+| `trait ident {…}`             | [traits] |
+| `impl Type {…}`<br>`impl Type for Trait {…}` | [implementations] |
+| `const ident = expr`          | [constant items] |
+| `static ident = expr`         | [static items] |
+| `extern "C" {…}`              | [external blocks] |
+| `fn ident<…>(…) …`<br>`struct ident<…> {…}`<br>`enum ident<…> {…}`<br>`impl<…> Type<…> {…}` | [generic definitions] |
+
+## Type expressions
+
+[Type expressions] are used to refer to types.
+
+| Type                                  | Usage |
+|---------------------------------------|-------|
+| `bool`, `u8`, `f64`, `char`, `str`    | [primitive types] |
+| `for<…>`                              | [higher-ranked trait bounds] |
+| `T: U`                                | [trait bounds] |
+| `T: 'a`                               | [lifetime bounds] |
+| `T: ?Sized`                           | [relaxed trait bounds] |
+| `'a + Trait`<br>`Trait + Trait`       | [compound type bounds] |
+| `[Type; len]`                         | [array types] |
+| `(Type, …)`                           | [tuple types] |
+| `[Type, …]`                           | [slice types] |
+| `(Type)`                              | [parenthesized types] |
+| `impl Trait`                          | [impl trait types] |
+| `dyn Trait`                           | [trait object types] |
+| `ident`<br>`ident::…`                 | [type paths] (can refer to structs, enums, unions, aliases, traits, generics, etc.) |
+| `&Type`<br>`&mut Type`                | [reference types] |
+| `*mut Type`<br>`*const Type`          | [raw pointer types] |
+| `fn(…) -> Type`                       | [function pointer types] |
+| `_`                                   | [inferred type] |
+| `!`                                   | [never type] |
+
+## Patterns
+
+[Patterns] are used to match values.
+
+| Pattern                           | Usage |
+|-----------------------------------|-------|
+| `"foo"`, `'a'`, `123`, `2.4`, …   | [literal patterns] |
+| `ident`                           | [identifier patterns] |
+| `_`                               | [wildcard patterns] |
+| `..`                              | [rest patterns] |
+| `&pattern`<br>`&mut pattern`      | [reference patterns] |
+| `path{…}`                         | [struct patterns] |
+| `path(…)`                         | [tuple struct patterns] |
+| `(pattern, …)`                    | [tuple patterns] |
+| `(pattern)`                       | [grouped patterns] |
+| `[pattern, …]`                    | [slice patterns] |
+| `CONST`, `Enum::Variant`, …       | [path patterns] |
+
 [`'static` lifetimes]: bound
 [`if let` patterns]: expr.if.let
 [`self` paths]: paths.qualifiers.mod-self
 [`Self` type paths]: paths.qualifiers.type-self
 [arith]: expr.arith-logic
+[array and slice indexing expressions]: expr.array.index
+[array expressions]: expr.array
 [array types]: type.array
 [assembly operands]: asm.operand-type.supported-operands.in
 [assignment]: expr.assign
+[associated items]: items.associated
 [async blocks]: expr.block.async
 [async closures]: expr.closure.async
 [async functions]: items.fn.async
 [await expressions]: expr.await
+[bitwise and logical NOT expressions]: expr.negate
+[block expressions]: expr.block
 [boolean expressions]: expr.literal
 [boolean type]: type.bool
 [borrow expressions]: expr.operator.borrow
@@ -180,10 +290,12 @@ This appendix provides an index of tokens and common forms with links to where t
 [byte literals]: lex.token.byte
 [byte string literals]: lex.token.str-byte
 [C string literals]: lex.token.str-c
+[call expressions]: expr.call
 [character literals]: lex.token.literal.char
 [closure expressions]: expr.closure
 [closures]: expr.closure
 [comparison]: expr.cmp
+[compound type bounds]: bound
 [compound]: expr.compound-assign
 [configuration predicates]: cfg
 [const assembly operands]: asm.operand-type.supported-operands.const
@@ -191,11 +303,17 @@ This appendix provides an index of tokens and common forms with links to where t
 [const functions]: const-eval.const-fn
 [const generics]: items.generics.const
 [const items]: items.const
+[constant items]: items.const
 [constants]: items.const
 [continue expressions]: expr.loop.continue
+[crate-relative paths]: paths.qualifiers.crate
+[dereference expressions]: expr.deref
 [dereference]: expr.deref
 [destructuring assignment]: expr.placeholder
+[disambiguated method calls]: expr.call.desugar
 [enumerations]: items.enum
+[explicit associated type bounds]: paths.expr
+[explicit crate paths]: paths.qualifiers.global-root
 [extern crate alias]: items.extern-crate.as
 [extern crate]: items.extern-crate
 [extern crates]: items.extern-crate
@@ -205,19 +323,27 @@ This appendix provides an index of tokens and common forms with links to where t
 [external block functions]: items.extern.fn
 [external block statics]: items.extern.static
 [external blocks]: items.extern
+[field access expressions]: expr.field
 [field]: expr.field
 [function pointer type]: type.fn-pointer
 [function pointer types]: type.fn-pointer
 [functions]: items.fn
+[generic arguments]: items.generics
+[generic definitions]: items.generics
 [generics]: items.generics
 [glob imports]: items.use.glob
+[grouped patterns]: patterns.paren
 [higher-ranked trait bounds]: bound.higher-ranked
 [identifier patterns]: patterns.ident
 [identifiers]: ident
 [if expressions]: expr.if
 [if let]: expr.if.let
+[impl trait types]: type.impl-trait
 [impl traits]: type.impl-trait
+[implementations]: items.impl
+[inferred type]: type.inferred
 [inferred types]: type.inferred
+[infinite loop expressions]: expr.loop.infinite
 [infinite loops]: expr.loop.infinite
 [inherent impls]: items.impl.inherent
 [inner attribute]: attributes.inner
@@ -225,7 +351,9 @@ This appendix provides an index of tokens and common forms with links to where t
 [keywords chapter]: lex.keywords
 [lazy-bool]: expr.bool-logic
 [let statements]: statement.let
+[lifetime bounds]: bound.lifetime
 [lifetimes and loop labels]: lex.token.life
+[literal patterns]: patterns.literal
 [macro calls]: macro.invocation
 [macro fragment specifier]: macro.decl.meta.specifier
 [macro fragment substitution]: macro.decl.meta.transcription
@@ -237,18 +365,27 @@ This appendix provides an index of tokens and common forms with links to where t
 [match expressions]: expr.match
 [match guards]: expr.match.guard
 [match]: expr.match
+[module-relative paths]: paths.qualifiers.mod-self
 [modules]: items.mod
+[negation expressions]: expr.negate
 [negation]: expr.negate
 [negative impls]: items.impl
 [never type]: type.never
 [number literals]: lex.token.literal.num
 [or patterns]: patterns.or
 [outer attribute]: attributes.outer
+[parent module paths]: paths.qualifiers.super
+[parenthesized expressions]: expr.paren
+[parenthesized types]: type.name.parenthesized
+[path patterns]: patterns.path
+[predicate loop expressions]: expr.loop.while
 [predicate loops]: expr.loop.while
+[primitive types]: type.kinds
 [qualified paths]: paths.qualified
 [question]: expr.try
 [range patterns]: patterns.range
 [raw assembly]: asm.options.supported-options.raw
+[raw borrow expressions]: expr.borrow.raw
 [raw borrow operator]: expr.borrow.raw
 [raw byte string literals]: lex.token.str-byte-raw
 [raw C string literals]: lex.token.str-c-raw
@@ -261,11 +398,16 @@ This appendix provides an index of tokens and common forms with links to where t
 [reference patterns]: patterns.ref
 [reference types]: type.pointer.reference
 [references]: type.pointer.reference
+[relaxed trait bounds]: bound.sized
+[repeat array expressions]: expr.array
 [reserved keyword]: lex.keywords.reserved
 [rest patterns]: patterns.rest
 [return expressions]: expr.return
 [self parameters]: items.fn.params.self-pat
+[single-element tuple expression]: expr.tuple
 [sized]: bound.sized
+[slice patterns]: patterns.slice
+[slice types]: type.slice
 [static items]: items.static
 [string literals]: lex.token.literal.str
 [struct expressions]: expr.struct
@@ -277,11 +419,24 @@ This appendix provides an index of tokens and common forms with links to where t
 [trait implementations]: items.impl.trait
 [trait impls]: items.impl.trait
 [trait items]: items.traits
+[trait object types]: type.trait-object
 [trait objects]: type.trait-object
+[traits]: items.traits
+[try propagation expressions]: expr.try
+[tuple expressions]: expr.tuple
 [tuple index]: expr.tuple-index
+[tuple indexing expressions]: expr.tuple-index
+[tuple patterns]: patterns.tuple
+[tuple struct constructors]: items.struct.tuple
+[tuple struct patterns]: patterns.tuple-struct
+[tuple types]: type.tuple
 [type aliases]: items.type
 [type cast expressions]: expr.as
+[Type expressions]: type.name
+[type paths]: type.name.path
 [union items]: items.union
+[unions]: items.union
+[unit]: type.tuple.unit
 [unsafe attributes]: attributes.safety
 [unsafe external blocks]: unsafe.extern
 [unsafe external functions]: items.extern.fn.safety

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -855,6 +855,9 @@ PUNCTUATION ->
     | `)`
 ```
 
+> [!NOTE]
+> See the [syntax index] for links to how punctuation characters are used.
+
 r[lex.token.delim]
 ## Delimiters
 
@@ -977,6 +980,7 @@ r[lex.token.reserved-guards.edition2024]
 [loop labels]: expressions/loop-expr.md
 [macros]: macros-by-example.md
 [String continuation escapes]: expressions/literal-expr.md#string-continuation-escapes
+[syntax index]: syntax-index.md#operators-and-punctuation
 [tuple structs]: items/structs.md
 [tuple enum variants]: items/enumerations.md
 [tuples]: types/tuple.md

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -795,6 +795,9 @@ r[lex.token.life.raw.edition2021]
 r[lex.token.punct]
 ## Punctuation
 
+r[lex.token.punct.intro]
+Punctuation tokens are used as operators, separators, and other parts of the grammar.
+
 r[lex.token.punct.syntax]
 ```grammar,lexer
 PUNCTUATION ->
@@ -851,59 +854,6 @@ PUNCTUATION ->
     | `(`
     | `)`
 ```
-
-r[lex.token.punct.intro]
-Punctuation symbol tokens are listed here for completeness. Their individual
-usages and meanings are defined in the linked pages.
-
-| Symbol | Name        | Usage |
-|--------|-------------|-------|
-| `+`    | Plus        | [Addition][arith], [Trait Bounds], [Macro Kleene Matcher][macros]
-| `-`    | Minus       | [Subtraction][arith], [Negation]
-| `*`    | Star        | [Multiplication][arith], [Dereference], [Raw Pointers], [Macro Kleene Matcher][macros], [Use wildcards]
-| `/`    | Slash       | [Division][arith]
-| `%`    | Percent     | [Remainder][arith]
-| `^`    | Caret       | [Bitwise and Logical XOR][arith]
-| `!`    | Not         | [Bitwise and Logical NOT][negation], [Macro Calls][macros], [Inner Attributes][attributes], [Never Type], [Negative impls]
-| `&`    | And         | [Bitwise and Logical AND][arith], [Borrow], [References], [Reference patterns]
-| <code>\|</code> | Or | [Bitwise and Logical OR][arith], [Closures], Patterns in [match], [if let], and [while let]
-| `&&`   | AndAnd      | [Lazy AND][lazy-bool], [Borrow], [References], [Reference patterns]
-| <code>\|\|</code> | OrOr | [Lazy OR][lazy-bool], [Closures]
-| `<<`   | Shl         | [Shift Left][arith], [Nested Generics][generics]
-| `>>`   | Shr         | [Shift Right][arith], [Nested Generics][generics]
-| `+=`   | PlusEq      | [Addition assignment][compound]
-| `-=`   | MinusEq     | [Subtraction assignment][compound]
-| `*=`   | StarEq      | [Multiplication assignment][compound]
-| `/=`   | SlashEq     | [Division assignment][compound]
-| `%=`   | PercentEq   | [Remainder assignment][compound]
-| `^=`   | CaretEq     | [Bitwise XOR assignment][compound]
-| `&=`   | AndEq       | [Bitwise And assignment][compound]
-| <code>\|=</code> | OrEq | [Bitwise Or assignment][compound]
-| `<<=`  | ShlEq       | [Shift Left assignment][compound]
-| `>>=`  | ShrEq       | [Shift Right assignment][compound], [Nested Generics][generics]
-| `=`    | Eq          | [Assignment], [Attributes], Various type definitions
-| `==`   | EqEq        | [Equal][comparison]
-| `!=`   | Ne          | [Not Equal][comparison]
-| `>`    | Gt          | [Greater than][comparison], [Generics], [Paths]
-| `<`    | Lt          | [Less than][comparison], [Generics], [Paths]
-| `>=`   | Ge          | [Greater than or equal to][comparison], [Generics]
-| `<=`   | Le          | [Less than or equal to][comparison]
-| `@`    | At          | [Subpattern binding]
-| `.`    | Dot         | [Field access][field], [Tuple index]
-| `..`   | DotDot      | [Range][range], [Struct expressions], [Patterns], [Range Patterns][rangepat]
-| `...`  | DotDotDot   | [Variadic functions][extern], [Range patterns]
-| `..=`  | DotDotEq    | [Inclusive Range][range], [Range patterns]
-| `,`    | Comma       | Various separators
-| `;`    | Semi        | Terminator for various items and statements, [Array types]
-| `:`    | Colon       | Various separators
-| `::`   | PathSep     | [Path separator][paths]
-| `->`   | RArrow      | [Function return type][functions], [Closure return type][closures], [Function pointer type]
-| `=>`   | FatArrow    | [Match arms][match], [Macros]
-| `<-`   | LArrow      | The left arrow symbol has been unused since before Rust 1.0, but it is still treated as a single token
-| `#`    | Pound       | [Attributes]
-| `$`    | Dollar      | [Macros]
-| `?`    | Question    | [Try propagation expressions][question], [Questionably sized][sized], [Macro Kleene Matcher][macros]
-| `~`    | Tilde       | The tilde operator has been unused since before Rust 1.0, but its token may still be used
 
 r[lex.token.delim]
 ## Delimiters
@@ -1019,59 +969,14 @@ r[lex.token.reserved-guards.edition2024]
 > [!EDITION-2024]
 > Before the 2024 edition, reserved guards are accepted by the lexer and interpreted as multiple tokens. For example, the `#"foo"#` form is interpreted as three tokens. `##` is interpreted as two tokens.
 
-[Inferred types]: types/inferred.md
-[Range patterns]: patterns.md#range-patterns
-[Reference patterns]: patterns.md#reference-patterns
-[Subpattern binding]: patterns.md#identifier-patterns
-[Wildcard patterns]: patterns.md#wildcard-pattern
-[arith]: expressions/operator-expr.md#arithmetic-and-logical-binary-operators
-[array types]: types/array.md
-[assignment]: expressions/operator-expr.md#assignment-expressions
-[attributes]: attributes.md
-[borrow]: expressions/operator-expr.md#borrow-operators
-[closures]: expressions/closure-expr.md
-[comparison]: expressions/operator-expr.md#comparison-operators
-[compound]: expressions/operator-expr.md#compound-assignment-expressions
-[constants]: items/constant-items.md
-[dereference]: expressions/operator-expr.md#the-dereference-operator
-[destructuring assignment]: expressions/underscore-expr.md
-[extern crates]: items/extern-crates.md
-[extern]: items/external-blocks.md
-[field]: expressions/field-expr.md
 [Floating-point literal expressions]: expressions/literal-expr.md#floating-point-literal-expressions
-[floating-point types]: types/numeric.md#floating-point-types
-[function pointer type]: types/function-pointer.md
-[functions]: items/functions.md
-[generics]: items/generics.md
 [identifier]: identifiers.md
-[if let]: expressions/if-expr.md#if-let-patterns
 [Integer literal expressions]: expressions/literal-expr.md#integer-literal-expressions
 [keywords]: keywords.md
-[lazy-bool]: expressions/operator-expr.md#lazy-boolean-operators
 [literal expressions]: expressions/literal-expr.md
 [loop labels]: expressions/loop-expr.md
 [macros]: macros-by-example.md
-[match]: expressions/match-expr.md
-[negation]: expressions/operator-expr.md#negation-operators
-[negative impls]: items/implementations.md
-[never type]: types/never.md
-[numeric types]: types/numeric.md
-[paths]: paths.md
-[patterns]: patterns.md
-[question]: expressions/operator-expr.md#the-try-propagation-expression
-[range]: expressions/range-expr.md
-[rangepat]: patterns.md#range-patterns
-[raw pointers]: types/pointer.md#raw-pointers-const-and-mut
-[references]: types/pointer.md
-[sized]: trait-bounds.md#sized
 [String continuation escapes]: expressions/literal-expr.md#string-continuation-escapes
-[struct expressions]: expressions/struct-expr.md
-[trait bounds]: trait-bounds.md
-[tuple index]: expressions/tuple-expr.md#tuple-indexing-expressions
 [tuple structs]: items/structs.md
 [tuple enum variants]: items/enumerations.md
 [tuples]: types/tuple.md
-[unary minus operator]: expressions/operator-expr.md#negation-operators
-[use declarations]: items/use-declarations.md
-[use wildcards]: items/use-declarations.md
-[while let]: expressions/loop-expr.md#while-let-patterns


### PR DESCRIPTION
This adds a new syntax index which shows some common, potentially hard-to-search syntax examples along with links to the definitions for those forms.

This is based on the syntax index that is in the book (https://doc.rust-lang.org/1.90.0/book/appendix-02-operators.html). There have been occasional requests for this, with links in the reference.

I decided to organize it by concepts instead of by syntax. For example `(…)` could be a grouped expression, type, or pattern. However, I think the amount of overlap between concepts is small, and I liked the idea of emphasizing the distinction of these concepts to really convey that they should not be conflated. But I would also be open to a more syntax-based organization.

This is not intended to be 100% exhaustive. There are many permutations and qualifiers, and I felt it would just make the list too long to try to cover everything.

Closes https://github.com/rust-lang/reference/issues/211
