### PR TITLE
Add missing semicolon to ambiguity.glob-vs-glob

### DIFF
--- a/src/names/name-resolution.md
+++ b/src/names/name-resolution.md
@@ -170,7 +170,7 @@ const _: () = {
     // The error happens when the name with the conflicting candidates
     // is used.
     let x = Ambig; // ERROR: `Ambig` is ambiguous.
-}
+};
 ```
 
 ```rust,no_run


### PR DESCRIPTION
This example was missing a semicolon which causes a second error.