### PR TITLE
attributes: add missing punctuation to instruction_set

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -298,7 +298,7 @@ The following is an index of all built-in attributes.
   - [`no_builtins`] --- Disables use of certain built-in functions.
   - [`target_feature`] --- Configure platform-specific code generation.
   - [`track_caller`] --- Pass the parent call location to `std::panic::Location::caller()`.
-  - [`instruction_set`] --- Specify the instruction set used to generate a functions code
+  - [`instruction_set`] --- Specify the instruction set used to generate a function's code.
 
 - Documentation
   - `doc` --- Specifies documentation. See [The Rustdoc Book] for more


### PR DESCRIPTION
The short description for each built in attribute except `instruction_set` was terminated with a period; add the missing period. Add a missing apostrophe to "functions code" in that description.