### PR TITLE
Remove exception WRT same-crate `non_exhaustive` reads

### DIFF
--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -334,7 +334,7 @@ c();
 ```
 
 r[type.closure.capture.precision.discriminants.non_exhaustive]
-If [`#[non_exhaustive]`][attributes.type-system.non_exhaustive] is applied to an enum defined in an external crate, the enum is treated as having multiple variants for the purpose of deciding whether a read occurs, even if it actually has only one variant.
+If [`#[non_exhaustive]`][attributes.type-system.non_exhaustive] is applied to an enum, the enum is treated as having multiple variants for the purpose of deciding whether a read occurs, even if it actually has only one variant.
 
 r[type.closure.capture.precision.discriminants.uninhabited-variants]
 Even if all variants but the one being matched against are uninhabited, making the pattern [irrefutable][patterns.refutable], the discriminant is still read if it otherwise would be.


### PR DESCRIPTION
Stabilization:

- https://github.com/rust-lang/rust/pull/150681

When matching against a single-variant enum marked `non_exhaustive` and defined in a different crate, we pretend that there might be multiple variants and force a read of the discriminant.  In [Rust PR 150681], we decided to remove the same-crate exception.  Now matching against a single-variant `non_exhaustive` enum in the same crate will also cause a discriminant read.

Separately, prior to [Rust PR 150681], `rustc` was eliding the discriminant read when an enum has only one *inhabited* variant.  This contradicts what the Reference says in:

> r[type.closure.capture.precision.discriminants.uninhabited-variants]
> Even if all variants but the one being matched against are uninhabited, making the pattern [irrefutable][patterns.refutable], the discriminant is still read if it otherwise would be.

We decided with our lang FCP to confirm the behavior already encoded in the Reference, so no change is needed there.

[Rust PR 150681]: https://github.com/rust-lang/rust/pull/150681

cc @meithecatte @ehuss