### PR TITLE
Switch to new range syntax

### DIFF
--- a/dev-guide/src/grammar.md
+++ b/dev-guide/src/grammar.md
@@ -66,7 +66,7 @@ RepeatPlusNonGreedy -> `+?`
 
 RepeatRange -> `{` Range? `..` Range? `}`
 
-RepeatRangeInclusive -> `{` Range `..=` Range `}`
+RepeatRangeInclusive -> `{` Range? `..=` Range `}`
 
 Range -> [0-9]+
 
@@ -140,7 +140,7 @@ The general format is a series of productions separated by blank lines. The expr
 | RepeatPlus | Expr+ | The preceding expression is repeated 1 or more times. |
 | RepeatPlusNonGreedy | Expr+? | The preceding expression is repeated 1 or more times without being greedy. |
 | RepeatRange | Expr{2..4} | The preceding expression is repeated between the range of times specified. Either bound can be excluded, which works just like Rust ranges. |
-| RepeatRangeInclusive | Expr{2..=4} | The preceding expression is repeated between the range of times specified (inclusive). |
+| RepeatRangeInclusive | Expr{2..=4} | The preceding expression is repeated between the inclusive range of times specified. The lower bound can be omitted. |
 
 ## Automatic linking
 

--- a/dev-guide/src/grammar.md
+++ b/dev-guide/src/grammar.md
@@ -81,7 +81,7 @@ Expr1 ->
     | Group
     | NegativeExpression
 
-Unicode -> `U+` [`A`-`Z` `0`-`9`]4..4
+Unicode -> `U+` [`A`-`Z` `0`-`9`]4..=4
 
 NonTerminal -> Name
 

--- a/dev-guide/src/grammar.md
+++ b/dev-guide/src/grammar.md
@@ -39,19 +39,34 @@ Sequence ->
         (` `* AdornedExpr)* ` `* Cut
       | (` `* AdornedExpr)+
 
-AdornedExpr -> ExprRepeat Suffix? Footnote?
+AdornedExpr -> Expr1 Quantifier? Suffix? Footnote?
 
 Suffix -> ` _` <not underscore, unless in backtick>* `_`
 
 Footnote -> `[^` ~[`]` LF]+ `]`
 
-ExprRepeat ->
-      Expr1 `?`
-    | Expr1 `*?`
-    | Expr1 `*`
-    | Expr1 `+?`
-    | Expr1 `+`
-    | Expr1 `{` Range? `..` Range? `}`
+Quantifier ->
+      Optional
+    | Repeat
+    | RepeatNonGreedy
+    | RepeatPlus
+    | RepeatPlusNonGreedy
+    | RepeatRange
+    | RepeatRangeInclusive
+
+Optional -> `?`
+
+Repeat -> `*`
+
+RepeatNonGreedy -> `*?`
+
+RepeatPlus -> `+`
+
+RepeatPlusNonGreedy -> `+?`
+
+RepeatRange -> `{` Range? `..` Range? `}`
+
+RepeatRangeInclusive -> `{` Range `..=` Range `}`
 
 Range -> [0-9]+
 
@@ -121,10 +136,11 @@ The general format is a series of productions separated by blank lines. The expr
 | Footnote | \[^extern-safe\] | Adds a footnote, which can supply extra information that may be helpful to the user. The footnote itself should be defined outside of the code block like a normal Markdown footnote. |
 | Optional | Expr? | The preceding expression is optional. |
 | Repeat | Expr* | The preceding expression is repeated 0 or more times. |
-| Repeat (non-greedy) | Expr*? | The preceding expression is repeated 0 or more times without being greedy. |
+| RepeatNonGreedy | Expr*? | The preceding expression is repeated 0 or more times without being greedy. |
 | RepeatPlus | Expr+ | The preceding expression is repeated 1 or more times. |
-| RepeatPlus (non-greedy) | Expr+? | The preceding expression is repeated 1 or more times without being greedy. |
+| RepeatPlusNonGreedy | Expr+? | The preceding expression is repeated 1 or more times without being greedy. |
 | RepeatRange | Expr{2..4} | The preceding expression is repeated between the range of times specified. Either bound can be excluded, which works just like Rust ranges. |
+| RepeatRangeInclusive | Expr{2..=4} | The preceding expression is repeated between the range of times specified (inclusive). |
 
 ## Automatic linking
 

--- a/src/notation.md
+++ b/src/notation.md
@@ -17,7 +17,7 @@ The following notations are used by the *Lexer* and *Syntax* grammar snippets:
 | x<sup>\*</sup>    | _OuterAttribute_<sup>\*</sup> | 0 or more of x                            |
 | x<sup>+</sup>     |  _MacroMatch_<sup>+</sup>     | 1 or more of x                            |
 | x<sup>a..b</sup>  | HEX_DIGIT<sup>1..6</sup>      | a to b repetitions of x, exclusive of b   |
-| x<sup>a..=b</sup> | HEX_DIGIT<sup>1..=6</sup>     | a to b repetitions of x, inclusive of b   |
+| x<sup>a..=b</sup> | HEX_DIGIT<sup>1..=5</sup>     | a to b repetitions of x, inclusive of b   |
 | Rule1 Rule2       | `fn` _Name_ _Parameters_      | Sequence of rules in order                |
 | \|                | `u8` \| `u16`, Block \| Item  | Either one or another                     |
 | \[ ]               | \[`b` `B`]                     | Any of the characters listed              |

--- a/src/notation.md
+++ b/src/notation.md
@@ -16,8 +16,8 @@ The following notations are used by the *Lexer* and *Syntax* grammar snippets:
 | x<sup>?</sup>     | `pub`<sup>?</sup>             | An optional item                          |
 | x<sup>\*</sup>    | _OuterAttribute_<sup>\*</sup> | 0 or more of x                            |
 | x<sup>+</sup>     |  _MacroMatch_<sup>+</sup>     | 1 or more of x                            |
-| x<sup>a..b</sup>  | HEX_DIGIT<sup>1..6</sup>      | a to b repetitions (exclusive) of x       |
-| x<sup>a..=b</sup> | HEX_DIGIT<sup>1..=6</sup>     | a to b repetitions (inclusive) of x       |
+| x<sup>a..b</sup>  | HEX_DIGIT<sup>1..6</sup>      | a to b repetitions of x, exclusive of b   |
+| x<sup>a..=b</sup> | HEX_DIGIT<sup>1..=6</sup>     | a to b repetitions of x, inclusive of b   |
 | Rule1 Rule2       | `fn` _Name_ _Parameters_      | Sequence of rules in order                |
 | \|                | `u8` \| `u16`, Block \| Item  | Either one or another                     |
 | \[ ]               | \[`b` `B`]                     | Any of the characters listed              |

--- a/src/notation.md
+++ b/src/notation.md
@@ -16,7 +16,8 @@ The following notations are used by the *Lexer* and *Syntax* grammar snippets:
 | x<sup>?</sup>     | `pub`<sup>?</sup>             | An optional item                          |
 | x<sup>\*</sup>    | _OuterAttribute_<sup>\*</sup> | 0 or more of x                            |
 | x<sup>+</sup>     |  _MacroMatch_<sup>+</sup>     | 1 or more of x                            |
-| x<sup>a..b</sup>  | HEX_DIGIT<sup>1..6</sup>      | a to b repetitions of x                   |
+| x<sup>a..b</sup>  | HEX_DIGIT<sup>1..6</sup>      | a to b repetitions (exclusive) of x       |
+| x<sup>a..=b</sup> | HEX_DIGIT<sup>1..=6</sup>     | a to b repetitions (inclusive) of x       |
 | Rule1 Rule2       | `fn` _Name_ _Parameters_      | Sequence of rules in order                |
 | \|                | `u8` \| `u16`, Block \| Item  | Either one or another                     |
 | \[ ]               | \[`b` `B`]                     | Any of the characters listed              |

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -157,7 +157,7 @@ ASCII_ESCAPE ->
     | `\n` | `\r` | `\t` | `\\` | `\0`
 
 UNICODE_ESCAPE ->
-    `\u{` ( HEX_DIGIT `_`* ){1..6} _valid hex char value_ `}`[^valid-hex-char]
+    `\u{` ( HEX_DIGIT `_`* ){1..=6} _valid hex char value_ `}`[^valid-hex-char]
 ```
 
 [^valid-hex-char]: See [lex.token.literal.char-escape.unicode].

--- a/tools/grammar/src/parser.rs
+++ b/tools/grammar/src/parser.rs
@@ -449,6 +449,9 @@ impl Parser<'_> {
             (Some(min), Some(max), _) if max < min => {
                 bail!(self, "range {min}{limit}{max} is malformed")
             }
+            (Some(min), Some(max), RangeLimit::HalfOpen) if max <= min => {
+                bail!(self, "half-open range maximum must be greater than minimum")
+            }
             (_, None, RangeLimit::Closed) => bail!(self, "closed range must have an upper bound"),
             _ => {}
         }

--- a/tools/grammar/src/parser.rs
+++ b/tools/grammar/src/parser.rs
@@ -452,6 +452,9 @@ impl Parser<'_> {
             (Some(min), Some(max), RangeLimit::HalfOpen) if max <= min => {
                 bail!(self, "half-open range maximum must be greater than minimum")
             }
+            (None, Some(0), RangeLimit::HalfOpen) => {
+                bail!(self, "half-open range `..0` is empty")
+            }
             (_, None, RangeLimit::Closed) => bail!(self, "closed range must have an upper bound"),
             _ => {}
         }
@@ -712,6 +715,15 @@ mod tests {
         assert!(
             err.contains("closed range must have an upper bound"),
             "expected closed-needs-upper error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_range_err_half_open_zero_max() {
+        let err = parse("A -> x{..0}").unwrap_err();
+        assert!(
+            err.contains("half-open range `..0` is empty"),
+            "expected half-open-zero error, got: {err}"
         );
     }
 

--- a/tools/mdbook-spec/src/grammar.rs
+++ b/tools/mdbook-spec/src/grammar.rs
@@ -21,6 +21,17 @@ pub struct RenderCtx {
     for_summary: bool,
 }
 
+#[cfg(test)]
+impl RenderCtx {
+    pub(crate) fn for_test() -> Self {
+        RenderCtx {
+            md_link_map: HashMap::new(),
+            rr_link_map: HashMap::new(),
+            for_summary: false,
+        }
+    }
+}
+
 /// Replaces the text grammar in the given chapter with the rendered version.
 pub fn insert_grammar(grammar: &Grammar, chapter: &Chapter, diag: &mut Diagnostics) -> String {
     let link_map = make_relative_link_map(grammar, chapter);

--- a/tools/mdbook-spec/src/grammar/render_markdown.rs
+++ b/tools/mdbook-spec/src/grammar/render_markdown.rs
@@ -71,7 +71,7 @@ fn last_expr(expr: &Expression) -> &ExpressionKind {
         | ExpressionKind::RepeatNonGreedy(_)
         | ExpressionKind::RepeatPlus(_)
         | ExpressionKind::RepeatPlusNonGreedy(_)
-        | ExpressionKind::RepeatRange(_, _, _)
+        | ExpressionKind::RepeatRange { .. }
         | ExpressionKind::Nt(_)
         | ExpressionKind::Terminal(_)
         | ExpressionKind::Prose(_)
@@ -135,13 +135,18 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, output: &mut String) {
             render_expression(e, cx, output);
             output.push_str("<sup>+ (non-greedy)</sup>");
         }
-        ExpressionKind::RepeatRange(e, a, b) => {
-            render_expression(e, cx, output);
+        ExpressionKind::RepeatRange {
+            expr,
+            min,
+            max,
+            limit,
+        } => {
+            render_expression(expr, cx, output);
             write!(
                 output,
-                "<sup>{}..{}</sup>",
-                a.map(|v| v.to_string()).unwrap_or_default(),
-                b.map(|v| v.to_string()).unwrap_or_default(),
+                "<sup>{min}{limit}{max}</sup>",
+                min = min.map(|v| v.to_string()).unwrap_or_default(),
+                max = max.map(|v| v.to_string()).unwrap_or_default(),
             )
             .unwrap();
         }

--- a/tools/mdbook-spec/src/grammar/render_railroad.rs
+++ b/tools/mdbook-spec/src/grammar/render_railroad.rs
@@ -229,6 +229,15 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, stack: bool) -> Option<B
                     let r = Repeat::new(n, Comment::new(cmt));
                     Box::new(r)
                 }
+                // A half-open range where min >= max is empty (e.g.,
+                // `e{2..2}` means zero repetitions).
+                ExpressionKind::RepeatRange {
+                    min: Some(a),
+                    max: Some(b),
+                    limit: RangeLimit::HalfOpen,
+                    ..
+                } if b <= a => Box::new(railroad::Empty),
+
                 // Decompose ranges with min >= 2 into a fixed prefix
                 // and a remainder:
                 // - `e{a..}` as `e{0..a-1} e{1..}`

--- a/tools/mdbook-spec/src/grammar/render_railroad.rs
+++ b/tools/mdbook-spec/src/grammar/render_railroad.rs
@@ -178,7 +178,6 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, stack: bool) -> Option<B
                     min: Some(1),
                     max: None,
                     limit: RangeLimit::HalfOpen,
-                    ..
                 } => {
                     let n = render_expression(e, cx, stack)?;
                     Box::new(Repeat::new(n, railroad::Empty))

--- a/tools/mdbook-spec/src/grammar/render_railroad.rs
+++ b/tools/mdbook-spec/src/grammar/render_railroad.rs
@@ -188,7 +188,7 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, stack: bool) -> Option<B
                     let lbox = LabeledBox::new(r, Comment::new("non-greedy".to_string()));
                     Box::new(lbox)
                 }
-                // For `e{..=0}` / `e{0..=0}` / `e{..0}` or `e{..1}` / `e{0..1}` render an empty node.
+                // For `e{..=0}` / `e{0..=0}` or `e{..1}` / `e{0..1}` render an empty node.
                 ExpressionKind::RepeatRange { max: Some(0), .. }
                 | ExpressionKind::RepeatRange {
                     max: Some(1),


### PR DESCRIPTION
This changes the syntax for range repeat so that it handles inclusive and exclusive upper bounds with `..=` and `..`.

The old syntax was confusing. It used `..` for inclusive bound, but that's not how Rust syntax works. This changes it so that it uses `..=` for inclusive bounds to be consistent with Rust syntax.

There are some other options for range syntax that I considered:

- `{a,b}` which is the syntax used by most regex engines, and some parsers like Pest and Parsimonious.
- IETF ABNF and W3C EBNF uses `a*bexpr` where `a` and `b` are optional.
- Peg-rs uses `*<n,m>` where `n` and `m` are optional.
- Various languages use `:` (Python, Julia, Excel, etc.) or `..` (Rust, Kotlin, Swift, C#, F#, Zig, Perl, etc.) to represent ranges.

This will become more relevant when we switch the raw string literals to use a bounded range. We can't easily avoid the use of bounded repetition because of raw-string's bound of 255. Listing out 255 variants would be just too much, and it is convenient to avoid English-descriptive rules.