### PR TITLE
conditional-compilation: add a space in `cfg.cfg_attr.attribute-list`

### DIFF
--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -443,7 +443,7 @@ Zero, one, or more attributes may be listed. Multiple attributes will each be ex
 > ```
 
 > [!NOTE]
-> The `cfg_attr` can expand to another `cfg_attr`. For example, `#[cfg_attr(target_os = "linux", cfg_attr(feature = "multithreaded", some_other_attribute))]` is valid. This example would be equivalent to `#[cfg_attr(all(target_os = "linux", feature ="multithreaded"), some_other_attribute)]`.
+> The `cfg_attr` can expand to another `cfg_attr`. For example, `#[cfg_attr(target_os = "linux", cfg_attr(feature = "multithreaded", some_other_attribute))]` is valid. This example would be equivalent to `#[cfg_attr(all(target_os = "linux", feature = "multithreaded"), some_other_attribute)]`.
 
 r[cfg.macro]
 ### The `cfg` macro


### PR DESCRIPTION
The other uses of `cfg` and `cfg_attr` have spaces on both sides of the `=`, but in the example of nested `cfg_attr` attributes, the space afterwards was missing; add it.