### PR TITLE
Remove restriction on dereferencing pointers in const

### DIFF
--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -203,7 +203,7 @@ r[const-eval.const-expr.borrows]
   > See [issue #143129](https://github.com/rust-lang/rust/issues/143129) for more details.
 
 r[const-eval.const-expr.deref]
-* The [dereference operator].
+* [Dereference expressions].
 
   ```rust,no_run
   # use core::cell::UnsafeCell;
@@ -320,8 +320,8 @@ The types of a const function's parameters and return type are restricted to tho
 [constant expressions]: #constant-expressions
 [constants]:            items/constant-items.md
 [Const parameters]:     items/generics.md
-[dereference expression]: expressions/operator-expr.md#the-dereference-operator
-[dereference operator]: expressions/operator-expr.md#the-dereference-operator
+[dereference expression]: expr.deref
+[dereference expressions]: expr.deref
 [destructors]:          destructors.md
 [enum discriminants]:   items/enumerations.md#discriminants
 [expression statements]: statements.md#expression-statements

--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -203,7 +203,23 @@ r[const-eval.const-expr.borrows]
   > See [issue #143129](https://github.com/rust-lang/rust/issues/143129) for more details.
 
 r[const-eval.const-expr.deref]
-* The [dereference operator] except for raw pointers.
+* The [dereference operator].
+
+  ```rust,no_run
+  # use core::cell::UnsafeCell;
+  const _: u8 = unsafe {
+      let x: *mut u8 = &raw mut *&mut 0;
+      //                        ^^^^^^^
+      //             Dereference of mutable reference.
+      *x = 1; // Dereference of mutable pointer.
+      *(x as *const u8) // Dereference of constant pointer.
+  };
+  const _: u8 = unsafe {
+      let x = &UnsafeCell::new(0);
+      *x.get() = 1; // Mutation of interior mutable value.
+      *x.get()
+  };
+  ```
 
 r[const-eval.const-expr.group]
 


### PR DESCRIPTION
We had said that the dereference operator could not be used with raw pointers in a constant expression.  However, that restriction has been lifted.  First, in Rust 1.58, we stabilized
`const_raw_ptr_deref`.

https://github.com/rust-lang/rust/pull/89551

This allowed for dereferencing immutable raw pointers in a constant expression.  Then, in Rust 1.83, we stabilized `const_mut_refs` and `const_refs_to_cell`.

https://github.com/rust-lang/rust/pull/129195

That allowed for:

- Mentioning `&mut` types.
- Creating `&mut` and `*mut` values.
- Creating `&T` and `*const T` values where `T` contains interior mutability.
- Dereferencing `&mut` and `*mut` values (both for reads and writes).

Let's remove the stated restriction on dereferencing raw pointers in a constant expression and add examples.

cc @ehuss @RalfJung

---

I noticed this when double-checking that we didn't need to do anything for:

- https://github.com/rust-lang/rust/pull/148259

cc @rust-lang/fls
