### PR TITLE
Guarantee the binary representation of `isize` explicitly

### DIFF
--- a/src/types/numeric.md
+++ b/src/types/numeric.md
@@ -44,7 +44,7 @@ platform's pointer type. It can represent every memory address in the process.
 > For more information, see the documentation for [type cast expressions], [`std::ptr`], and [provenance][std::ptr#provenance] in particular.
 
 r[type.numeric.int.size.isize]
-The `isize` type is a signed integer type with the same number of bits as the
+The `isize` type is a signed two's complement integer type with the same number of bits as the
 platform's pointer type. The theoretical upper bound on object and array size
 is the maximum `isize` value. This ensures that `isize` can be used to calculate
 differences between pointers into an object or array and can address every byte


### PR DESCRIPTION
Following the discussion in https://github.com/rust-lang/rust/pull/147960, this adds an explicit guarantee that `isize` is represented with two's complement.

This is not intended as a new guarantee, but only as stating what is already mentioned in [other places of the reference](https://github.com/rust-lang/reference/blob/76d5c4649efcdf3867ce3d319f6f7f27c3d51184/src/expressions/operator-expr.md?plain=1#L328) in the same place as it is for fixed-width integer types:

> Remember that signed integers are always represented using two's complement.

r? @traviscross