### PR TITLE
Fix ambiguity of RESERVED_RAW_IDENTIFIER

### DIFF
--- a/src/identifiers.md
+++ b/src/identifiers.md
@@ -15,7 +15,8 @@ NON_KEYWORD_IDENTIFIER -> IDENTIFIER_OR_KEYWORD _except a [strict][lex.keywords.
 
 IDENTIFIER -> NON_KEYWORD_IDENTIFIER | RAW_IDENTIFIER
 
-RESERVED_RAW_IDENTIFIER -> `r#` (`_` | `crate` | `self` | `Self` | `super`)
+RESERVED_RAW_IDENTIFIER ->
+    `r#` (`_` | `crate` | `self` | `Self` | `super`) _not immediately followed by XID_Continue_
 ```
 
 <!-- When updating the version, update the UAX links, too. -->


### PR DESCRIPTION
This clarifies that the literals expressed in the
RESERVED_RAW_IDENTIFIER rule cannot be followed by a XID_Continue character. Originally in my mind these literals were to be interpreted as tokens (and thus assume some kind of break follows them). However, since this is part of the lexer itself, this doesn't really work for it to be defined this way.

This helps ensure that strings like `r#_f` or `r#selfie` are not interpreted as reserved raw identifiers.