### PR TITLE
Add support for named repeat ranges

### DIFF
--- a/dev-guide/src/grammar.md
+++ b/dev-guide/src/grammar.md
@@ -57,6 +57,7 @@ Quantifier ->
     | RepeatPlusNonGreedy
     | RepeatRange
     | RepeatRangeInclusive
+    | RepeatRangeNamed
 
 Optional -> `?`
 
@@ -68,9 +69,11 @@ RepeatPlus -> `+`
 
 RepeatPlusNonGreedy -> `+?`
 
-RepeatRange -> `{` Range? `..` Range? `}`
+RepeatRange -> `{` ( Name `:` )? Range? `..` Range? `}`
 
-RepeatRangeInclusive -> `{` Range? `..=` Range `}`
+RepeatRangeInclusive -> `{` ( Name `:` )? Range? `..=` Range `}`
+
+RepeatRangeNamed -> `{` Name `}`
 
 Range -> [0-9]+
 
@@ -150,6 +153,8 @@ The general format is a series of productions separated by blank lines. The expr
 | RepeatPlusNonGreedy | Expr+? | The preceding expression is repeated 1 or more times without being greedy. |
 | RepeatRange | Expr{2..4} | The preceding expression is repeated between the range of times specified. Either bound can be excluded, which works just like Rust ranges. |
 | RepeatRangeInclusive | Expr{2..=4} | The preceding expression is repeated between the inclusive range of times specified. The lower bound can be omitted. |
+| Named RepeatRangeInclusive | Expr{name:2..=4} | If a name precedes the range, then the number of repetitions are stored in a variable with that name that subsequent RepeatRangeNamed expressions can refer to. |
+| RepeatRangeNamed | Expr{name} | Repeat the number of times from the previously labeled repetition. |
 
 ## Automatic linking
 

--- a/dev-guide/src/grammar.md
+++ b/dev-guide/src/grammar.md
@@ -52,9 +52,7 @@ Footnote -> `[^` ~[`]` LF]+ `]`
 Quantifier ->
       Optional
     | Repeat
-    | RepeatNonGreedy
     | RepeatPlus
-    | RepeatPlusNonGreedy
     | RepeatRange
     | RepeatRangeInclusive
     | RepeatRangeNamed
@@ -63,11 +61,7 @@ Optional -> `?`
 
 Repeat -> `*`
 
-RepeatNonGreedy -> `*?`
-
 RepeatPlus -> `+`
-
-RepeatPlusNonGreedy -> `+?`
 
 RepeatRange -> `{` ( Name `:` )? Range? `..` Range? `}`
 
@@ -148,9 +142,7 @@ The general format is a series of productions separated by blank lines. The expr
 | Optional | Expr? | The preceding expression is optional. |
 | NegativeLookahead | !Expr | Matches if Expr does not follow, without consuming any input. |
 | Repeat | Expr* | The preceding expression is repeated 0 or more times. |
-| RepeatNonGreedy | Expr*? | The preceding expression is repeated 0 or more times without being greedy. |
 | RepeatPlus | Expr+ | The preceding expression is repeated 1 or more times. |
-| RepeatPlusNonGreedy | Expr+? | The preceding expression is repeated 1 or more times without being greedy. |
 | RepeatRange | Expr{2..4} | The preceding expression is repeated between the range of times specified. Either bound can be excluded, which works just like Rust ranges. |
 | RepeatRangeInclusive | Expr{2..=4} | The preceding expression is repeated between the inclusive range of times specified. The lower bound can be omitted. |
 | Named RepeatRangeInclusive | Expr{name:2..=4} | If a name precedes the range, then the number of repetitions are stored in a variable with that name that subsequent RepeatRangeNamed expressions can refer to. |

--- a/dev-guide/src/grammar.md
+++ b/dev-guide/src/grammar.md
@@ -145,8 +145,8 @@ The general format is a series of productions separated by blank lines. The expr
 | RepeatPlus | Expr+ | The preceding expression is repeated 1 or more times. |
 | RepeatRange | Expr{2..4} | The preceding expression is repeated between the range of times specified. Either bound can be excluded, which works just like Rust ranges. |
 | RepeatRangeInclusive | Expr{2..=4} | The preceding expression is repeated between the inclusive range of times specified. The lower bound can be omitted. |
-| Named RepeatRangeInclusive | Expr{name:2..=4} | If a name precedes the range, then the number of repetitions are stored in a variable with that name that subsequent RepeatRangeNamed expressions can refer to. |
-| RepeatRangeNamed | Expr{name} | Repeat the number of times from the previously labeled repetition. |
+| RepeatRange (named) | Expr{name:2..4} | When a name precedes the range, the number of repetitions is bound to that name so that subsequent RepeatRangeNamed expressions can refer to it. The same applies to RepeatRangeInclusive. |
+| RepeatRangeNamed | Expr{name} | The preceding expression is repeated the number of times determined by a previously named RepeatRange or RepeatRangeInclusive. |
 
 ## Automatic linking
 

--- a/src/notation.md
+++ b/src/notation.md
@@ -18,6 +18,8 @@ The following notations are used by the *Lexer* and *Syntax* grammar snippets:
 | x<sup>+</sup>     |  _MacroMatch_<sup>+</sup>     | 1 or more of x                            |
 | x<sup>a..b</sup>  | HEX_DIGIT<sup>1..6</sup>      | a to b repetitions of x, exclusive of b   |
 | x<sup>a..=b</sup> | HEX_DIGIT<sup>1..=5</sup>     | a to b repetitions of x, inclusive of b   |
+| x<sup>n:a..=b</sup> | `#`<sup>n:1..=255</sup>      | a labeled repetition that a subsequent repetition can refer to |
+| x<sup>n</sup>     | `#`<sup>n</sup>               | repeat the number of times from the previously labeled repetition |
 | Rule1 Rule2       | `fn` _Name_ _Parameters_      | Sequence of rules in order                |
 | \|                | `u8` \| `u16`, Block \| Item  | Either one or another                     |
 | !                 | !COMMENT                      | Matches if the expression does not follow, without consuming any input |

--- a/src/notation.md
+++ b/src/notation.md
@@ -18,8 +18,8 @@ The following notations are used by the *Lexer* and *Syntax* grammar snippets:
 | x<sup>+</sup>     |  _MacroMatch_<sup>+</sup>     | 1 or more of x                            |
 | x<sup>a..b</sup>  | HEX_DIGIT<sup>1..6</sup>      | a to b repetitions of x, exclusive of b   |
 | x<sup>a..=b</sup> | HEX_DIGIT<sup>1..=5</sup>     | a to b repetitions of x, inclusive of b   |
-| x<sup>n:a..=b</sup> | `#`<sup>n:1..=255</sup>      | a labeled repetition that a subsequent repetition can refer to |
-| x<sup>n</sup>     | `#`<sup>n</sup>               | repeat the number of times from the previously labeled repetition |
+| x<sup>n:a..=b</sup> | `#`<sup>n:1..=255</sup>      | a to b repetitions of x (inclusive of b), with the count bound to the name n |
+| x<sup>n</sup>     | `#`<sup>n</sup>               | x repeated the number of times bound to n by a previous labeled repetition |
 | Rule1 Rule2       | `fn` _Name_ _Parameters_      | Sequence of rules in order                |
 | \|                | `u8` \| `u16`, Block \| Item  | Either one or another                     |
 | !                 | !COMMENT                      | Matches if the expression does not follow, without consuming any input |

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -214,11 +214,13 @@ r[lex.token.literal.str-raw]
 
 r[lex.token.literal.str-raw.syntax]
 ```grammar,lexer
-RAW_STRING_LITERAL -> `r` RAW_STRING_CONTENT SUFFIX?
+RAW_STRING_LITERAL ->
+      `r` `"` ^ RAW_STRING_CONTENT `"` SUFFIX?
+    | `r` `#`{n:1..=255} ^ `"` RAW_STRING_CONTENT_HASHED `"` `#`{n} SUFFIX?
 
-RAW_STRING_CONTENT ->
-      `"` ^ ( ~CR )*? `"`
-    | `#` RAW_STRING_CONTENT `#`
+RAW_STRING_CONTENT -> (!`"` ~CR )*
+
+RAW_STRING_CONTENT_HASHED -> (!(`"` `#`{n}) ~CR )*
 ```
 
 r[lex.token.literal.str-raw.intro]
@@ -301,11 +303,12 @@ r[lex.token.str-byte-raw]
 r[lex.token.str-byte-raw.syntax]
 ```grammar,lexer
 RAW_BYTE_STRING_LITERAL ->
-    `br` RAW_BYTE_STRING_CONTENT SUFFIX?
+      `br` `"` ^ RAW_BYTE_STRING_CONTENT `"` SUFFIX?
+    | `br` `#`{n:1..=255} ^ `"` RAW_BYTE_STRING_CONTENT_HASHED `"` `#`{n} SUFFIX?
 
-RAW_BYTE_STRING_CONTENT ->
-      `"` ^ ASCII_FOR_RAW*? `"`
-    | `#` RAW_BYTE_STRING_CONTENT `#`
+RAW_BYTE_STRING_CONTENT -> (!`"` ASCII_FOR_RAW )*
+
+RAW_BYTE_STRING_CONTENT_HASHED -> (!(`"` `#`{n}) ASCII_FOR_RAW )*
 
 ASCII_FOR_RAW -> !CR ASCII
 ```
@@ -395,11 +398,12 @@ r[lex.token.str-c-raw]
 r[lex.token.str-c-raw.syntax]
 ```grammar,lexer
 RAW_C_STRING_LITERAL ->
-    `cr` RAW_C_STRING_CONTENT SUFFIX?
+      `cr` `"` ^ RAW_C_STRING_CONTENT `"` SUFFIX?
+    | `cr` `#`{n:1..=255} ^ `"` RAW_C_STRING_CONTENT_HASHED `"` `#`{n} SUFFIX?
 
-RAW_C_STRING_CONTENT ->
-      `"` ^ ( ~[CR NUL] )*? `"`
-    | `#` RAW_C_STRING_CONTENT `#`
+RAW_C_STRING_CONTENT -> (!`"` ~[CR NUL] )*
+
+RAW_C_STRING_CONTENT_HASHED -> (!(`"` `#`{n}) ~[CR NUL] )*
 ```
 
 r[lex.token.str-c-raw.intro]

--- a/tools/grammar/src/lib.rs
+++ b/tools/grammar/src/lib.rs
@@ -61,13 +61,16 @@ pub enum ExpressionKind {
     RepeatPlus(Box<Expression>),
     /// `A+?`
     RepeatPlusNonGreedy(Box<Expression>),
-    /// `A{2..4}` or `A{2..=4}`
+    /// `A{2..4}` or `A{2..=4}` or `A{name:2..=4}`
     RepeatRange {
         expr: Box<Expression>,
+        name: Option<String>,
         min: Option<u32>,
         max: Option<u32>,
         limit: RangeLimit,
     },
+    /// `A{name}`
+    RepeatRangeNamed(Box<Expression>, String),
     /// `NonTerminal`
     Nt(String),
     /// `` `string` ``
@@ -172,6 +175,7 @@ impl Expression {
             | ExpressionKind::RepeatPlus(e)
             | ExpressionKind::RepeatPlusNonGreedy(e)
             | ExpressionKind::RepeatRange { expr: e, .. }
+            | ExpressionKind::RepeatRangeNamed(e, _)
             | ExpressionKind::NegExpression(e)
             | ExpressionKind::Cut(e) => {
                 e.visit_nt(callback);

--- a/tools/grammar/src/lib.rs
+++ b/tools/grammar/src/lib.rs
@@ -55,12 +55,8 @@ pub enum ExpressionKind {
     NegativeLookahead(Box<Expression>),
     /// `A*`
     Repeat(Box<Expression>),
-    /// `A*?`
-    RepeatNonGreedy(Box<Expression>),
     /// `A+`
     RepeatPlus(Box<Expression>),
-    /// `A+?`
-    RepeatPlusNonGreedy(Box<Expression>),
     /// `A{2..4}` or `A{2..=4}` or `A{name:2..=4}`
     RepeatRange {
         expr: Box<Expression>,
@@ -171,9 +167,7 @@ impl Expression {
             | ExpressionKind::Optional(e)
             | ExpressionKind::NegativeLookahead(e)
             | ExpressionKind::Repeat(e)
-            | ExpressionKind::RepeatNonGreedy(e)
             | ExpressionKind::RepeatPlus(e)
-            | ExpressionKind::RepeatPlusNonGreedy(e)
             | ExpressionKind::RepeatRange { expr: e, .. }
             | ExpressionKind::RepeatRangeNamed(e, _)
             | ExpressionKind::NegExpression(e)

--- a/tools/grammar/src/parser.rs
+++ b/tools/grammar/src/parser.rs
@@ -439,24 +439,16 @@ impl Parser<'_> {
         Ok(ExpressionKind::Optional(box_kind(kind)))
     }
 
-    /// Parse `*` | `*?` after expression.
+    /// Parse `*` after expression.
     fn parse_repeat(&mut self, kind: ExpressionKind) -> Result<ExpressionKind> {
         self.expect("*", "expected `*`")?;
-        Ok(if self.take_str("?") {
-            ExpressionKind::RepeatNonGreedy(box_kind(kind))
-        } else {
-            ExpressionKind::Repeat(box_kind(kind))
-        })
+        Ok(ExpressionKind::Repeat(box_kind(kind)))
     }
 
-    /// Parse `+` | `+?` after expression.
+    /// Parse `+` after expression.
     fn parse_repeat_plus(&mut self, kind: ExpressionKind) -> Result<ExpressionKind> {
         self.expect("+", "expected `+`")?;
-        Ok(if self.take_str("?") {
-            ExpressionKind::RepeatPlusNonGreedy(box_kind(kind))
-        } else {
-            ExpressionKind::RepeatPlus(box_kind(kind))
-        })
+        Ok(ExpressionKind::RepeatPlus(box_kind(kind)))
     }
 
     /// Parse `{a..b}` | `{a..=b}` | `{name:a..=b}` | `{name}` after expression.

--- a/tools/grammar/src/parser.rs
+++ b/tools/grammar/src/parser.rs
@@ -778,7 +778,7 @@ mod tests {
 
     #[test]
     fn test_range_closed_exact() {
-        // `x{2..=2}` means exactly 2 — not empty.
+        // `x{2..=2}` means exactly 2 -- not empty.
         let (min, max, limit) = repeat_range("A -> x{2..=2}");
         assert_eq!(min, Some(2));
         assert_eq!(max, Some(2));
@@ -1178,5 +1178,146 @@ mod tests {
         assert_eq!(*min, Some(2));
         assert_eq!(*max, Some(5));
         assert!(matches!(limit, RangeLimit::HalfOpen));
+    }
+
+    // --- Named repeat range tests ---
+
+    /// Extract full `RepeatRange` fields including the name.
+    fn named_repeat_range(input: &str) -> (Option<String>, Option<u32>, Option<u32>, RangeLimit) {
+        let grammar = parse(input).unwrap();
+        let rule = grammar.productions.get("A").unwrap();
+        let ExpressionKind::RepeatRange {
+            name,
+            min,
+            max,
+            limit,
+            ..
+        } = &rule.expression.kind
+        else {
+            panic!("expected RepeatRange, got {:?}", rule.expression.kind);
+        };
+        (name.clone(), *min, *max, *limit)
+    }
+
+    #[test]
+    fn named_range_closed() {
+        let (name, min, max, limit) = named_repeat_range("A -> x{n:1..=255}");
+        assert_eq!(name.as_deref(), Some("n"));
+        assert_eq!(min, Some(1));
+        assert_eq!(max, Some(255));
+        assert!(matches!(limit, RangeLimit::Closed));
+    }
+
+    #[test]
+    fn named_range_half_open() {
+        let (name, min, max, limit) = named_repeat_range("A -> x{n:2..5}");
+        assert_eq!(name.as_deref(), Some("n"));
+        assert_eq!(min, Some(2));
+        assert_eq!(max, Some(5));
+        assert!(matches!(limit, RangeLimit::HalfOpen));
+    }
+
+    #[test]
+    fn named_range_omitted_min() {
+        let (name, min, max, limit) = named_repeat_range("A -> x{n:..=5}");
+        assert_eq!(name.as_deref(), Some("n"));
+        assert_eq!(min, None);
+        assert_eq!(max, Some(5));
+        assert!(matches!(limit, RangeLimit::Closed));
+    }
+
+    #[test]
+    fn named_range_omitted_max() {
+        let (name, min, max, limit) = named_repeat_range("A -> x{n:2..}");
+        assert_eq!(name.as_deref(), Some("n"));
+        assert_eq!(min, Some(2));
+        assert_eq!(max, None);
+        assert!(matches!(limit, RangeLimit::HalfOpen));
+    }
+
+    #[test]
+    fn named_reference() {
+        // `{n}` without a colon or range produces a
+        // RepeatRangeNamed variant.
+        let grammar = parse("A -> x{n}").unwrap();
+        let rule = grammar.productions.get("A").unwrap();
+        let ExpressionKind::RepeatRangeNamed(_, name) = &rule.expression.kind else {
+            panic!("expected RepeatRangeNamed, got {:?}", rule.expression.kind);
+        };
+        assert_eq!(name, "n");
+    }
+
+    #[test]
+    fn named_binding_and_reference_in_sequence() {
+        // A production with a named binding and a named reference.
+        let grammar = parse("A -> x{n:1..=255} y{n}").unwrap();
+        let rule = grammar.productions.get("A").unwrap();
+        let ExpressionKind::Sequence(seq) = &rule.expression.kind else {
+            panic!("expected Sequence, got {:?}", rule.expression.kind);
+        };
+        assert_eq!(seq.len(), 2);
+
+        // First element: x{n:1..=255}
+        let ExpressionKind::RepeatRange {
+            name,
+            min,
+            max,
+            limit,
+            ..
+        } = &seq[0].kind
+        else {
+            panic!("expected RepeatRange, got {:?}", seq[0].kind);
+        };
+        assert_eq!(name.as_deref(), Some("n"));
+        assert_eq!(*min, Some(1));
+        assert_eq!(*max, Some(255));
+        assert!(matches!(limit, RangeLimit::Closed));
+
+        // Second element: y{n}
+        let ExpressionKind::RepeatRangeNamed(_, ref_name) = &seq[1].kind else {
+            panic!("expected RepeatRangeNamed, got {:?}", seq[1].kind);
+        };
+        assert_eq!(ref_name, "n");
+    }
+
+    #[test]
+    fn named_range_backtrack_to_plain_range() {
+        // When parse_name() succeeds but the next byte is
+        // neither `:` nor `}`, the parser backtracks and
+        // falls through to plain range parsing.  `{2..5}` is
+        // such a case after the parse_name fix (digits are
+        // rejected), but let's test a scenario where a name is
+        // parsed and then backtracked.
+        //
+        // There is no single-character token after a name that
+        // triggers backtrack in valid grammar (the match arms
+        // cover `:` and `}`), but the fallback resets the index
+        // and tries plain range parsing.  We verify that
+        // `{2..5}` parses correctly as a plain range even
+        // though it starts with a digit.
+        let (min, max, limit) = repeat_range("A -> x{2..5}");
+        assert_eq!(min, Some(2));
+        assert_eq!(max, Some(5));
+        assert!(matches!(limit, RangeLimit::HalfOpen));
+    }
+
+    #[test]
+    fn named_range_err_colon_missing_dots() {
+        // `{n:}` -- name followed by colon, then no `..`.
+        let err = parse("A -> x{n:}").unwrap_err();
+        assert!(
+            err.contains("expected `..`"),
+            "expected `..` error for {{n:}}, got: {err}"
+        );
+    }
+
+    #[test]
+    fn named_range_err_empty_braces() {
+        // `{}` -- empty braces contain no name and no range.
+        let err = parse("A -> x{}").unwrap_err();
+        assert!(
+            err.contains("expected `..`"),
+            "expected `..` error for {{}}, got: {err}"
+        );
     }
 }

--- a/tools/mdbook-spec/src/grammar/render_markdown.rs
+++ b/tools/mdbook-spec/src/grammar/render_markdown.rs
@@ -73,6 +73,7 @@ fn last_expr(expr: &Expression) -> &ExpressionKind {
         | ExpressionKind::RepeatPlus(_)
         | ExpressionKind::RepeatPlusNonGreedy(_)
         | ExpressionKind::RepeatRange { .. }
+        | ExpressionKind::RepeatRangeNamed(_, _)
         | ExpressionKind::Nt(_)
         | ExpressionKind::Terminal(_)
         | ExpressionKind::Prose(_)
@@ -142,6 +143,7 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, output: &mut String) {
         }
         ExpressionKind::RepeatRange {
             expr,
+            name,
             min,
             max,
             limit,
@@ -149,11 +151,16 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, output: &mut String) {
             render_expression(expr, cx, output);
             write!(
                 output,
-                "<sup>{min}{limit}{max}</sup>",
+                "<sup>{name}{min}{limit}{max}</sup>",
+                name = name.as_ref().map(|n| format!("{n}:")).unwrap_or_default(),
                 min = min.map(|v| v.to_string()).unwrap_or_default(),
                 max = max.map(|v| v.to_string()).unwrap_or_default(),
             )
             .unwrap();
+        }
+        ExpressionKind::RepeatRangeNamed(e, name) => {
+            render_expression(e, cx, output);
+            write!(output, "<sup>{name}</sup>").unwrap();
         }
         ExpressionKind::Nt(nt) => {
             let dest = cx.md_link_map.get(nt).map_or("missing", |d| d.as_str());

--- a/tools/mdbook-spec/src/grammar/render_markdown.rs
+++ b/tools/mdbook-spec/src/grammar/render_markdown.rs
@@ -69,9 +69,7 @@ fn last_expr(expr: &Expression) -> &ExpressionKind {
         | ExpressionKind::Optional(_)
         | ExpressionKind::NegativeLookahead(_)
         | ExpressionKind::Repeat(_)
-        | ExpressionKind::RepeatNonGreedy(_)
         | ExpressionKind::RepeatPlus(_)
-        | ExpressionKind::RepeatPlusNonGreedy(_)
         | ExpressionKind::RepeatRange { .. }
         | ExpressionKind::RepeatRangeNamed(_, _)
         | ExpressionKind::Nt(_)
@@ -129,17 +127,9 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, output: &mut String) {
             render_expression(e, cx, output);
             output.push_str("<sup>\\*</sup>");
         }
-        ExpressionKind::RepeatNonGreedy(e) => {
-            render_expression(e, cx, output);
-            output.push_str("<sup>\\* (non-greedy)</sup>");
-        }
         ExpressionKind::RepeatPlus(e) => {
             render_expression(e, cx, output);
             output.push_str("<sup>+</sup>");
-        }
-        ExpressionKind::RepeatPlusNonGreedy(e) => {
-            render_expression(e, cx, output);
-            output.push_str("<sup>+ (non-greedy)</sup>");
         }
         ExpressionKind::RepeatRange {
             expr,

--- a/tools/mdbook-spec/src/grammar/render_railroad.rs
+++ b/tools/mdbook-spec/src/grammar/render_railroad.rs
@@ -174,12 +174,6 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, stack: bool) -> Option<B
                     let n = render_expression(e, cx, stack)?;
                     Box::new(Optional::new(Repeat::new(n, railroad::Empty)))
                 }
-                ExpressionKind::RepeatNonGreedy(e) => {
-                    let n = render_expression(e, cx, stack)?;
-                    let r = Box::new(Optional::new(Repeat::new(n, railroad::Empty)));
-                    let lbox = LabeledBox::new(r, Comment::new("non-greedy".to_string()));
-                    Box::new(lbox)
-                }
                 // Treat `e+` and `e{1..}` equally.
                 ExpressionKind::RepeatPlus(e)
                 | ExpressionKind::RepeatRange {
@@ -191,12 +185,6 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, stack: bool) -> Option<B
                 } => {
                     let n = render_expression(e, cx, stack)?;
                     Box::new(Repeat::new(n, railroad::Empty))
-                }
-                ExpressionKind::RepeatPlusNonGreedy(e) => {
-                    let n = render_expression(e, cx, stack)?;
-                    let r = Repeat::new(n, railroad::Empty);
-                    let lbox = LabeledBox::new(r, Comment::new("non-greedy".to_string()));
-                    Box::new(lbox)
                 }
                 // For `e{..=0}` / `e{0..=0}` or `e{..1}` / `e{0..1}` render an empty node.
                 ExpressionKind::RepeatRange { max: Some(0), .. }

--- a/tools/mdbook-spec/src/grammar/render_railroad.rs
+++ b/tools/mdbook-spec/src/grammar/render_railroad.rs
@@ -81,6 +81,7 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, stack: bool) -> Option<B
                 ExpressionKind::Grouped(e)
                 | ExpressionKind::RepeatRange {
                     expr: e,
+                    name: _,
                     min: Some(1),
                     max: Some(1),
                     limit: RangeLimit::Closed,
@@ -153,6 +154,7 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, stack: bool) -> Option<B
                 ExpressionKind::Optional(e)
                 | ExpressionKind::RepeatRange {
                     expr: e,
+                    name: _,
                     min: None | Some(0),
                     max: Some(1),
                     limit: RangeLimit::Closed,
@@ -164,6 +166,7 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, stack: bool) -> Option<B
                 ExpressionKind::Repeat(e)
                 | ExpressionKind::RepeatRange {
                     expr: e,
+                    name: _,
                     min: None | Some(0),
                     max: None,
                     limit: RangeLimit::HalfOpen,
@@ -181,6 +184,7 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, stack: bool) -> Option<B
                 ExpressionKind::RepeatPlus(e)
                 | ExpressionKind::RepeatRange {
                     expr: e,
+                    name: _,
                     min: Some(1),
                     max: None,
                     limit: RangeLimit::HalfOpen,
@@ -205,6 +209,7 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, stack: bool) -> Option<B
                 // `(e{1..=b})?` (or `(e{1..b})?` for half-open).
                 ExpressionKind::RepeatRange {
                     expr: e,
+                    name,
                     min: None | Some(0),
                     max: Some(b @ 2..),
                     limit,
@@ -212,6 +217,7 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, stack: bool) -> Option<B
                     state = ExpressionKind::Optional(Box::new(Expression::new_kind(
                         ExpressionKind::RepeatRange {
                             expr: e.clone(),
+                            name: name.clone(),
                             min: Some(1),
                             max: Some(*b),
                             limit: *limit,
@@ -222,6 +228,7 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, stack: bool) -> Option<B
                 // Render `e{1..b}` / `e{1..=b}` directly.
                 ExpressionKind::RepeatRange {
                     expr: e,
+                    name: _,
                     min: Some(1),
                     max: Some(b @ 2..),
                     limit,
@@ -251,12 +258,14 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, stack: bool) -> Option<B
                 // - `e{a..b}` as `e{0..a-1} e{1..b-(a-1)}`
                 ExpressionKind::RepeatRange {
                     expr: e,
+                    name,
                     min: Some(a @ 2..),
                     max: b @ None,
                     limit,
                 }
                 | ExpressionKind::RepeatRange {
                     expr: e,
+                    name,
                     min: Some(a @ 2..),
                     max: b @ Some(_),
                     limit,
@@ -267,6 +276,7 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, stack: bool) -> Option<B
                     }
                     es.push(Expression::new_kind(ExpressionKind::RepeatRange {
                         expr: e.clone(),
+                        name: name.clone(),
                         min: Some(1),
                         max: b.map(|x| x - (a - 1)),
                         limit: *limit,
@@ -279,6 +289,12 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, stack: bool) -> Option<B
                     limit: RangeLimit::Closed,
                     ..
                 } => unreachable!("closed range must have upper bound"),
+                ExpressionKind::RepeatRangeNamed(e, name) => {
+                    let n = render_expression(e, cx, stack)?;
+                    let cmt = format!("repeat exactly {name} times");
+                    let lbox = LabeledBox::new(n, Comment::new(cmt));
+                    Box::new(lbox)
+                }
                 ExpressionKind::Nt(nt) => node_for_nt(cx, nt),
                 ExpressionKind::Terminal(t) => Box::new(Terminal::new(t.clone())),
                 ExpressionKind::Prose(s) => Box::new(Terminal::new(s.clone())),
@@ -405,6 +421,7 @@ mod tests {
     fn range_expr(min: Option<u32>, max: Option<u32>, limit: RangeLimit) -> Expression {
         Expression::new_kind(ExpressionKind::RepeatRange {
             expr: Box::new(Expression::new_kind(ExpressionKind::Nt("e".to_string()))),
+            name: None,
             min,
             max,
             limit,

--- a/tools/mdbook-spec/src/grammar/render_railroad.rs
+++ b/tools/mdbook-spec/src/grammar/render_railroad.rs
@@ -596,4 +596,45 @@ mod tests {
             "neg expression should have exception label"
         );
     }
+
+    // -- Named repeat range tests --
+
+    #[test]
+    fn repeat_range_named_reference() {
+        // RepeatRangeNamed renders with a "repeat exactly n times"
+        // label.
+        let expr = Expression::new_kind(ExpressionKind::RepeatRangeNamed(
+            Box::new(Expression::new_kind(ExpressionKind::Nt("x".to_string()))),
+            "n".to_string(),
+        ));
+        let svg = render_to_svg(&expr).unwrap();
+        assert!(
+            svg.contains("repeat exactly n times"),
+            "expected 'repeat exactly n times' label, got: {svg}"
+        );
+    }
+
+    #[test]
+    fn repeat_range_with_name_renders() {
+        // A RepeatRange with a name should render without crash.
+        // The name is not currently displayed in railroad diagrams,
+        // so we just verify that SVG output is produced and
+        // contains the expected structural elements.
+        let expr = Expression::new_kind(ExpressionKind::RepeatRange {
+            expr: Box::new(Expression::new_kind(ExpressionKind::Nt("e".to_string()))),
+            name: Some("n".to_string()),
+            min: Some(2),
+            max: Some(5),
+            limit: RangeLimit::Closed,
+        });
+        let svg = render_to_svg(&expr).unwrap();
+        assert!(
+            svg.contains("nonterminal"),
+            "expected nonterminal in SVG output"
+        );
+        assert!(
+            svg.contains("more times"),
+            "expected 'more times' repeat comment"
+        );
+    }
 }


### PR DESCRIPTION
This adds the ability to add a label to a repeat range so that a subsequent expression can match the same repetition. This is used in raw strings where the `#` characters must be balanced on both sides, with a limit on the number of matches.

This also removes the non-greedy repetitions because they are no longer used.
