### PR TITLE
Fields must fit in the type, even for repr(Rust)

### DIFF
--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -173,7 +173,7 @@ The only data layout guarantees made by this representation are those required f
 For enums, the above guarantees only apply to fields of inhabited variants.
 
 r[layout.repr.rust.layout.struct]
-For [structs], it is further guaranteed that the fields do not overlap. That is, the fields can be ordered such that the offset plus the size of any field is less than or equal to the offset of the next field in the ordering, or for the last field, the size of the struct. The ordering does not have to be the same as the order in which the fields are specified in the declaration of the type.
+For [structs], it is further guaranteed that the fields do not overlap. That is, if we take the fields ordered by their offset, then for each field its offset plus its size is less than or equal to the offset of the next field in the ordering, or for the last field, the size of the struct. The ordering does not have to be the same as the order in which the fields are specified in the declaration of the type.
 
 Be aware that this guarantee does not imply that the fields have distinct addresses: zero-sized types may have the same address as other fields in the same struct.
 

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -168,6 +168,7 @@ The only data layout guarantees made by this representation are those required f
 
  1. The offset of a field is divisible by that field's alignment.
  2. The alignment of the type is at least the maximum alignment of its fields.
+ 3. For any field, its offset plus its size is at most the size of the type.
 
 r[layout.repr.rust.layout.struct]
 For [structs], it is further guaranteed that the fields do not overlap. That is, the fields can be ordered such that the offset plus the size of any field is less than or equal to the offset of the next field in the ordering. The ordering does not have to be the same as the order in which the fields are specified in the declaration of the type.

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -166,20 +166,19 @@ The `Rust` representation is the default representation for nominal types withou
 r[layout.repr.rust.layout]
 The only data layout guarantees made by this representation are those required for soundness. These are:
 
- 1. The offset of a constructible field is divisible by that field's alignment.
- 2. The alignment of the type is at least the maximum alignment of its constructible fields.
- 3. For any constructible field, its offset plus its size is at most the size of the type.
+ 1. The offset of a field is divisible by that field's alignment.
+ 2. The alignment of the type is at least the maximum alignment of its fields.
+ 3. For any field, its offset plus its size is at most the size of the type.
 
-r[layout.repr.rust.layout.constructible]
-
-A field is considered constructible if it is possible to create a value of the type containing the field.
-
-For example, given `enum E { A { x: u32 }, B { y: u32, z: ! } }`, the field `x` is constructible because you can create the value `E::A { x: 0 }`, but the fields `y` and `z` are not constructible because the type of `z` is uninhabited, so it is impossible to create an `E::B` value.
+For enums, the above guarantees only apply to fields of inhabited variants.
 
 r[layout.repr.rust.layout.struct]
-For [structs], it is further guaranteed that the fields do not overlap. That is, the fields can be ordered such that the offset plus the size of any field is less than or equal to the offset of the next field in the ordering. The ordering does not have to be the same as the order in which the fields are specified in the declaration of the type.
+For [structs], it is further guaranteed that the fields do not overlap. That is, the fields can be ordered such that the offset plus the size of any field is less than or equal to the offset of the next field in the ordering, or for the last field, the size of the struct. The ordering does not have to be the same as the order in which the fields are specified in the declaration of the type.
 
 Be aware that this guarantee does not imply that the fields have distinct addresses: zero-sized types may have the same address as other fields in the same struct.
+
+r[layout.repr.rust.layout.enum]
+For enums, a variant of the enum is said to be inhabited if all of its fields are [inhabited](glossary.html#inhabited). When an enum variant is inhabited, its fields are laid out according to the same guarantees as a struct. Otherwise, nothing is guaranteed about the fields. This allows the enum to be smaller than fields of uninhabited variants.
 
 r[layout.repr.rust.unspecified]
 There are no other guarantees of data layout made by this representation.

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -166,9 +166,15 @@ The `Rust` representation is the default representation for nominal types withou
 r[layout.repr.rust.layout]
 The only data layout guarantees made by this representation are those required for soundness. These are:
 
- 1. The offset of a field is divisible by that field's alignment.
- 2. The alignment of the type is at least the maximum alignment of its fields.
- 3. For any field, its offset plus its size is at most the size of the type.
+ 1. The offset of a constructible field is divisible by that field's alignment.
+ 2. The alignment of the type is at least the maximum alignment of its constructible fields.
+ 3. For any constructible field, its offset plus its size is at most the size of the type.
+
+r[layout.repr.rust.layout.constructible]
+
+A field is considered constructible if it is possible to create a value of the type containing the field.
+
+For example, given `enum E { A { x: u32 }, B { y: u32, z: ! } }`, the field `x` is constructible because you can create the value `E::A { x: 0 }`, but the fields `y` and `z` are not constructible because the type of `z` is uninhabited, so it is impossible to create an `E::B` value.
 
 r[layout.repr.rust.layout.struct]
 For [structs], it is further guaranteed that the fields do not overlap. That is, the fields can be ordered such that the offset plus the size of any field is less than or equal to the offset of the next field in the ordering. The ordering does not have to be the same as the order in which the fields are specified in the declaration of the type.


### PR DESCRIPTION
This clarifies the `repr(Rust)` layout rules slightly by specifying that fields must fit in their struct. That is, the offset of a field plus its size must be less than the size of the struct.

**Accidental stabilization.** One question that needs to be addressed before we can merge this is the fact that we have guaranteed that fields of `repr(Rust)` do not overlap, even though one can imagine structs where this is not the case when the struct is uninhabited. For example:
```rs
// could this be size zero? it would violate sizeof<i32>() <= sizeof<Foo>()
struct Foo(i32, !);

// could the two integers both be at offset zero? it would violate the no-overlap guarantee
struct Foo(i32, i32, !);
```
So as part of this PR I am posing the following question to the lang team:

> Should we undo the guarantee about fields not overlapping if the struct has uninhabited fields?

In any case, I think we should definitely guarantee that fields fit in the struct for inhabited `repr(Rust)` structs.

Context: [#t-lang > ZST Uninhabited types with non-ZST fields @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/ZST.20Uninhabited.20types.20with.20non-ZST.20fields/near/572468369)