### PR TITLE
dev-guide stabilization.md: add missing "not"

### DIFF
--- a/dev-guide/src/process/stabilization.md
+++ b/dev-guide/src/process/stabilization.md
@@ -17,7 +17,7 @@ When opening a PR, please include links to as much information as possible so th
 - The files in `rustc` where it is implemented, if it is isolated to a relatively concise part.
 - The tests in `rust-lang/rust`.
 
-Always link to the tracking issue and, if applicable, the stabilization PR. Beyond those, information that already appears in the tracking issue, stabilization report, or PR does need to be duplicated in the PR description.
+Always link to the tracking issue and, if applicable, the stabilization PR. Beyond those, information that already appears in the tracking issue, stabilization report, or PR does not need to be duplicated in the PR description.
 
 ## Inline tests
 


### PR DESCRIPTION
Presumably the intent was to say that information does not need to be duplicated, rather than saying that it needs to be duplicated.