### PR TITLE
Fix ordering of generic arguments

### DIFF
--- a/src/paths.md
+++ b/src/paths.md
@@ -83,7 +83,7 @@ Vec::<u8>::with_capacity(1024);
 ```
 
 r[paths.expr.argument-order]
-The order of generic arguments is restricted to lifetime arguments, then type arguments, then const arguments, then equality constraints.
+The order of generic arguments is restricted to lifetime parameters and then type and const parameters intermixed.
 
 r[paths.expr.complex-const-params]
 Const arguments must be surrounded by braces unless they are a [literal], an [inferred const], or a single segment path. An [inferred const] may not be surrounded by braces.


### PR DESCRIPTION
This was missed in https://github.com/rust-lang/reference/pull/1098 where the order of types and const generics was relaxed. See https://github.com/rust-lang/rust/pull/90207#issuecomment-958843546

Fixes https://github.com/rust-lang/reference/issues/1857