### PR TITLE
start documenting how to satisfy trait bounds

### DIFF
--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -310,6 +310,14 @@ struct Foo<#[my_flexible_clone(unbounded)] H> {
 }
 ```
 
+## Instantiation
+
+r[items.generics.instantiation]
+When using an item its generic parameters have to get instantiated.
+
+> [!NOTE]
+> This is a placeholder for future expansion and overlaps with [items.fn.generics.mono].
+
 [array repeat expression]: ../expressions/array-expr.md
 [arrays]: ../types/array.md
 [slices]: ../types/slice.md


### PR DESCRIPTION
This doesn't explain a few things which might be good:
- what does it mean for generic arguments to be equal to each other
- any sort of alias-bound candidates, normalization
- type inference variables

I also don't know how to talk about `r[items.generics.instantiation]` and deduplicate it with `[items.fn.generics.mono]`. Moving `[items.fn.generics.mono]` out of the function chapter makes the reference less useful for teaching/to learn things.

I also don't know how to do examples. For candidate preference I have a large set of examples https://rustc-dev-guide.rust-lang.org/solve/candidate-preference.html. I don't know how we'd put them into the reference.