### PR TITLE
paths: align singular/plural in `paths.canonical.intro`

### DIFF
--- a/src/paths.md
+++ b/src/paths.md
@@ -395,7 +395,7 @@ r[paths.canonical]
 ## Canonical paths
 
 r[paths.canonical.intro]
-Items defined in a module or implementation have a *canonical path* that corresponds to where within its crate it is defined.
+Each item defined in a module or implementation has a *canonical path* that corresponds to where within its crate it is defined.
 
 r[paths.canonical.alias]
 All other paths to these items are aliases.


### PR DESCRIPTION
Consistently use the single form to describe the items, since the overall section generally refers to "canonical path" in the singular.