### PR TITLE
document `min_global_align`

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -120,6 +120,8 @@
 
 - [Inline assembly](inline-assembly.md)
 
+- [Target properties](target-properties.md)
+
 - [Unsafety](unsafety.md)
     - [The `unsafe` keyword](unsafe-keyword.md)
     - [Behavior considered undefined](behavior-considered-undefined.md)

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -252,6 +252,12 @@ string slice type is `&str`, while the mutable string slice type is `&mut str`.
 
 Strings slices are always valid UTF-8.
 
+### Symbol
+
+A symbol is a name used to refer to code or data in an executable format (e.g. ELF or Macho).
+
+A `static` emits a data symbol, functions emit code symbols.
+
 ### Trait
 
 A trait is a language item that is used for describing the functionalities a type must provide.

--- a/src/items/static-items.md
+++ b/src/items/static-items.md
@@ -24,6 +24,10 @@ If the `static` has a size of at least 1 byte, this allocation is disjoint from 
 immutable `static` items can overlap with allocations that do not themselves have a unique address, such
 as [promoteds] and [`const` items][constant].
 
+r[items.static.symbol]
+A static item produces a data [symbol]. The visibility and mangling of the symbol name can be adjusted with
+attributes like [`no_mangle`] and [`export_name`].
+
 r[items.static.namespace]
 The static declaration defines a static value in the [value namespace] of the module or block where it is located.
 
@@ -168,3 +172,6 @@ following are true:
 [interior mutable]: ../interior-mutability.md
 [value namespace]: ../names/namespaces.md
 [promoteds]: ../destructors.md#constant-promotion
+[symbol]: ../glossary.md#symbol
+[`no_mangle`]: ../abi.md#the-no_mangle-attribute
+[`export_name`]: ../abi.md#the-export_name-attribute

--- a/src/target-properties.md
+++ b/src/target-properties.md
@@ -1,0 +1,13 @@
+r[target-properties]
+# Target properties
+
+r[target-properties.pointer-width]
+The size of a pointer in bits is equal to the `pointer_width` specified by the target.
+
+r[target-properties.endianness]
+The endianness is equal to the `options.endian` specified by the target.
+
+r[target-properties.min_global_align]
+Every data [symbol] is aligned to at least the `options.min_global_align` specified by the target.
+
+[symbol]: glossary.md#symbol


### PR DESCRIPTION
related to https://github.com/rust-lang/rust/pull/142198
zullip thread: [#t-lang-docs/reference > respecting &#96;target.min_global_align&#96;](https://rust-lang.zulipchat.com/#narrow/channel/520709-t-lang-docs.2Freference/topic/respecting.20.60target.2Emin_global_align.60/with/547000981)
