### PR TITLE
operator-expr: remove stray word in footnote

### DIFF
--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -549,7 +549,7 @@ reference types and `mut` or `const` in pointer types.
 [^lessmut]: only when `m₁` is `mut` or `m₂` is `const`. Casting `mut` reference/pointer to
 `const` pointer is allowed.
 
-[^no-capture]: only for closures that do not capture (close over) any local variables can be casted to function pointers.
+[^no-capture]: only closures that do not capture (close over) any local variables can be casted to function pointers.
 
 ### Semantics
 

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -539,17 +539,17 @@ reference types and `mut` or `const` in pointer types.
 | [Function pointer]    | Integer               | Function pointer to address cast                      |
 | Closure [^no-capture] | Function pointer      | Closure to function pointer cast                      |
 
-[^meta-compat]: where `T` and `V` have compatible metadata:
+[^meta-compat]: Where `T` and `V` have compatible metadata:
       * `V: Sized`, or
       * Both slice metadata (`*[u16]` -> `*[u8]`, `*str` -> `*(u8, [u32])`), or
       * Both the same trait object metadata, modulo dropping auto traits (`*dyn Debug` -> `*(u16, dyn Debug)`, `*dyn Debug + Send` -> `*dyn Debug`)
           * **Note**: *adding* auto traits is only allowed if the principal trait has the auto trait as a super trait (given `trait T: Send {}`, `*dyn T` -> `*dyn T + Send` is valid, but `*dyn Debug` -> `*dyn Debug + Send` is not)
           * **Note**: Generics (including lifetimes) must match (`*dyn T<'a, A>` -> `*dyn T<'b, B>` requires `'a = 'b` and `A = B`)
 
-[^lessmut]: only when `m₁` is `mut` or `m₂` is `const`. Casting `mut` reference/pointer to
+[^lessmut]: Only when `m₁` is `mut` or `m₂` is `const`. Casting `mut` reference/pointer to
 `const` pointer is allowed.
 
-[^no-capture]: only closures that do not capture (close over) any local variables can be casted to function pointers.
+[^no-capture]: Only closures that do not capture (close over) any local variables can be casted to function pointers.
 
 ### Semantics
 

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -549,7 +549,7 @@ reference types and `mut` or `const` in pointer types.
 [^lessmut]: Only when `m₁` is `mut` or `m₂` is `const`. Casting `mut` reference/pointer to
 `const` pointer is allowed.
 
-[^no-capture]: Only closures that do not capture (close over) any local variables can be casted to function pointers.
+[^no-capture]: Only closures that do not capture (close over) any local variables can be cast to function pointers.
 
 ### Semantics
 

--- a/src/items/enumerations.md
+++ b/src/items/enumerations.md
@@ -241,7 +241,7 @@ assert_eq!(2, Enum::Baz as isize);
 ```
 
 r[items.enum.discriminant.coercion.fieldless]
-[Field-less enums] can be casted if they do not have explicit discriminants, or where only unit variants are explicit.
+[Field-less enums] can be cast if they do not have explicit discriminants, or where only unit variants are explicit.
 
 ```rust
 enum Fieldless {

--- a/src/items/traits.md
+++ b/src/items/traits.md
@@ -173,7 +173,7 @@ trait DynIncompatible {
     fn foo() {}  // ERROR: associated function without Sized
     fn returns(&self) -> Self; // ERROR: Self in return type
     fn typed<T>(&self, x: T) {} // ERROR: has generic type parameters
-    fn nested(self: Rc<Box<Self>>) {} // ERROR: nested receiver cannot be downcasted
+    fn nested(self: Rc<Box<Self>>) {} // ERROR: nested receiver cannot be dispatched on
 }
 
 struct S;


### PR DESCRIPTION
"only for closures that {x} can be {y}" repeats the limitation; it should either be "only closures that {x} can be {y}", or, if the capability ("{y}") is implicit, it can be "only for closures that {x}". Go with the first option that keeps the context, and remove the extra "for".