### PR TITLE
Clarify only arrays undergo unsized coercion during dispatch

### DIFF
--- a/src/expressions/method-call-expr.md
+++ b/src/expressions/method-call-expr.md
@@ -22,7 +22,7 @@ r[expr.method.autoref-deref]
 When looking up a method call, the receiver may be automatically dereferenced or borrowed in order to call a method. This requires a more complex lookup process than for other functions, since there may be a number of possible methods to call. The following procedure is used:
 
 r[expr.method.candidate-receivers]
-The first step is to build a list of candidate receiver types. Obtain these by repeatedly [dereferencing][dereference] the receiver expression's type, adding each type encountered to the list, then finally attempting an [unsized coercion] at the end, and adding the result type if that is successful.
+The first step is to build a list of candidate receiver types. Obtain these by repeatedly [dereferencing][dereference] the receiver expression's type, adding each type encountered to the list, then finally attempting an array [unsized coercion] at the end, and adding the result type if that is successful.
 
 r[expr.method.candidate-receivers-refs]
 Then, for each candidate `T`, add `&T` and `&mut T` to the list immediately after `T`.


### PR DESCRIPTION
A small example to illustrate the difference between array and trait unsized coercions: ([playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&code=%23%21%5Bfeature%28unsize%29%5D%0A%0Afn+check_dyn%28t%3A+%26Type%29+%7B%0A++++check_is_unsize%3A%3A%3CType%2C+dyn+Trait%3E%28%29%3B+%2F%2F+Success%0A++++t.method%28%29%3B+%2F%2F%7EERROR%0A%7D%0A%0Afn+check_array%28t%3A+%26%5Bi32%3B+3%5D%29+%7B%0A++++check_is_unsize%3A%3A%3C%5Bi32%3B+3%5D%2C+%5Bi32%5D%3E%28%29%3B+%2F%2F+Success%0A++++t.len%28%29%3B+%2F%2F+Success%0A++++%2F%2F+%5E+Note+that+len+is+only+defined+on+%5BT%5D.%0A%7D%0A%0Afn+check_is_unsize%3CFrom%3A+%3FSized%2C+To%3A+%3FSized%3E%28%29%0Awhere%0A++++From%3A+std%3A%3Amarker%3A%3AUnsize%3CTo%3E%2C%0A%7B%7D%0A%0Astruct+Type%3B%0A%0Atrait+Trait+%7B%7D%0A%0Aimpl+dyn+Trait+%7B%0A++++fn+method%28%26self%29+%7B%7D%0A%7D%0A%0Aimpl+Trait+for+Type+%7B%7D))

```rust
fn check_dyn(t: &Type) {
    check_is_unsize::<Type, dyn Trait>(); // Success
    t.method(); //~ERROR
}

fn check_array(t: &[i32; 3]) {
    check_is_unsize::<[i32; 3], [i32]>(); // Success
    t.len(); // Success
    // ^ Note that len is only defined on [T].
}

fn check_is_unsize<From: ?Sized, To: ?Sized>()
where
    From: std::marker::Unsize<To>,
{}

struct Type;

trait Trait {}

impl dyn Trait {
    fn method(&self) {}
}

impl Trait for Type {}
```

This came up during a discussion about autoref in zulip: [#t-lang/custom-refs > Autoref](https://rust-lang.zulipchat.com/#narrow/channel/522311-t-lang.2Fcustom-refs/topic/Autoref/with/567570937). Thanks to @BennoLossin for the original example.

The rustc dev guide [describes this algorithm](https://rustc-dev-guide.rust-lang.org/hir-typeck/method-lookup.html) similarly to the way the reference does today; it mentions unsized coercions in general, but only uses arrays as an example.