### PR TITLE
const-eval: explain the final-value-byte-provenance restriction

### DIFF
--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -232,6 +232,12 @@ r[const-eval.const-expr.loop]
 r[const-eval.const-expr.if-match]
 * [if] and [match] expressions.
 
+r[const-eval.const-expr.final-value-provenance]
+The representation of the final value of a constant or static initializer must only contain provenance in whole-pointer groups: if a byte has provenance but is not part of an adjacent group of bytes that form an entire pointer, compilation will fail.
+
+If a byte in the representation of the final value is uninitialized, then it *may* end up having provenance, which can cause compilation to fail.
+As a quality-of-implementation concern, the compiler should only actually fail if the initializer copies or overwrites parts of a pointer and that memory ends up in the final value.
+
 r[const-eval.const-context]
 ## Const context
 [const context]: #const-context

--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -264,6 +264,28 @@ const _: Pair = unsafe {
 > The bytes with provenance must form a complete pointer in the correct order. In the example above, the pointer is written at offset 20, but a pointer requires 8 bytes (assuming an 8-byte pointer). Four of those bytes fit in the `y` field; the rest extend into the padding at offset 24. When the fields are initialized, the `y` bytes get overwritten, leaving only a partial pointer (4 bytes) in the padding. These 4 bytes have provenance but don't form a complete pointer, causing compilation to fail.
 >
 > This restriction ensures that any bytes with provenance in the final value represent complete pointers. Binary formats such as ELF cannot represent pointer fragments, so the compiler cannot emit them in the final binary.
+>
+> Reversing the order of the pointer bytes also causes compilation to fail, even though all bytes are present:
+>
+> ```rust,compile_fail
+> # use core::mem::{self, MaybeUninit};
+> const PTR_WIDTH: usize = mem::size_of::<*const u8>();
+> const _: MaybeUninit<u64> = unsafe {
+> //       ^^^^^^^^^^^^^^^^
+> //       ERROR: Partial pointer in final value of constant.
+>     let mut m = MaybeUninit::<u64>::uninit();
+>     let ptr: *const u8 = &0;
+>     let ptr_bytes = &raw const ptr as *const MaybeUninit<u8>;
+>     // Write pointer bytes in reverse order.
+>     let dst: *mut MaybeUninit<u8> = m.as_mut_ptr().cast();
+>     let mut i = 0;
+>     while i < PTR_WIDTH {
+>         dst.add(i).write(ptr_bytes.add(PTR_WIDTH - 1 - i).read());
+>         i += 1;
+>     }
+>     m
+> };
+> ```
 
 > [!NOTE]
 > If a byte in the representation of the final value is uninitialized, then it *may* end up having provenance, which can cause compilation to fail. `rustc` tries (but does not guarantee) to only actually fail if the initializer copies or overwrites parts of a pointer and those bytes appear in the final value.

--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -235,7 +235,7 @@ r[const-eval.const-expr.if-match]
 ## Const initializers
 
 r[const-eval.const-expr.final-value-provenance]
-The representation of the final value of a [constant][constant initializer] or [static initializer] must only contain bytes with provenance in whole-pointer groups. If a byte has provenance but is not part of an adjacent group of bytes that form an entire pointer, compilation will fail.
+The representation of the final value of a [constant][constant initializer] or [static initializer] must only contain bytes with provenance in whole-pointer groups. If a byte has provenance but is not part of an adjacent group of correctly-ordered bytes that form an entire pointer, compilation will fail.
 
 ```rust,compile_fail
 # use core::mem::MaybeUninit;

--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -232,11 +232,13 @@ r[const-eval.const-expr.loop]
 r[const-eval.const-expr.if-match]
 * [if] and [match] expressions.
 
-r[const-eval.const-expr.final-value-provenance]
-The representation of the final value of a constant or static initializer must only contain provenance in whole-pointer groups: if a byte has provenance but is not part of an adjacent group of bytes that form an entire pointer, compilation will fail.
+## Const initializers
 
-If a byte in the representation of the final value is uninitialized, then it *may* end up having provenance, which can cause compilation to fail.
-As a quality-of-implementation concern, the compiler should only actually fail if the initializer copies or overwrites parts of a pointer and that memory ends up in the final value.
+r[const-eval.const-expr.final-value-provenance]
+The representation of the final value of a [constant][constant initializer] or [static initializer] must only contain bytes with provenance in whole-pointer groups. If a byte has provenance but is not part of an adjacent group of bytes that form an entire pointer, compilation will fail.
+
+> [!NOTE]
+> If a byte in the representation of the final value is uninitialized, then it *may* end up having provenance, which can cause compilation to fail. `rustc` tries (but does not guarantee) to only actually fail if the initializer copies or overwrites parts of a pointer and those bytes appear in the final value.
 
 r[const-eval.const-context]
 ## Const context
@@ -313,6 +315,7 @@ The types of a const function's parameters and return type are restricted to tho
 [const generic argument]: items/generics.md#const-generics
 [const generic parameters]: items/generics.md#const-generics
 [constant expressions]: #constant-expressions
+[constant initializer]: items.const
 [constants]:            items/constant-items.md
 [Const parameters]:     items/generics.md
 [dereference expression]: expr.deref
@@ -342,6 +345,7 @@ The types of a const function's parameters and return type are restricted to tho
 [promoted]:             destructors.md#constant-promotion
 [range expressions]:    expressions/range-expr.md
 [slice]:                types/slice.md
+[static initializer]: items.static.init
 [statics]:              items/static-items.md
 [Struct expressions]:   expressions/struct-expr.md
 [temporary lifetime extension]: destructors.scope.lifetime-extension

--- a/src/const_eval.md
+++ b/src/const_eval.md
@@ -261,6 +261,11 @@ const _: Pair = unsafe {
 ```
 
 > [!NOTE]
+> The bytes with provenance must form a complete pointer in the correct order. In the example above, the pointer is written at offset 20, but a pointer requires 8 bytes (assuming an 8-byte pointer). Four of those bytes fit in the `y` field; the rest extend into the padding at offset 24. When the fields are initialized, the `y` bytes get overwritten, leaving only a partial pointer (4 bytes) in the padding. These 4 bytes have provenance but don't form a complete pointer, causing compilation to fail.
+>
+> This restriction ensures that any bytes with provenance in the final value represent complete pointers. Binary formats such as ELF cannot represent pointer fragments, so the compiler cannot emit them in the final binary.
+
+> [!NOTE]
 > If a byte in the representation of the final value is uninitialized, then it *may* end up having provenance, which can cause compilation to fail. `rustc` tries (but does not guarantee) to only actually fail if the initializer copies or overwrites parts of a pointer and those bytes appear in the final value.
 >
 > E.g., `rustc` currently accepts this, even though the padding bytes are uninitialized:


### PR DESCRIPTION
This is the docs part for https://github.com/rust-lang/rust/pull/148967.

I had no idea where to put it. Putting it in "const-expr" is odd since that is generally a *compositional* notion (the subexpressions of a const expression must be const expressions), whereas the limitation I am describing here only applies *at the top level*, i.e. for the final value of a const/static initializer.

### Related

- https://github.com/rust-lang/rust/issues/148470
- https://github.com/rust-lang/rust/pull/148967
- https://github.com/rust-lang/rust/pull/144081