### PR TITLE
Use `clobber_abi`s corresponding to the called functions in `[asm.abi-clobbers.many]`'s example.

### DIFF
--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -1009,7 +1009,8 @@ unsafe {
         sym foo,
         sym bar,
         out("rax") z,
-        clobber_abi("C")
+        clobber_abi("sysv64"),
+        clobber_abi("win64"),
     );
 }
 assert_eq!(z, 1);


### PR DESCRIPTION
The example calls an `extern "sysv64" fn` and an `extern "win64" fn`, but only declares `clobber_abi("C")`, despite being in the section that says `clobber_abi` can be specified multiple times.