### PR TITLE
Fix restrictions of or-patterns

### DIFF
--- a/src/patterns.md
+++ b/src/patterns.md
@@ -1059,7 +1059,7 @@ r[patterns.or]
 
 _Or-patterns_ are patterns that match on one of two or more sub-patterns (for example `A | B | C`).
 They can nest arbitrarily.
-Syntactically, or-patterns are allowed in any of the places where other patterns are allowed (represented by the [Pattern] production), with the exceptions of `let`-bindings and function and closure arguments (represented by the [PatternNoTopAlt] production).
+Syntactically, or-patterns are allowed in any of the places where other patterns are allowed (represented by the [Pattern] production), with the exceptions of `let`-bindings and function and closure parameters (represented by the [PatternNoTopAlt] production).
 
 r[patterns.constraints]
 ### Static semantics


### PR DESCRIPTION
A small discrepancy in the definition of `or-patterns` was discovered during the `rust-lang/fls` meeting on 2025-12-12 involving Eric Huss and TC - `or-patterns` must not be used in function and closure **parameters**, as opposed to function and closure arguments as stated in the text. Function and closure parameters are the constructs carrying `PatternNoTopAlt`s.