### PR TITLE
Update note about shebang removal in `include`d files

### DIFF
--- a/src/input-format.md
+++ b/src/input-format.md
@@ -60,9 +60,13 @@ r[input.tokenization]
 The resulting sequence of characters is then converted into tokens as described in the remainder of this chapter.
 
 > [!NOTE]
-> The standard library [`include!`] macro applies byte order mark removal and CRLF normalization to the file it reads.
-> Moreover, it applies shebang removal if invoked in an item context (as opposed to expression or statement contexts).
-> The [`include_str!`] and [`include_bytes!`] macros do not perform any of these preprocessing steps.
+> The standard library [`include!`] macro applies the following transformations to the file it reads:
+>
+> - Byte order mark removal.
+> - CRLF normalization.
+> - Shebang removal when invoked in an item context (as opposed to expression or statement contexts).
+>
+> The [`include_str!`] and [`include_bytes!`] macros do not apply these transformations.
 
 [inner attribute]: attributes.md
 [BYTE ORDER MARK]: https://en.wikipedia.org/wiki/Byte_order_mark#UTF-8

--- a/src/input-format.md
+++ b/src/input-format.md
@@ -55,7 +55,9 @@ r[input.shebang.inner-attribute]
 As an exception, if the `#!` characters are followed (ignoring intervening [comments] or [whitespace]) by a `[` token, nothing is removed. This prevents an [inner attribute] at the start of a source file being removed.
 
 > [!NOTE]
-> The standard library [`include!`] macro applies byte order mark removal, CRLF normalization, and shebang removal to the file it reads. The [`include_str!`] and [`include_bytes!`] macros do not.
+> The standard library [`include!`] macro applies byte order mark removal and CRLF normalization to the file it reads.
+> Moreover, it applies shebang removal if invoked in an item context (as opposed to expression or statement contexts).
+> The [`include_str!`] and [`include_bytes!`] macros do not perform any of these preprocessing steps.
 
 r[input.tokenization]
 ## Tokenization

--- a/src/input-format.md
+++ b/src/input-format.md
@@ -54,15 +54,15 @@ fn main() {
 r[input.shebang.inner-attribute]
 As an exception, if the `#!` characters are followed (ignoring intervening [comments] or [whitespace]) by a `[` token, nothing is removed. This prevents an [inner attribute] at the start of a source file being removed.
 
-> [!NOTE]
-> The standard library [`include!`] macro applies byte order mark removal and CRLF normalization to the file it reads.
-> Moreover, it applies shebang removal if invoked in an item context (as opposed to expression or statement contexts).
-> The [`include_str!`] and [`include_bytes!`] macros do not perform any of these preprocessing steps.
-
 r[input.tokenization]
 ## Tokenization
 
 The resulting sequence of characters is then converted into tokens as described in the remainder of this chapter.
+
+> [!NOTE]
+> The standard library [`include!`] macro applies byte order mark removal and CRLF normalization to the file it reads.
+> Moreover, it applies shebang removal if invoked in an item context (as opposed to expression or statement contexts).
+> The [`include_str!`] and [`include_bytes!`] macros do not perform any of these preprocessing steps.
 
 [inner attribute]: attributes.md
 [BYTE ORDER MARK]: https://en.wikipedia.org/wiki/Byte_order_mark#UTF-8


### PR DESCRIPTION
Imports changes from https://github.com/rust-lang/rust/pull/146377.

I'm open to wording suggestions.

r? traviscross