### PR TITLE
Use American spelling for "labeled"

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -23,8 +23,10 @@ use-boolean-and = true
 
 [output.html.redirect]
 "/crates-and-source-files.html#preludes-and-no_std" = "names/preludes.html"
+"/expressions/block-expr.html#labelled-block-expressions" = "block-expr.html#labeled-block-expressions"
 "/expressions/enum-variant-expr.html" = "struct-expr.html"
 "/expressions/if-expr.html#if-let-expressions" = "if-expr.html#if-let-patterns"
+"/expressions/loop-expr.html#labelled-block-expressions" = "loop-expr.html#labeled-block-expressions"
 "/expressions/loop-expr.html#predicate-pattern-loops" = "loop-expr.html#while-let-patterns"
 "/expressions/operator-expr.html#slice-dst-pointer-to-pointer-cast" = "operator-expr.html#pointer-to-pointer-cast"
 "/expressions/operator-expr.html#the-question-mark-operator" = "operator-expr.html#the-try-propagation-expression"

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -247,9 +247,9 @@ let a = unsafe { an_unsafe_fn() };
 ```
 
 r[expr.block.label]
-## Labelled block expressions
+## Labeled block expressions
 
-Labelled block expressions are documented in the [Loops and other breakable expressions] section.
+Labeled block expressions are documented in the [Loops and other breakable expressions] section.
 
 r[expr.block.attributes]
 ## Attributes on block expressions
@@ -301,4 +301,4 @@ fn is_unix_platform() -> bool {
 [tuple expressions]: tuple-expr.md
 [unsafe operations]: ../unsafety.md
 [value expressions]: ../expressions.md#place-expressions-and-value-expressions
-[Loops and other breakable expressions]: loop-expr.md#labelled-block-expressions
+[Loops and other breakable expressions]: expr.loop.block-labels

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -18,16 +18,16 @@ Rust supports four loop expressions:
 *   A [`loop` expression](#infinite-loops) denotes an infinite loop.
 *   A [`while` expression](#predicate-loops) loops until a predicate is false.
 *   A [`for` expression](#iterator-loops) extracts values from an iterator, looping until the iterator is empty.
-*   A [labelled block expression](#labelled-block-expressions) runs a loop exactly once, but allows exiting the loop early with `break`.
+*   A [labeled block expression][expr.loop.block-labels] runs a loop exactly once, but allows exiting the loop early with `break`.
 
 r[expr.loop.break-label]
 All four types of loop support [`break` expressions](#break-expressions), and [labels](#loop-labels).
 
 r[expr.loop.continue-label]
-All except labelled block expressions support [`continue` expressions](#continue-expressions).
+All except labeled block expressions support [`continue` expressions](#continue-expressions).
 
 r[expr.loop.explicit-result]
-Only `loop` and labelled block expressions support [evaluation to non-trivial values](#break-and-loop-values).
+Only `loop` and labeled block expressions support [evaluation to non-trivial values](#break-and-loop-values).
 
 r[expr.loop.infinite]
 ## Infinite loops
@@ -309,7 +309,7 @@ r[expr.loop.break.value]
 A `break` expression is only permitted in the body of a loop, and has one of the forms `break`, `break 'label` or ([see below](#break-and-loop-values)) `break EXPR` or `break 'label EXPR`.
 
 r[expr.loop.block-labels]
-## Labelled block expressions
+## Labeled block expressions
 
 r[expr.loop.block-labels.syntax]
 ```grammar,expressions
@@ -317,13 +317,13 @@ LabelBlockExpression -> BlockExpression
 ```
 
 r[expr.loop.block-labels.intro]
-Labelled block expressions are exactly like block expressions, except that they allow using `break` expressions within the block.
+Labeled block expressions are exactly like block expressions, except that they allow using `break` expressions within the block.
 
 r[expr.loop.block-labels.break]
-Unlike loops, `break` expressions within a labelled block expression *must* have a label (i.e. the label is not optional).
+Unlike loops, `break` expressions within a labeled block expression *must* have a label (i.e. the label is not optional).
 
 r[expr.loop.block-labels.label-required]
-Similarly, labelled block expressions *must* begin with a label.
+Similarly, labeled block expressions *must* begin with a label.
 
 ```rust
 # fn do_thing() {}

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -710,7 +710,7 @@ For more detail, see the [formal specification].
 
 [`extern crate self`]: items.extern-crate.self
 [`macro_use` prelude]: names/preludes.md#macro_use-prelude
-[block labels]: expressions/loop-expr.md#labelled-block-expressions
+[block labels]: expr.loop.block-labels
 [delimiters]: tokens.md#delimiters
 [formal specification]: macro-ambiguity.md
 [Hygiene]: #hygiene

--- a/src/names/namespaces.md
+++ b/src/names/namespaces.md
@@ -137,7 +137,7 @@ It is still an error for a [`use` import] to shadow another macro, regardless of
 [Attribute macros]: ../procedural-macros.md#the-proc_macro_attribute-attribute
 [attributes]: ../attributes.md
 [bang-style macros]: ../macros.md
-[Block labels]: ../expressions/loop-expr.md#labelled-block-expressions
+[Block labels]: expr.loop.block-labels
 [boolean]: ../types/boolean.md
 [Built-in attributes]: ../attributes.md#built-in-attributes-index
 [closure parameters]: ../expressions/closure-expr.md


### PR DESCRIPTION
We follow American spellings in the Reference, but we had used the Commonwealth spelling "labelled" rather than the American spelling "labeled".  Let's fix that and add the appropriate redirects.

cc @ehuss
