### PR TITLE
coerce.site.return: make example more simple

### DIFF
--- a/src/type-coercions.md
+++ b/src/type-coercions.md
@@ -60,7 +60,7 @@ r[coerce.site.constructor]
 r[coerce.site.return]
 * Function results&mdash;either the final line of a block if it is not semicolon-terminated or any expression in a `return` statement
 
-  For example, `x` is coerced to have type `&dyn Display` in the following:
+  For example, `x` is coerced to have type `&dyn core::fmt::Display` in the following:
 
   ```rust
   fn foo(x: &u32) -> &dyn core::fmt::Display {


### PR DESCRIPTION
- remove the import and use the type directly
- get the type from its original path, and not a re-export