### PR TITLE
items: clarify label for type-aliases documentation

### DIFF
--- a/src/items.md
+++ b/src/items.md
@@ -46,7 +46,7 @@ There are several kinds of items:
 * [`extern crate` declarations]
 * [`use` declarations]
 * [function definitions]
-* [type definitions]
+* [type aliases]
 * [struct definitions]
 * [enumeration definitions]
 * [union definitions]
@@ -93,5 +93,5 @@ See [item scopes] for information on the scoping rules of items.
 [struct definitions]: items/structs.md
 [trait definitions]: items/traits.md
 [traits]: items/traits.md
-[type definitions]: items/type-aliases.md
+[type aliases]: items/type-aliases.md
 [union definitions]: items/unions.md

--- a/src/items.md
+++ b/src/items.md
@@ -46,7 +46,7 @@ There are several kinds of items:
 * [`extern crate` declarations]
 * [`use` declarations]
 * [function definitions]
-* [type aliases]
+* [type alias definitions]
 * [struct definitions]
 * [enumeration definitions]
 * [union definitions]
@@ -93,5 +93,5 @@ See [item scopes] for information on the scoping rules of items.
 [struct definitions]: items/structs.md
 [trait definitions]: items/traits.md
 [traits]: items/traits.md
-[type aliases]: items/type-aliases.md
+[type alias definitions]: items/type-aliases.md
 [union definitions]: items/unions.md


### PR DESCRIPTION
"type definitions" could be about structs, enums, or unions too; the syntax diagram and the link target both refer to type aliases, so use that label for the link.