### PR TITLE
Denote examples better

### DIFF
--- a/src/introduction.md
+++ b/src/introduction.md
@@ -109,7 +109,7 @@ These conventions are documented here.
 
   All examples are written for the latest edition unless otherwise stated.
 
-* The grammar and lexical productions are described in the [Notation] chapter:
+* The grammar and lexical productions are described in the [Notation] chapter.
 
 r[example.rule.label]
 * Rule identifiers appear before each language rule enclosed in square brackets. These identifiers provide a way to refer to and link to a specific rule in the language ([e.g.][example rule]). The rule identifier uses periods to separate sections from most general to most specific ([destructors.scope.nesting.function-body] for example). On narrow screens, the rule name will collapse to display `[*]`.


### PR DESCRIPTION
By using `:` in the text and `> ` in the Markdown.

I replaced with a more distinct example in the first two `> ` blocks to denote better to the reader that these are examples.

[The way it is currently written in the reference](https://doc.rust-lang.org/stable/reference/#conventions) can create confusion. I looked awhile at it, trying to make sense why you would write examples for terms in italics too (= I parsed this sentence as meta language). Until I grasped that this sentence *is* an example (= the sentence is to be parsed as object language).

This is partly due to the fact that `> ` blocks are not rendered in a special way (at this position?) in the book. And further, the first example (the second paragraph of the first list item, which I have split into two examples) was missing the `> `s.

Please modify at will. Just remove the ambiguity between object and meta language.