### PR TITLE
Add review process overview to review-policy.md

### DIFF
--- a/docs/review-policy.md
+++ b/docs/review-policy.md
@@ -1,5 +1,13 @@
 Team members are given permission to merge changes from other contributors in the <https://github.com/rust-lang/reference> repository. There are different guidelines for reviewing based on the kind of changes being made:
 
+## Review Principles
+
+Reviewers and authors should focus on a few key principles during the review process:
+
+* **Understandability**: Language within the reference should be understandable to most members of the project. Contributions should assumes that readers are familiar with the rest of the content of the reference, but wherever possible sections should facilitate that understanding by linking to related content that are needed to build an understanding.
+* **Defensibility**: When the lang-docs team merges a change to the reference they are agreeing to take responsibility for it going forward. Team members need to feel confident defending and explaining the correctness of content within the reference. Whenever possible, changes to the reference should back up any claims they make with concise examples verifying their correctness.
+* **Voice**: Authors are not expected to have specification writer competence when drafting new contributions to the reference. So long as claims are understandable and defensible, it is fine for PRs to be written in a casual tone or with the voice of the author instead of the voice of the reference. Team members are expected to bring editorial experience as part of their reviews and will edit the phrasing to fit the reference before merging if necessary.
+
 ## Policy changes
 
 - Significant changes to the policy of how the team operates, such as changes to this document, should have agreement of the team without any blocking objections.

--- a/docs/review-policy.md
+++ b/docs/review-policy.md
@@ -1,12 +1,12 @@
 Team members are given permission to merge changes from other contributors in the <https://github.com/rust-lang/reference> repository. There are different guidelines for reviewing based on the kind of changes being made:
 
-## Review Principles
+## Review principles
 
 Reviewers and authors should focus on a few key principles during the review process:
 
-* **Understandability**: Language within the reference should be understandable to most members of the project. Contributions should assumes that readers are familiar with the rest of the content of the reference, but wherever possible sections should facilitate that understanding by linking to related content that are needed to build an understanding.
-* **Defensibility**: When the lang-docs team merges a change to the reference they are agreeing to take responsibility for it going forward. Team members need to feel confident defending and explaining the correctness of content within the reference. Whenever possible, changes to the reference should back up any claims they make with concise examples verifying their correctness.
-* **Voice**: Authors are not expected to have specification writer competence when drafting new contributions to the reference. So long as claims are understandable and defensible, it is fine for PRs to be written in a casual tone or with the voice of the author instead of the voice of the reference. Team members are expected to bring editorial experience as part of their reviews and will edit the phrasing to fit the reference before merging if necessary.
+* **Understandability**: Language within the Reference should be understandable to most members of the Project. Contributions should assumes that readers are familiar with the rest of the content of the Reference, but, wherever possible, sections should facilitate that understanding by linking to related content.
+* **Defensibility**: When the lang-docs team merges a change to the Reference, they are agreeing to take responsibility for it going forward. Team members need to feel confident defending and explaining the correctness of content within the Reference. Whenever possible, changes to the Reference should back up any claims with concise examples to verify correctness.
+* **Voice**: Authors are not expected to have competence as a specification writer when drafting new contributions to the Reference. So long as claims are understandable and defensible, it is fine for PRs to be written in a casual tone or with the voice of the author instead of the voice of the Reference. Team members will bring editorial experience as part of their reviews and will revise the phrasing, organization, style, etc. to fit the Reference before merging if necessary.
 
 ## Policy changes
 


### PR DESCRIPTION
This section slightly duplicates the text below. In the review flowchart, this policy already discusses "checking if the content is true," which I feel corresponds to the defensibility goal, and the "is this editorially sound" and "is this well written," which I think are aimed more directly at reviewers and ensuring they bring a consistent tone to the contribution pre-merge. Understandability isn't explicitly mentioned in the policy, afaict.

With this new section, I wanted to speak more to both reviewers and authors, including subject-matter reviewers who aren't necessarily bringing the editorial expertise to help set better expectations for how the back-and-forth of the review process is expected to work. As part of that, I wanted to explain the underlying rationale for these goals/principles of the review process. I'm not really sure the voice one fits in as it's currently structured, since it's sort of a goal/non-goal depending on who the reader is, but this seemed good enough for a first pass.