### PR TITLE
Add dev-guide/book to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /book
+/dev-guide/book
 /target


### PR DESCRIPTION
This was missed in https://github.com/rust-lang/reference/pull/2097.