### PR TITLE
Add a chapter on divergence

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -98,6 +98,7 @@
     - [Subtyping and variance](subtyping.md)
     - [Trait and lifetime bounds](trait-bounds.md)
     - [Type coercions](type-coercions.md)
+    - [Divergence](divergence.md)
     - [Destructors](destructors.md)
     - [Lifetime elision](lifetime-elision.md)
 

--- a/src/divergence.md
+++ b/src/divergence.md
@@ -19,6 +19,8 @@ See the following rules for specific expression divergence behavior:
 
 - [expr.block.diverging] --- Block expressions.
 - [expr.if.diverging] --- `if` expressions.
+- [expr.loop.block-labels.type] --- Labeled block expressions with `break`.
+- [expr.loop.break-value.diverging] --- `loop` expressions with `break`.
 - [expr.loop.break.diverging] --- `break` expressions.
 - [expr.loop.continue.diverging] --- `continue` expressions.
 - [expr.loop.infinite.diverging] --- Infinite `loop` expressions.

--- a/src/divergence.md
+++ b/src/divergence.md
@@ -18,10 +18,13 @@ The following language constructs unconditonally produce a _diverging expression
 * [A `continue` expression](./expressions/loop-expr.md#r-expr.loop.continue.type)
 * [A `return` expression](./expressions/return-expr.md#r-expr.return.type)
 * [A `match` expression with no arms](./expressions/match-expr.md#r-expr.match.type.diverging.empty)
-* [A `block` expression that it itself is diverging.](../expressions/block-expr.md#r-expr.block.type.diverging)
+* [A `block` expression that it itself is diverging.](./expressions/block-expr.md#r-expr.block.type.diverging)
 
 r[divergence.diverging-expressions.conditional]
 In a control flow expression, if all arms diverge, then the entire expression also diverges.
+
+r[divergence.diverging-expressions.place-expressions]
+A place expression of the type [`!`](./types/never.md) is considering _diverging_ only if it is read from.
 
 r[divergence.fallback]
 ## Fallback

--- a/src/divergence.md
+++ b/src/divergence.md
@@ -16,13 +16,13 @@ Any expression of type [`!`] is a _diverging expression_, but there are also div
 >
 > fn diverging() -> ! {
 >     // This has a type of `!`.
->     // So, the entire function is considered diverging
+>     // So, the entire function is considered diverging.
 >     make_never();
 >     // OK: The type of the body is `!` which matches the return type.
 > }
 > fn not_diverging() -> ! {
 >     // This type is uninhabited.
->     // However, the entire function is not considered diverging
+>     // However, the entire function is not considered diverging.
 >     make_empty();
 >     // ERROR: The type of the body is `()` but expected type `!`.
 > }

--- a/src/divergence.md
+++ b/src/divergence.md
@@ -1,0 +1,52 @@
+r[divergence]
+# Divergence
+
+r[divergence.intro]
+Divergence is the state where a particular section of code could never be encountered at runtime. Importantly, while there are certain language constructs that immediately produce a _diverging expression_ of the type [`!`](./types/never.md), divergence can also propogate to the surrounding block.
+
+Any expression of type [`!`](./types/never.md) is a _diverging expression_, but there are also diverging expressions which are not of type `!` (e.g. `Some(panic!())`).
+
+r[divergence.diverging-expressions]
+## Producing diverging expressions
+
+r[divergence.diverging-expressions.unconditional]
+The following language constructs unconditonally produce a _diverging expression_ of the type [`!`](./types/never.md):
+
+* [A call to a function returning `!`.](./types/never.md#r-type.never.constraint)
+* [A `loop` expression with no corresponding break.](./expressions/loop-expr.md#r-expr.loop.infinite.diverging)
+* [A `break` expression](./expressions/loop-expr.md#r-expr.loop.break.type)
+* [A `continue` expression](./expressions/loop-expr.md#r-expr.loop.continue.type)
+* [A `return` expression](./expressions/return-expr.md#r-expr.return.type)
+* [A `match` expression with no arms](./expressions/match-expr.md#r-expr.match.type.diverging.empty)
+* [A `block` expression that it itself is diverging.](../expressions/block-expr.md#r-expr.block.type.diverging)
+
+r[divergence.diverging-expressions.conditional]
+In a control flow expression, if all arms diverge, then the entire expression also diverges.
+
+r[divergence.fallback]
+## Fallback
+If a type to be inferred is only unified with diverging expressions, then that type will be inferred to be `!`.
+
+The following fails to compile because `!` does not implement `Debug`:
+```rust,compile_fail,E0277
+fn foo() -> i32 { 22 }
+match foo() {
+    4 => Default::default(),
+    _ => return,
+};
+```
+
+> [!EDITION-2024]
+> Before the 2024 edition, the type was inferred to instead be `()`.
+
+Importantly, type unification may happen *structurally*, so the fallback `!` may be part of a larger type. The following compiles:
+```rust
+fn foo() -> i32 { 22 }
+// This has the type `Option<!>`, not `!`
+match foo() {
+    4 => Default::default(),
+    _ => Some(return),
+};
+```
+
+<!-- TODO: This last point should likely should be moved to a more general "type inference" section discussing generalization + unification. -->

--- a/src/divergence.md
+++ b/src/divergence.md
@@ -30,8 +30,6 @@ See the following rules for specific expression divergence behavior:
 > [!NOTE]
 > The [`panic!`] macro and related panic-generating macros like [`unreachable!`] also have the type [`!`] and are diverging.
 
-Importantly, while there are certain language constructs that immediately produce a _diverging expression_ of the type [`!`], divergence can also propogate to the surrounding block --- where divergence indicates that the block itself will never finish executing.
-
 r[divergence.never]
 Any expression of type [`!`] is a diverging expression. However, diverging expressions are not limited to type [`!`]; expressions of other types may also diverge (e.g., `Some(loop {})` has type `Option<!>`).
 
@@ -56,6 +54,9 @@ Any expression of type [`!`] is a diverging expression. However, diverging expre
 >     // ERROR: The type of the body is `()` but expected type `!`.
 > }
 > ```
+
+> [!NOTE]
+> Divergence can propagate to the surrounding block. See [expr.block.diverging].
 
 r[divergence.fallback]
 ## Fallback

--- a/src/divergence.md
+++ b/src/divergence.md
@@ -6,6 +6,25 @@ Divergence is the state where a particular section of code could never be encoun
 
 Any expression of type [`!`](./types/never.md) is a _diverging expression_, but there are also diverging expressions which are not of type `!` (e.g. `Some(loop {})` produces a type of `Option<!>`).
 
+> [!NOTE]
+> Though `!` is considered an uninhabited type, a type being uninhabited is not sufficient for it to diverge.
+>
+> ```rust,compile_fail,E0308
+> # #![ feature(never_type) ]
+> # fn make<T>() -> T { loop {} }
+> enum Empty {}
+> fn diverging() -> ! {
+>     // This has a type of `!`.
+>     // So, the entire function is considered diverging
+>     make::<!>();
+> }
+> fn not_diverging() -> ! {
+>     // This type is uninhabited.
+>     // However, the entire function is not considered diverging
+>     make::<Empty>();
+> }
+> ```
+
 r[divergence.fallback]
 ## Fallback
 If a type to be inferred is only unified with diverging expressions, then that type will be inferred to be `!`.

--- a/src/divergence.md
+++ b/src/divergence.md
@@ -2,9 +2,9 @@ r[divergence]
 # Divergence
 
 r[divergence.intro]
-If an expression diverges, then nothing after that expression will execute. Importantly, while there are certain language constructs that immediately produce a _diverging expression_ of the type [`!`](./types/never.md), divergence can also propogate to the surrounding block --- where divergence indicates that the block itself will never finish executing.
+If an expression diverges, then nothing after that expression will execute. Importantly, while there are certain language constructs that immediately produce a _diverging expression_ of the type [`!`], divergence can also propogate to the surrounding block --- where divergence indicates that the block itself will never finish executing.
 
-Any expression of type [`!`](./types/never.md) is a _diverging expression_, but there are also diverging expressions which are not of type `!` (e.g. `Some(loop {})` produces a type of `Option<!>`).
+Any expression of type [`!`] is a _diverging expression_, but there are also diverging expressions which are not of type `!` (e.g. `Some(loop {})` produces a type of `Option<!>`).
 
 > [!NOTE]
 > Though `!` is considered an uninhabited type, a type being uninhabited is not sufficient for it to diverge.
@@ -30,7 +30,8 @@ Any expression of type [`!`](./types/never.md) is a _diverging expression_, but 
 
 r[divergence.fallback]
 ## Fallback
-If a type to be inferred is only unified with diverging expressions, then that type will be inferred to be `!`.
+
+If a type to be inferred is only unified with diverging expressions, then that type will be inferred to be [`!`].
 
 > [!EXAMPLE]
 > ```rust,compile_fail,E0277
@@ -58,3 +59,5 @@ If a type to be inferred is only unified with diverging expressions, then that t
 > ```
 
 <!-- TODO: This last point should likely should be moved to a more general "type inference" section discussing generalization + unification. -->
+
+[`!`]: type.never

--- a/src/divergence.md
+++ b/src/divergence.md
@@ -32,7 +32,8 @@ See the following rules for specific expression divergence behavior:
 
 Importantly, while there are certain language constructs that immediately produce a _diverging expression_ of the type [`!`], divergence can also propogate to the surrounding block --- where divergence indicates that the block itself will never finish executing.
 
-Any expression of type [`!`] is a _diverging expression_, but there are also diverging expressions which are not of type `!` (e.g. `Some(loop {})` produces a type of `Option<!>`).
+r[divergence.never]
+Any expression of type [`!`] is a diverging expression. However, diverging expressions are not limited to type [`!`]; expressions of other types may also diverge (e.g., `Some(loop {})` has type `Option<!>`).
 
 > [!NOTE]
 > Though `!` is considered an uninhabited type, a type being uninhabited is not sufficient for it to diverge.

--- a/src/divergence.md
+++ b/src/divergence.md
@@ -10,18 +10,21 @@ Any expression of type [`!`](./types/never.md) is a _diverging expression_, but 
 > Though `!` is considered an uninhabited type, a type being uninhabited is not sufficient for it to diverge.
 >
 > ```rust,compile_fail,E0308
-> # #![ feature(never_type) ]
-> # fn make<T>() -> T { loop {} }
 > enum Empty {}
+> fn make_never() -> ! {loop{}}
+> fn make_empty() -> Empty {loop{}}
+>
 > fn diverging() -> ! {
 >     // This has a type of `!`.
 >     // So, the entire function is considered diverging
->     make::<!>();
+>     make_never();
+>     // OK: The type of the body is `!` which matches the return type.
 > }
 > fn not_diverging() -> ! {
 >     // This type is uninhabited.
 >     // However, the entire function is not considered diverging
->     make::<Empty>();
+>     make_empty();
+>     // ERROR: The type of the body is `()` but expected type `!`.
 > }
 > ```
 

--- a/src/divergence.md
+++ b/src/divergence.md
@@ -15,6 +15,21 @@ fn example() {
 }
 ```
 
+See the following rules for specific expression divergence behavior:
+
+- [expr.block.diverging] --- Block expressions.
+- [expr.if.diverging] --- `if` expressions.
+- [expr.loop.break.diverging] --- `break` expressions.
+- [expr.loop.continue.diverging] --- `continue` expressions.
+- [expr.loop.infinite.diverging] --- Infinite `loop` expressions.
+- [expr.match.diverging] --- `match` expressions.
+- [expr.match.empty] --- Empty `match` expressions.
+- [expr.return.diverging] --- `return` expressions.
+- [type.never.constraint] --- Function calls returning `!`.
+
+> [!NOTE]
+> The [`panic!`] macro and related panic-generating macros like [`unreachable!`] also have the type [`!`] and are diverging.
+
 Importantly, while there are certain language constructs that immediately produce a _diverging expression_ of the type [`!`], divergence can also propogate to the surrounding block --- where divergence indicates that the block itself will never finish executing.
 
 Any expression of type [`!`] is a _diverging expression_, but there are also diverging expressions which are not of type `!` (e.g. `Some(loop {})` produces a type of `Option<!>`).

--- a/src/divergence.md
+++ b/src/divergence.md
@@ -6,50 +6,32 @@ Divergence is the state where a particular section of code could never be encoun
 
 Any expression of type [`!`](./types/never.md) is a _diverging expression_, but there are also diverging expressions which are not of type `!` (e.g. `Some(panic!())`).
 
-r[divergence.diverging-expressions]
-## Producing diverging expressions
-
-r[divergence.diverging-expressions.unconditional]
-The following language constructs unconditonally produce a _diverging expression_ of the type [`!`](./types/never.md):
-
-* [A call to a function returning `!`.](./types/never.md#r-type.never.constraint)
-* [A `loop` expression with no corresponding break.](./expressions/loop-expr.md#r-expr.loop.infinite.diverging)
-* [A `break` expression](./expressions/loop-expr.md#r-expr.loop.break.type)
-* [A `continue` expression](./expressions/loop-expr.md#r-expr.loop.continue.type)
-* [A `return` expression](./expressions/return-expr.md#r-expr.return.type)
-* [A `match` expression with no arms](./expressions/match-expr.md#r-expr.match.type.diverging.empty)
-* [A `block` expression that it itself is diverging.](./expressions/block-expr.md#r-expr.block.type.diverging)
-
-r[divergence.diverging-expressions.conditional]
-In a control flow expression, if all arms diverge, then the entire expression also diverges.
-
-r[divergence.diverging-expressions.place-expressions]
-A place expression of the type [`!`](./types/never.md) is considering _diverging_ only if it is read from.
-
 r[divergence.fallback]
 ## Fallback
 If a type to be inferred is only unified with diverging expressions, then that type will be inferred to be `!`.
 
-The following fails to compile because `!` does not implement `Debug`:
-```rust,compile_fail,E0277
-fn foo() -> i32 { 22 }
-match foo() {
-    4 => Default::default(),
-    _ => return,
-};
-```
+> [!EXAMPLE]
+> ```rust,compile_fail,E0277
+> fn foo() -> i32 { 22 }
+> match foo() {
+>     // ERROR: The trait bound `!: Default` is not satisfied.
+>     4 => Default::default(),
+>     _ => return,
+> };
+> ```
 
 > [!EDITION-2024]
 > Before the 2024 edition, the type was inferred to instead be `()`.
 
-Importantly, type unification may happen *structurally*, so the fallback `!` may be part of a larger type. The following compiles:
-```rust
-fn foo() -> i32 { 22 }
-// This has the type `Option<!>`, not `!`
-match foo() {
-    4 => Default::default(),
-    _ => Some(return),
-};
-```
+> [!NOTE]
+> Importantly, type unification may happen *structurally*, so the fallback `!` may be part of a larger type. The > following compiles:
+> ```rust
+> fn foo() -> i32 { 22 }
+> // This has the type `Option<!>`, not `!`
+> match foo() {
+>     4 => Default::default(),
+>     _ => Some(return),
+> };
+> ```
 
 <!-- TODO: This last point should likely should be moved to a more general "type inference" section discussing generalization + unification. -->

--- a/src/divergence.md
+++ b/src/divergence.md
@@ -43,7 +43,8 @@ If a type to be inferred is only unified with diverging expressions, then that t
 > Before the 2024 edition, the type was inferred to instead be `()`.
 
 > [!NOTE]
-> Importantly, type unification may happen *structurally*, so the fallback `!` may be part of a larger type. The > following compiles:
+> Importantly, type unification may happen *structurally*, so the fallback `!` may be part of a larger type. The following compiles:
+>
 > ```rust
 > fn foo() -> i32 { 22 }
 > // This has the type `Option<!>`, not `!`

--- a/src/divergence.md
+++ b/src/divergence.md
@@ -4,7 +4,7 @@ r[divergence]
 r[divergence.intro]
 Divergence is the state where a particular section of code could never be encountered at runtime. Importantly, while there are certain language constructs that immediately produce a _diverging expression_ of the type [`!`](./types/never.md), divergence can also propogate to the surrounding block.
 
-Any expression of type [`!`](./types/never.md) is a _diverging expression_, but there are also diverging expressions which are not of type `!` (e.g. `Some(panic!())`).
+Any expression of type [`!`](./types/never.md) is a _diverging expression_, but there are also diverging expressions which are not of type `!` (e.g. `Some(loop {})` produces a type of `Option<!>`).
 
 r[divergence.fallback]
 ## Fallback

--- a/src/divergence.md
+++ b/src/divergence.md
@@ -2,7 +2,7 @@ r[divergence]
 # Divergence
 
 r[divergence.intro]
-Divergence is the state where a particular section of code could never be encountered at runtime. Importantly, while there are certain language constructs that immediately produce a _diverging expression_ of the type [`!`](./types/never.md), divergence can also propogate to the surrounding block.
+If an expression diverges, then nothing after that expression will execute. Importantly, while there are certain language constructs that immediately produce a _diverging expression_ of the type [`!`](./types/never.md), divergence can also propogate to the surrounding block --- where divergence indicates that the block itself will never finish executing.
 
 Any expression of type [`!`](./types/never.md) is a _diverging expression_, but there are also diverging expressions which are not of type `!` (e.g. `Some(loop {})` produces a type of `Option<!>`).
 

--- a/src/divergence.md
+++ b/src/divergence.md
@@ -2,7 +2,20 @@ r[divergence]
 # Divergence
 
 r[divergence.intro]
-If an expression diverges, then nothing after that expression will execute. Importantly, while there are certain language constructs that immediately produce a _diverging expression_ of the type [`!`], divergence can also propogate to the surrounding block --- where divergence indicates that the block itself will never finish executing.
+A *diverging expression* is an expression that never completes normal execution.
+
+```rust
+fn diverges() -> ! {
+    panic!("This function never returns!");
+}
+
+fn example() {
+    let x: i32 = diverges(); // This line never completes.
+    println!("This is never printed: {x}");
+}
+```
+
+Importantly, while there are certain language constructs that immediately produce a _diverging expression_ of the type [`!`], divergence can also propogate to the surrounding block --- where divergence indicates that the block itself will never finish executing.
 
 Any expression of type [`!`] is a _diverging expression_, but there are also diverging expressions which are not of type `!` (e.g. `Some(loop {})` produces a type of `Option<!>`).
 

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -100,11 +100,19 @@ fn diverging_place_read() -> ! {
     // A read of a place expression produces a diverging block
     let _x = foo.x;
 }
-fn diverging_place_not_read() -> () {
+```
+
+```rust,compile_fail,E0308
+# #![ feature(never_type) ]
+# fn make<T>() -> T { loop {} }
+# struct Foo {
+#     x: !,
+# }
+fn diverging_place_not_read() -> ! {
     let foo = Foo { x: make() };
     // Asssignment to `_` means the place is not read
     let _ = foo.x;
-}
+} // ERROR: Mismatched types.
 ```
 
 r[expr.block.value]

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -69,12 +69,12 @@ A block is itself considered to be [diverging](../divergence.md) if all reachabl
 # #![ feature(never_type) ]
 # fn make<T>() -> T { loop {} }
 fn no_control_flow() -> ! {
-    // There are no conditional statements, so this entire block is diverging.
+    // There are no conditional statements, so this entire function body is diverging.
     loop {}
 }
 
 fn control_flow_diverging() -> ! {
-    // All paths are diverging, so this entire block is diverging.
+    // All paths are diverging, so this entire function body is diverging.
     if true {
         loop {}
     } else {

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -97,7 +97,7 @@ struct Foo {
 
 fn diverging_place_read() -> ! {
     let foo = Foo { x: make() };
-    // A read of a place expression produces a diverging block
+    // A read of a place expression produces a diverging block.
     let _x = foo.x;
 }
 ```
@@ -110,7 +110,7 @@ fn diverging_place_read() -> ! {
 # }
 fn diverging_place_not_read() -> ! {
     let foo = Foo { x: make() };
-    // Asssignment to `_` means the place is not read
+    // Assignment to `_` means the place is not read.
     let _ = foo.x;
 } // ERROR: Mismatched types.
 ```

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -43,7 +43,7 @@ r[expr.block.result]
 Then the final operand is executed, if given.
 
 r[expr.block.type]
-Except in the case of divergence [(see below)](block-expr.md#r-expr.block.type.diverging), the type of a block is the type of the final operand, or `()` if the final operand is omitted.
+The type of a block is the type of its final operand; if that operand is omitted, the type is the [unit type], unless the block [diverges][expr.block.type.diverging], in which case it is the [never type].
 
 ```rust
 # fn fn_call() {}
@@ -337,6 +337,7 @@ fn is_unix_platform() -> bool {
 [inner attributes]: ../attributes.md
 [method]: ../items/associated-items.md#methods
 [mutable reference]: ../types/pointer.md#mutables-references-
+[never type]: type.never
 [place expression]: expr.place-value.place-memory-location
 [scopes]: ../names/scopes.md
 [shared references]: ../types/pointer.md#shared-references-
@@ -345,6 +346,7 @@ fn is_unix_platform() -> bool {
 [struct]: struct-expr.md
 [the lint check attributes]: ../attributes/diagnostics.md#lint-check-attributes
 [tuple expressions]: tuple-expr.md
+[unit type]: type.tuple.unit
 [unsafe operations]: ../unsafety.md
 [value expressions]: ../expressions.md#place-expressions-and-value-expressions
 [Loops and other breakable expressions]: expr.loop.block-labels

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -66,6 +66,7 @@ r[expr.block.type.diverging]
 A block is itself considered to be [diverging](../divergence.md) if all reachable control flow paths contain a [diverging expression](../divergence.md), unless that expression is a [place expression](../expressions.md#r-expr.place-value.place-memory-location) that is not read from.
 
 ```rust,no_run
+# #![ feature(never_type) ]
 # fn make<T>() -> T { loop {} }
 fn no_control_flow() -> ! {
     // There are no conditional statements, so this entire block is diverging.
@@ -94,19 +95,15 @@ struct Foo {
     x: !,
 }
 
-fn diverging_place_read() -> () {
+fn diverging_place_read() -> ! {
     let foo = Foo { x: make() };
-    let _: ! = {
-        // A read of a place expression produces a diverging block
-        let _x = foo.x;
-    };
+    // A read of a place expression produces a diverging block
+    let _x = foo.x;
 }
 fn diverging_place_not_read() -> () {
     let foo = Foo { x: make() };
-    let _: () = {
-        // Asssignment to `_` means the place is not read
-        let _ = foo.x;
-    };
+    // Asssignment to `_` means the place is not read
+    let _ = foo.x;
 }
 ```
 

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -43,7 +43,7 @@ r[expr.block.result]
 Then the final operand is executed, if given.
 
 r[expr.block.type]
-The type of a block is the type of its final operand; if that operand is omitted, the type is the [unit type], unless the block [diverges][expr.block.type.diverging], in which case it is the [never type].
+The type of a block is the type of its final operand; if that operand is omitted, the type is the [unit type], unless the block [diverges][expr.block.diverging], in which case it is the [never type].
 
 ```rust
 # fn fn_call() {}
@@ -62,7 +62,7 @@ assert_eq!(5, five);
 > [!NOTE]
 > As a control flow expression, if a block expression is the outer expression of an expression statement, the expected type is `()` unless it is followed immediately by a semicolon.
 
-r[expr.block.type.diverging]
+r[expr.block.diverging]
 A block is considered to be [diverging][divergence] if all reachable control flow paths contain a diverging expression, unless that expression is a [place expression] that is not read from.
 
 ```rust,no_run

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -63,7 +63,7 @@ assert_eq!(5, five);
 > As a control flow expression, if a block expression is the outer expression of an expression statement, the expected type is `()` unless it is followed immediately by a semicolon.
 
 r[expr.block.type.diverging]
-A block is itself considered to be [diverging](../divergence.md) if all reachable control flow paths contain a [diverging expression](../divergence.md#r-divergence.diverging-expressions), unless that expression is a [place expression](../expressions.md#r-expr.place-value.place-memory-location) that is not read from.
+A block is itself considered to be [diverging](../divergence.md) if all reachable control flow paths contain a [diverging expression](../divergence.md), unless that expression is a [place expression](../expressions.md#r-expr.place-value.place-memory-location) that is not read from.
 
 ```rust,no_run
 # fn make<T>() -> T { loop {} }

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -67,7 +67,6 @@ A block is itself considered to be [diverging](../divergence.md) if all reachabl
 
 ```rust,no_run
 # #![ feature(never_type) ]
-# fn make<T>() -> T { loop {} }
 fn no_control_flow() -> ! {
     // There are no conditional statements, so this entire function body is diverging.
     loop {}
@@ -91,9 +90,15 @@ fn control_flow_not_diverging() -> () {
     }
 }
 
+// Note: This makes use of the unstable never type which is only available on
+// Rust's nightly channel. This is done for illustration purposes. It is
+// possible to encounter this scenario in stable Rust, but requires a more
+// convoluted example.
 struct Foo {
     x: !,
 }
+
+fn make<T>() -> T { loop {} }
 
 fn diverging_place_read() -> ! {
     let foo = Foo { x: make() };

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -43,7 +43,7 @@ r[expr.block.result]
 Then the final operand is executed, if given.
 
 r[expr.block.type]
-Except in the case of divergence (see below), the type of a block is the type of the final operand, or `()` if the final operand is omitted.
+Except in the case of divergence [(see below)](block-expr.md#r-expr.block.type.diverging), the type of a block is the type of the final operand, or `()` if the final operand is omitted.
 
 ```rust
 # fn fn_call() {}
@@ -63,7 +63,7 @@ assert_eq!(5, five);
 > As a control flow expression, if a block expression is the outer expression of an expression statement, the expected type is `()` unless it is followed immediately by a semicolon.
 
 r[expr.block.type.diverging]
-A block is itself considered to be [diverging](../divergence.md) if all reachable control flow paths contain a [diverging expression](../divergence.md#r-divergence.diverging-expressions), unless that expression is a place expression that is not read from.
+A block is itself considered to be [diverging](../divergence.md) if all reachable control flow paths contain a [diverging expression](../divergence.md#r-divergence.diverging-expressions), unless that expression is a [place expression](../expressions.md#r-expr.place-value.place-memory-location) that is not read from.
 
 ```rust,no_run
 # fn make<T>() -> T { loop {} }

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -63,7 +63,7 @@ assert_eq!(5, five);
 > As a control flow expression, if a block expression is the outer expression of an expression statement, the expected type is `()` unless it is followed immediately by a semicolon.
 
 r[expr.block.type.diverging]
-A block is itself considered to be [diverging](../divergence.md) if all reachable control flow paths contain a [diverging expression](../divergence.md), unless that expression is a [place expression](../expressions.md#r-expr.place-value.place-memory-location) that is not read from.
+A block is considered to be [diverging][divergence] if all reachable control flow paths contain a diverging expression, unless that expression is a [place expression] that is not read from.
 
 ```rust,no_run
 # #![ feature(never_type) ]
@@ -337,6 +337,7 @@ fn is_unix_platform() -> bool {
 [inner attributes]: ../attributes.md
 [method]: ../items/associated-items.md#methods
 [mutable reference]: ../types/pointer.md#mutables-references-
+[place expression]: expr.place-value.place-memory-location
 [scopes]: ../names/scopes.md
 [shared references]: ../types/pointer.md#shared-references-
 [statement]: ../statements.md

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -65,43 +65,49 @@ assert_eq!(5, five);
 r[expr.block.type.diverging]
 A block is itself considered to be [diverging](../divergence.md) if all reachable control flow paths contain a [diverging expression](../divergence.md#r-divergence.diverging-expressions), unless that expression is a place expression that is not read from.
 
-```rust
-# #![ feature(never_type) ]
+```rust,no_run
 # fn make<T>() -> T { loop {} }
-let no_control_flow: ! = {
+fn no_control_flow() -> ! {
     // There are no conditional statements, so this entire block is diverging.
     loop {}
-};
+}
 
-let control_flow_diverging: ! = {
+fn control_flow_diverging() -> ! {
     // All paths are diverging, so this entire block is diverging.
     if true {
         loop {}
     } else {
         loop {}
     }
-};
+}
 
-let control_flow_not_diverging: () = {
+fn control_flow_not_diverging() -> () {
     // Some paths are not diverging, so this entire block is not diverging.
     if true {
         ()
     } else {
         loop {}
     }
-};
+}
 
 struct Foo {
     x: !,
 }
 
-let foo = Foo { x: make() };
-let diverging_place_not_read: () = {
+fn diverging_place_read() -> () {
+    let foo = Foo { x: make() };
+    let _: ! = {
+        // A read of a place expression produces a diverging block
+        let _x = foo.x;
+    };
+}
+fn diverging_place_not_read() -> () {
+    let foo = Foo { x: make() };
     let _: () = {
         // Asssignment to `_` means the place is not read
         let _ = foo.x;
     };
-};
+}
 ```
 
 r[expr.block.value]

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -43,7 +43,7 @@ r[expr.block.result]
 Then the final operand is executed, if given.
 
 r[expr.block.type]
-The type of a block is the type of the final operand, or `()` if the final operand is omitted.
+Typically, the type of a block is the type of the final operand, or `()` if the final operand is omitted.
 
 ```rust
 # fn fn_call() {}
@@ -61,6 +61,9 @@ assert_eq!(5, five);
 
 > [!NOTE]
 > As a control flow expression, if a block expression is the outer expression of an expression statement, the expected type is `()` unless it is followed immediately by a semicolon.
+
+r[expr.block.type.diverging]
+However, if there are any values unconditionally created within a block that are [diverging](../divergence.md), then the block itself is considered diverging.
 
 r[expr.block.value]
 Blocks are always [value expressions] and evaluate the last operand in value expression context.

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -43,7 +43,7 @@ r[expr.block.result]
 Then the final operand is executed, if given.
 
 r[expr.block.type]
-Typically, the type of a block is the type of the final operand, or `()` if the final operand is omitted.
+Except in the case of divergence (see below), the type of a block is the type of the final operand, or `()` if the final operand is omitted.
 
 ```rust
 # fn fn_call() {}
@@ -63,7 +63,46 @@ assert_eq!(5, five);
 > As a control flow expression, if a block expression is the outer expression of an expression statement, the expected type is `()` unless it is followed immediately by a semicolon.
 
 r[expr.block.type.diverging]
-A block is itself considered to be [diverging](../divergence.md) if all reachable control flow paths contain a [diverging expression](../divergence.md#r-divergence.diverging-expressions).
+A block is itself considered to be [diverging](../divergence.md) if all reachable control flow paths contain a [diverging expression](../divergence.md#r-divergence.diverging-expressions), unless that expression is a place expression that is not read from.
+
+```rust
+# #![ feature(never_type) ]
+# fn make<T>() -> T { loop {} }
+let no_control_flow: ! = {
+    // There are no conditional statements, so this entire block is diverging.
+    loop {}
+};
+
+let control_flow_diverging: ! = {
+    // All paths are diverging, so this entire block is diverging.
+    if true {
+        loop {}
+    } else {
+        loop {}
+    }
+};
+
+let control_flow_not_diverging: () = {
+    // Some paths are not diverging, so this entire block is not diverging.
+    if true {
+        ()
+    } else {
+        loop {}
+    }
+};
+
+struct Foo {
+    x: !,
+}
+
+let foo = Foo { x: make() };
+let diverging_place_not_read: () = {
+    let _: () = {
+        // Asssignment to `_` means the place is not read
+        let _ = foo.x;
+    };
+};
+```
 
 r[expr.block.value]
 Blocks are always [value expressions] and evaluate the last operand in value expression context.

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -63,7 +63,7 @@ assert_eq!(5, five);
 > As a control flow expression, if a block expression is the outer expression of an expression statement, the expected type is `()` unless it is followed immediately by a semicolon.
 
 r[expr.block.type.diverging]
-However, if there are any values unconditionally created within a block that are [diverging](../divergence.md), then the block itself is considered diverging.
+A block is itself considered to be [diverging](../divergence.md) if all reachable control flow paths contain a [diverging expression](../divergence.md#r-divergence.diverging-expressions).
 
 r[expr.block.value]
 Blocks are always [value expressions] and evaluate the last operand in value expression context.

--- a/src/expressions/if-expr.md
+++ b/src/expressions/if-expr.md
@@ -70,6 +70,25 @@ let y = if 12 * 15 > 150 {
 assert_eq!(y, "Bigger");
 ```
 
+r[expr.if.diverging]
+An `if` expression diverges if either the condition expression diverges or if all arms diverge.
+
+```rust
+# #![ feature(never_type) ]
+// Diverges because the condition expression diverges
+let x: ! = if { loop {}; true } {
+    ()
+} else {
+    ()
+};
+
+let x: ! = if true {
+    loop {}
+} else {
+    loop {}
+};
+```
+
 r[expr.if.let]
 ## `if let` patterns
 

--- a/src/expressions/if-expr.md
+++ b/src/expressions/if-expr.md
@@ -76,11 +76,13 @@ An `if` expression diverges if either the condition expression diverges or if al
 ```rust,no_run
 fn diverging_condition() -> ! {
     // Diverges because the condition expression diverges
-    if { loop {}; true } {
+    if loop {} {
         ()
     } else {
         ()
-    }
+    };
+    // The semicolon above is important:
+    // The type of the `if` statement is `()`, despite being diverging.
 }
 
 fn diverging_arms() -> ! {

--- a/src/expressions/if-expr.md
+++ b/src/expressions/if-expr.md
@@ -71,7 +71,7 @@ assert_eq!(y, "Bigger");
 ```
 
 r[expr.if.diverging]
-An `if` expression diverges if either the condition expression diverges or if all arms diverge.
+An `if` expression [diverges] if either the condition expression diverges or if all arms diverge.
 
 ```rust,no_run
 fn diverging_condition() -> ! {
@@ -199,4 +199,5 @@ r[expr.if.edition2024]
 
 [`match` expressions]: match-expr.md
 [boolean type]: ../types/boolean.md
+[diverges]: divergence
 [scrutinee]: ../glossary.md#scrutinee

--- a/src/expressions/if-expr.md
+++ b/src/expressions/if-expr.md
@@ -81,8 +81,11 @@ fn diverging_condition() -> ! {
     } else {
         ()
     };
-    // The semicolon above is important:
-    // The type of the `if` statement is `()`, despite being diverging.
+    // The semicolon above is important: The type of the `if` expression is
+    // `()`, despite being diverging. When the final body expression is
+    // elided, the type of the body is inferred to ! because the function body
+    // diverges. Without the semicolon, the `if` would be the tail expression
+    // with type `()`, which would fail to match the return type `!`.
 }
 
 fn diverging_arms() -> ! {

--- a/src/expressions/if-expr.md
+++ b/src/expressions/if-expr.md
@@ -73,20 +73,24 @@ assert_eq!(y, "Bigger");
 r[expr.if.diverging]
 An `if` expression diverges if either the condition expression diverges or if all arms diverge.
 
-```rust
-# #![ feature(never_type) ]
-// Diverges because the condition expression diverges
-let x: ! = if { loop {}; true } {
-    ()
-} else {
-    ()
-};
+```rust,no_run
+fn diverging_condition() -> ! {
+    // Diverges because the condition expression diverges
+    if { loop {}; true } {
+        ()
+    } else {
+        ()
+    }
+}
 
-let x: ! = if true {
-    loop {}
-} else {
-    loop {}
-};
+fn diverging_arms() -> ! {
+    // Diverges because all arms diverge
+    if true {
+        loop {}
+    } else {
+        loop {}
+    }
+}
 ```
 
 r[expr.if.let]

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -338,6 +338,23 @@ let result = 'block: {
 };
 ```
 
+r[expr.loop.block-labels.type]
+The type of a labeled block expression is the [least upper bound] of all of the break operands and the final operand. If the final operand is omitted, the type of the final operand defaults to the [unit type], unless the block [diverges][expr.block.diverging], in which case it is the [never type].
+
+> [!EXAMPLE]
+> ```rust
+> fn example(condition: bool) {
+>     let s = String::from("owned");
+>
+>     let _: &str = 'block: {
+>         if condition {
+>             break 'block &s;  // &String coerced to &str via Deref
+>         }
+>         break 'block "literal";  // &'static str coerced to &str
+>     };
+> }
+> ```
+
 r[expr.loop.continue]
 ## `continue` expressions
 

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -296,6 +296,9 @@ A `break` expression is normally associated with the innermost `loop`, `for` or 
 r[expr.loop.break.value]
 A `break` expression is only permitted in the body of a loop, and has one of the forms `break`, `break 'label` or ([see below](#break-and-loop-values)) `break EXPR` or `break 'label EXPR`.
 
+r[expr.loop.break.type]
+A `break` expression itself has a type of [`!`](../types/never.md).
+
 r[expr.loop.block-labels]
 ## Labeled block expressions
 
@@ -354,6 +357,9 @@ Like `break`, `continue` is normally associated with the innermost enclosing loo
 
 r[expr.loop.continue.in-loop-only]
 A `continue` expression is only permitted in the body of a loop.
+
+r[expr.loop.continue.type]
+A `continue` expression itself has a type of [`!`](../types/never.md).
 
 r[expr.loop.break-value]
 ## `break` and loop values

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -299,6 +299,9 @@ A `break` expression is normally associated with the innermost `loop`, `for` or 
 r[expr.loop.break.value]
 A `break` expression is only permitted in the body of a loop, and has one of the forms `break`, `break 'label` or ([see below](#break-and-loop-values)) `break EXPR` or `break 'label EXPR`.
 
+r[expr.loop.break-value.implicit-value]
+In a [`loop` with break expressions][expr.loop.break-value] or a [labeled block expression], a `break` without an expression is equivalent to `break ()`.
+
 r[expr.loop.block-labels]
 ## Labeled block expressions
 
@@ -382,7 +385,7 @@ assert_eq!(result, 13);
 ```
 
 r[expr.loop.break-value.loop]
-In the case a `loop` has an associated `break`, it is not considered diverging, and the `loop` must have a type compatible with each `break` expression. `break` without an expression is considered identical to `break` with expression `()`.
+In the case a `loop` has an associated `break`, it is not considered diverging, and the `loop` must have a type compatible with each `break` expression.
 
 [`!`]: type.never
 [`if` condition chains]: if-expr.md#chains-of-conditions
@@ -390,5 +393,6 @@ In the case a `loop` has an associated `break`, it is not considered diverging, 
 [`match` expression]: match-expr.md
 [boolean type]: ../types/boolean.md
 [diverging]: divergence
+[labeled block expression]: expr.loop.block-labels
 [scrutinee]: ../glossary.md#scrutinee
 [temporary values]: ../expressions.md#temporaries

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -282,6 +282,8 @@ for x in 1..100 {
 assert_eq!(last, 12);
 ```
 
+Thus, the `break` expression itself is diverging and has a type of [`!`](../types/never.md).
+
 r[expr.loop.break.label]
 A `break` expression is normally associated with the innermost `loop`, `for` or `while` loop enclosing the `break` expression, but a [label](#loop-labels) can be used to specify which enclosing loop is affected. Example:
 
@@ -295,9 +297,6 @@ A `break` expression is normally associated with the innermost `loop`, `for` or 
 
 r[expr.loop.break.value]
 A `break` expression is only permitted in the body of a loop, and has one of the forms `break`, `break 'label` or ([see below](#break-and-loop-values)) `break EXPR` or `break 'label EXPR`.
-
-r[expr.loop.break.type]
-A `break` expression itself has a type of [`!`](../types/never.md).
 
 r[expr.loop.block-labels]
 ## Labeled block expressions
@@ -346,6 +345,8 @@ ContinueExpression -> `continue` LIFETIME_OR_LABEL?
 r[expr.loop.continue.intro]
 When `continue` is encountered, the current iteration of the associated loop body is immediately terminated, returning control to the loop *head*.
 
+Thus, the `continue` expression itself has a type of [`!`](../types/never.md).
+
 r[expr.loop.continue.while]
 In the case of a `while` loop, the head is the conditional operands controlling the loop.
 
@@ -357,9 +358,6 @@ Like `break`, `continue` is normally associated with the innermost enclosing loo
 
 r[expr.loop.continue.in-loop-only]
 A `continue` expression is only permitted in the body of a loop.
-
-r[expr.loop.continue.type]
-A `continue` expression itself has a type of [`!`](../types/never.md).
 
 r[expr.loop.break-value]
 ## `break` and loop values

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -401,15 +401,64 @@ let result = loop {
 assert_eq!(result, 13);
 ```
 
-r[expr.loop.break-value.loop]
-In the case a `loop` has an associated `break`, it is not considered diverging, and the `loop` must have a type compatible with each `break` expression.
+r[expr.loop.break-value.type]
+The type of a `loop` with associated `break` expressions is the [least upper bound] of all of the break operands.
+
+> [!EXAMPLE]
+> ```rust
+> fn example(condition: bool) {
+>     let s = String::from("owned");
+>
+>     let _: &str = loop {
+>         if condition {
+>             break &s; // &String coerced to &str via Deref
+>         }
+>         break "literal"; // &'static str coerced to &str
+>     };
+> }
+> ```
+
+r[expr.loop.break-value.diverging]
+A `loop` with associated `break` expressions does not [diverge] if any of the break operands do not diverge. If all of the `break` operands diverge, then the `loop` expression also diverges.
+
+> [!EXAMPLE]
+> ```rust
+> fn diverging_loop_with_break(condition: bool) -> ! {
+>     // This loop is diverging because all `break` operands are diverging.
+>     loop {
+>         if condition {
+>             break loop {};
+>         } else {
+>             break panic!();
+>         }
+>     }
+> }
+> ```
+>
+> ```rust,compile_fail,E0308
+> fn loop_with_non_diverging_break(condition: bool) -> ! {
+>     // The type of this loop is i32 even though one of the breaks is
+>     // diverging.
+>     loop {
+>         if condition {
+>             break loop {};
+>         } else {
+>             break 123i32;
+>         }
+>     } // ERROR: expected `!`, found `i32`
+> }
+> ```
 
 [`!`]: type.never
 [`if` condition chains]: if-expr.md#chains-of-conditions
 [`if` expressions]: if-expr.md
 [`match` expression]: match-expr.md
 [boolean type]: ../types/boolean.md
+[diverge]: divergence
 [diverging]: divergence
 [labeled block expression]: expr.loop.block-labels
+[least upper bound]: coerce.least-upper-bound
+[never type]: type.never
 [scrutinee]: ../glossary.md#scrutinee
 [temporary values]: ../expressions.md#temporaries
+[unit type]: type.tuple.unit

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -41,7 +41,7 @@ r[expr.loop.infinite.intro]
 A `loop` expression repeats execution of its body continuously: `loop { println!("I live."); }`.
 
 r[expr.loop.infinite.diverging]
-A `loop` expression without an associated `break` expression is diverging and has type [`!`](../types/never.md).
+A `loop` expression without an associated `break` expression is [diverging] and has type [`!`].
 
 r[expr.loop.infinite.break]
 A `loop` expression containing associated [`break` expression(s)](#break-expressions) may terminate, and must have type compatible with the value of the `break` expression(s).
@@ -282,7 +282,8 @@ for x in 1..100 {
 assert_eq!(last, 12);
 ```
 
-Thus, the `break` expression itself is diverging and has a type of [`!`](../types/never.md).
+r[expr.loop.break.diverging]
+A `break` expression is [diverging] and has a type of [`!`].
 
 r[expr.loop.break.label]
 A `break` expression is normally associated with the innermost `loop`, `for` or `while` loop enclosing the `break` expression, but a [label](#loop-labels) can be used to specify which enclosing loop is affected. Example:
@@ -345,7 +346,8 @@ ContinueExpression -> `continue` LIFETIME_OR_LABEL?
 r[expr.loop.continue.intro]
 When `continue` is encountered, the current iteration of the associated loop body is immediately terminated, returning control to the loop *head*.
 
-Thus, the `continue` expression itself has a type of [`!`](../types/never.md).
+r[expr.loop.continue.diverging]
+A `continue` expression is [diverging] and has a type of [`!`].
 
 r[expr.loop.continue.while]
 In the case of a `while` loop, the head is the conditional operands controlling the loop.
@@ -382,9 +384,11 @@ assert_eq!(result, 13);
 r[expr.loop.break-value.loop]
 In the case a `loop` has an associated `break`, it is not considered diverging, and the `loop` must have a type compatible with each `break` expression. `break` without an expression is considered identical to `break` with expression `()`.
 
+[`!`]: type.never
 [`if` condition chains]: if-expr.md#chains-of-conditions
 [`if` expressions]: if-expr.md
 [`match` expression]: match-expr.md
 [boolean type]: ../types/boolean.md
+[diverging]: divergence
 [scrutinee]: ../glossary.md#scrutinee
 [temporary values]: ../expressions.md#temporaries

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -92,7 +92,7 @@ r[expr.match.binding-restriction]
 Every binding of the same name must have the same type, and have the same binding mode.
 
 r[expr.match.type]
-The type of the overall `match` expression is the least upper bound of the individual match arms.
+The type of the overall `match` expression is the [least upper bound](../type-coercions.md#r-coerce.least-upper-bound) of the individual match arms.
 
 r[expr.match.type.diverging.empty]
 If there are no match arms, then the `match` expression is diverging and the type is [`!`](../types/never.md).

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -109,7 +109,7 @@ If there are no match arms, then the `match` expression is [diverging] and the t
 > ```
 
 
-r[expr.match.conditional]
+r[expr.match.diverging]
 If either the scrutinee expression or all of the match arms diverge, then the entire `match` expression also diverges.
 
 > [!NOTE]

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -95,7 +95,7 @@ r[expr.match.type]
 The type of the overall `match` expression is the [least upper bound](../type-coercions.md#r-coerce.least-upper-bound) of the individual match arms.
 
 r[expr.match.empty]
-If there are no match arms, then the `match` expression is diverging and the type is [`!`](../types/never.md).
+If there are no match arms, then the `match` expression is [diverging] and the type is [`!`].
 
 > [!EXAMPLE]
 > ```rust
@@ -113,7 +113,7 @@ r[expr.match.conditional]
 If either the scrutinee expression or all of the match arms diverge, then the entire `match` expression also diverges.
 
 > [!NOTE]
-> Even if the entire `match` expression diverges, its type may not be [`!`](../types/never.md).
+> Even if the entire `match` expression diverges, its type may not be [`!`].
 >
 >```rust,compile_fail,E0004
 >    let a = match true {
@@ -184,9 +184,11 @@ Outer attributes are allowed on match arms. The only attributes that have meanin
 r[expr.match.attributes.inner]
 [Inner attributes] are allowed directly after the opening brace of the match expression in the same expression contexts as [attributes on block expressions].
 
+[`!`]: type.never
 [`cfg`]: ../conditional-compilation.md
 [attributes on block expressions]: block-expr.md#attributes-on-block-expressions
 [binding mode]: ../patterns.md#binding-modes
+[diverging]: divergence
 [Inner attributes]: ../attributes.md
 [lint check attributes]: ../attributes/diagnostics.md#lint-check-attributes
 [pattern]: ../patterns.md

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -91,6 +91,28 @@ Every binding in each `|` separated pattern must appear in all of the patterns i
 r[expr.match.binding-restriction]
 Every binding of the same name must have the same type, and have the same binding mode.
 
+r[expr.match.type]
+The type of the overall `match` expression is the least upper bound of the individual match arms.
+
+r[expr.match.type.diverging.empty]
+If there are no match arms, then the `match` expression is diverging and the type is [`!`](../types/never.md).
+
+r[expr.match.type.diverging.conditional]
+If either the scrutinee expression or all of the match arms diverge, then the entire `match` expression also diverges.
+
+> [!NOTE]
+> If even the entire `match` expression diverges, its type may not be [`!`](../types/never.md).
+>
+>```rust,compile_fail,E0004
+>    let a = match true {
+>        true => Some(panic!()),
+>        false => None,
+>    };
+>    // Fails to compile because `a` has the type `Option<!>`
+>    // (or, `Option<()>` in edition 2021 and below)
+>    match a {}
+>```
+
 r[expr.match.guard]
 ## Match guards
 

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -94,22 +94,21 @@ Every binding of the same name must have the same type, and have the same bindin
 r[expr.match.type]
 The type of the overall `match` expression is the [least upper bound](../type-coercions.md#r-coerce.least-upper-bound) of the individual match arms.
 
-r[expr.match.type.diverging.empty]
+r[expr.match.empty]
 If there are no match arms, then the `match` expression is diverging and the type is [`!`](../types/never.md).
 
-r[expr.match.type.diverging.conditional]
+r[expr.match.conditional]
 If either the scrutinee expression or all of the match arms diverge, then the entire `match` expression also diverges.
 
 > [!NOTE]
-> If even the entire `match` expression diverges, its type may not be [`!`](../types/never.md).
+> Even if the entire `match` expression diverges, its type may not be [`!`](../types/never.md).
 >
 >```rust,compile_fail,E0004
 >    let a = match true {
 >        true => Some(panic!()),
 >        false => None,
 >    };
->    // Fails to compile because `a` has the type `Option<!>`
->    // (or, `Option<()>` in edition 2021 and below)
+>    // Fails to compile because `a` has the type `Option<!>`.
 >    match a {}
 >```
 

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -112,18 +112,6 @@ If there are no match arms, then the `match` expression is [diverging] and the t
 r[expr.match.diverging]
 If either the scrutinee expression or all of the match arms diverge, then the entire `match` expression also diverges.
 
-> [!NOTE]
-> Even if the entire `match` expression diverges, its type may not be [`!`].
->
->```rust,compile_fail,E0004
->    let a = match true {
->        true => Some(panic!()),
->        false => None,
->    };
->    // Fails to compile because `a` has the type `Option<!>`.
->    match a {}
->```
-
 r[expr.match.guard]
 ## Match guards
 

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -92,7 +92,7 @@ r[expr.match.binding-restriction]
 Every binding of the same name must have the same type, and have the same binding mode.
 
 r[expr.match.type]
-The type of the overall `match` expression is the [least upper bound](../type-coercions.md#r-coerce.least-upper-bound) of the individual match arms.
+The type of the overall `match` expression is the [least upper bound] of the individual match arms.
 
 r[expr.match.empty]
 If there are no match arms, then the `match` expression is [diverging] and the type is [`!`].
@@ -190,6 +190,7 @@ r[expr.match.attributes.inner]
 [binding mode]: ../patterns.md#binding-modes
 [diverging]: divergence
 [Inner attributes]: ../attributes.md
+[least upper bound]: coerce.least-upper-bound
 [lint check attributes]: ../attributes/diagnostics.md#lint-check-attributes
 [pattern]: ../patterns.md
 [place expression]: ../expressions.md#place-expressions-and-value-expressions

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -97,6 +97,19 @@ The type of the overall `match` expression is the [least upper bound](../type-co
 r[expr.match.empty]
 If there are no match arms, then the `match` expression is diverging and the type is [`!`](../types/never.md).
 
+> [!EXAMPLE]
+```rust
+# fn make<T>() -> T { loop {} }
+enum Empty {}
+
+fn diverging_match_no_arms() -> ! {
+    let e: Empty = make();
+    let 
+    match e {}
+}
+```
+
+
 r[expr.match.conditional]
 If either the scrutinee expression or all of the match arms diverge, then the entire `match` expression also diverges.
 

--- a/src/expressions/match-expr.md
+++ b/src/expressions/match-expr.md
@@ -98,16 +98,15 @@ r[expr.match.empty]
 If there are no match arms, then the `match` expression is diverging and the type is [`!`](../types/never.md).
 
 > [!EXAMPLE]
-```rust
-# fn make<T>() -> T { loop {} }
-enum Empty {}
-
-fn diverging_match_no_arms() -> ! {
-    let e: Empty = make();
-    let 
-    match e {}
-}
-```
+> ```rust
+> # fn make<T>() -> T { loop {} }
+> enum Empty {}
+>
+> fn diverging_match_no_arms() -> ! {
+>     let e: Empty = make();
+>     match e {}
+> }
+> ```
 
 
 r[expr.match.conditional]

--- a/src/expressions/return-expr.md
+++ b/src/expressions/return-expr.md
@@ -12,7 +12,8 @@ Return expressions are denoted with the keyword `return`.
 r[expr.return.behavior]
 Evaluating a `return` expression moves its argument into the designated output location for the current function call, destroys the current function activation frame, and transfers control to the caller frame.
 
-Thus, a `return` expression itself has a type of [`!`](../types/never.md).
+r[expr.return.diverging]
+A `return` expression is [diverging] and has a type of [`!`].
 
 An example of a `return` expression:
 
@@ -24,3 +25,6 @@ fn max(a: i32, b: i32) -> i32 {
     return b;
 }
 ```
+
+[`!`]: type.never
+[diverging]: divergence

--- a/src/expressions/return-expr.md
+++ b/src/expressions/return-expr.md
@@ -22,3 +22,6 @@ fn max(a: i32, b: i32) -> i32 {
     return b;
 }
 ```
+
+r[expr.return.type]
+A `return` expression itself has a type of [`!`](../types/never.md).

--- a/src/expressions/return-expr.md
+++ b/src/expressions/return-expr.md
@@ -12,6 +12,8 @@ Return expressions are denoted with the keyword `return`.
 r[expr.return.behavior]
 Evaluating a `return` expression moves its argument into the designated output location for the current function call, destroys the current function activation frame, and transfers control to the caller frame.
 
+Thus, a `return` expression itself has a type of [`!`](../types/never.md).
+
 An example of a `return` expression:
 
 ```rust
@@ -22,6 +24,3 @@ fn max(a: i32, b: i32) -> i32 {
     return b;
 }
 ```
-
-r[expr.return.type]
-A `return` expression itself has a type of [`!`](../types/never.md).

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -50,7 +50,7 @@ r[items.fn.signature]
 Functions may declare a set of *input* [*variables*][variables] as parameters, through which the caller passes arguments into the function, and the *output* [*type*][type] of the value the function will return to its caller on completion.
 
 r[items.fn.implicit-return]
-If the output type is not explicitly stated, it is the [unit type].
+If the output type is not explicitly stated, it is the [unit type]. However, if the block expression is not [diverging](../divergence.md), then the output type is instead [`!`](../types/never.md).
 
 r[items.fn.fn-item-type]
 When referred to, a _function_ yields a first-class *value* of the corresponding zero-sized [*function item type*], which when called evaluates to a direct call to the function.

--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -50,7 +50,7 @@ r[items.fn.signature]
 Functions may declare a set of *input* [*variables*][variables] as parameters, through which the caller passes arguments into the function, and the *output* [*type*][type] of the value the function will return to its caller on completion.
 
 r[items.fn.implicit-return]
-If the output type is not explicitly stated, it is the [unit type]. However, if the block expression is not [diverging](../divergence.md), then the output type is instead [`!`](../types/never.md).
+If the output type is not explicitly stated, it is the [unit type].
 
 r[items.fn.fn-item-type]
 When referred to, a _function_ yields a first-class *value* of the corresponding zero-sized [*function item type*], which when called evaluates to a direct call to the function.

--- a/src/type-coercions.md
+++ b/src/type-coercions.md
@@ -208,6 +208,8 @@ In some contexts, the compiler must coerce together multiple types to try and fi
 + To find the common type for a series of if branches.
 + To find the common type for a series of match arms.
 + To find the common type for array elements.
++ To find the common type for a [labeled block expression] among the break operands and the final block operand.
++ To find the common type for an [`loop` expression with break expressions] among the break operands.
 + To find the type for the return type of a closure with multiple return statements.
 + To check the type for the return type of a function with multiple return statements.
 
@@ -285,5 +287,7 @@ This description is obviously informal. Making it more precise is expected to pr
 [type cast operator]: expressions/operator-expr.md#type-cast-expressions
 [`Unsize`]: std::marker::Unsize
 [`CoerceUnsized`]: std::ops::CoerceUnsized
+[labeled block expression]: expr.loop.block-labels
+[`loop` expression with break expressions]: expr.loop.break-value
 [method-call expressions]: expressions/method-call-expr.md
 [supertraits]: items/traits.md#supertraits


### PR DESCRIPTION
It was little tricky when trying to describe *diverging blocks*. The compiler's implementation maintains sort of a "global state" when checking an expression and sub-expressions, which it resets on conditional things. Semantically, I think the way I worded it is much clearer than trying to match the implementation.

Happy to hear any specific feedback, Lcnr made did an initial review pass in https://github.com/rust-lang/project-goal-reference-expansion/commit/407917146a090fac7ec3ae31132447bce8c98137, so the second commit tries to address that.

Closes https://github.com/rust-lang/reference/issues/271
Closes https://github.com/rust-lang/reference/issues/1033