### PR TITLE
Update Unicode version and links to 17.0

### DIFF
--- a/src/identifiers.md
+++ b/src/identifiers.md
@@ -20,7 +20,7 @@ RESERVED_RAW_IDENTIFIER -> `r#` (`_` | `crate` | `self` | `Self` | `super`)
 
 <!-- When updating the version, update the UAX links, too. -->
 r[ident.unicode]
-Identifiers follow the specification in [Unicode Standard Annex #31][UAX31] for Unicode version 16.0, with the additions described below. Some examples of identifiers:
+Identifiers follow the specification in [Unicode Standard Annex #31][UAX31] for Unicode version 17.0, with the additions described below. Some examples of identifiers:
 
 * `foo`
 * `_identifier`
@@ -86,5 +86,5 @@ It is an error to use the [RESERVED_RAW_IDENTIFIER] token.
 [proc-macro]: procedural-macros.md
 [reserved]: keywords.md#reserved-keywords
 [strict]: keywords.md#strict-keywords
-[UAX15]: https://www.unicode.org/reports/tr15/tr15-56.html
-[UAX31]: https://www.unicode.org/reports/tr31/tr31-41.html
+[UAX15]: https://www.unicode.org/reports/tr15/tr15-57.html
+[UAX31]: https://www.unicode.org/reports/tr31/tr31-43.html


### PR DESCRIPTION
As specified by the change in https://github.com/rust-lang/rust/pull/148831.