### PR TITLE
Remove cargo workspace inheritance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,3 @@ exclude = [
     "linkchecker"
 ]
 resolver = "2"
-
-[workspace.package]
-edition = "2024"
-license = "MIT OR Apache-2.0"
-
-[workspace.dependencies]
-diagnostics = { path = "tools/diagnostics" }
-grammar = { path = "tools/grammar" }
-pathdiff =  "0.2.3"
-regex = "1.12.2"
-walkdir = "2.5.0"

--- a/tools/diagnostics/Cargo.toml
+++ b/tools/diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagnostics"
-edition.workspace = true
-license.workspace = true
+edition = "2024"
+license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/tools/grammar/Cargo.toml
+++ b/tools/grammar/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "grammar"
-edition.workspace = true
-license.workspace = true
+edition = "2024"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
-diagnostics.workspace = true
-pathdiff.workspace = true
-regex.workspace = true
-walkdir.workspace = true
+diagnostics = { path = "../diagnostics" }
+pathdiff =  "0.2.3"
+regex = "1.12.2"
+walkdir = "2.5.0"

--- a/tools/mdbook-spec/Cargo.toml
+++ b/tools/mdbook-spec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mdbook-spec"
-edition.workspace = true
-license.workspace = true
+edition = "2024"
+license = "MIT OR Apache-2.0"
 description = "An mdBook preprocessor to help with the Rust specification."
 repository = "https://github.com/rust-lang/spec/"
 default-run = "mdbook-spec"
@@ -10,15 +10,15 @@ default-run = "mdbook-spec"
 
 [dependencies]
 anyhow = "1.0.79"
-diagnostics.workspace = true
-grammar.workspace = true
+diagnostics = { path = "../diagnostics" }
+grammar = { path = "../grammar" }
 mdbook-markdown = "0.5.1"
 mdbook-preprocessor = "0.5.1"
 once_cell = "1.19.0"
 pathdiff = "0.2.1"
 railroad = { version = "0.3.2", default-features = false }
-regex.workspace = true
+regex = "1.12.2"
 semver = "1.0.21"
 serde_json = "1.0.113"
 tempfile = "3.10.1"
-walkdir.workspace = true
+walkdir = "2.5.0"

--- a/tools/style-check/Cargo.toml
+++ b/tools/style-check/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "style-check"
-edition.workspace = true
-license.workspace = true
+edition = "2024"
+license = "MIT OR Apache-2.0"
 authors = ["steveklabnik <steve@steveklabnik.com>"]
 
 [dependencies]

--- a/tools/xtask/Cargo.toml
+++ b/tools/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-edition.workspace = true
-license.workspace = true
+edition = "2024"
+license = "MIT OR Apache-2.0"
 
 [dependencies]


### PR DESCRIPTION
This removes the inheritance added in 39239d00780c476d9fe84db833b442b7b6695f3f. Due to the way `mdbook-spec` is integrated into `rust-lang/rust`, `cargo vendor` does not work. This doesn't work because we are trying to meld multiple workspaces, and `cargo vendor` doesn't normalize/remove the workspace inheritance.