### PR TITLE
Fix formatting of markdown grammar with cut

### DIFF
--- a/tools/mdbook-spec/src/grammar/render_markdown.rs
+++ b/tools/mdbook-spec/src/grammar/render_markdown.rs
@@ -65,6 +65,7 @@ fn render_production(prod: &Production, cx: &RenderCtx, output: &mut String) {
 fn last_expr(expr: &Expression) -> &ExpressionKind {
     match &expr.kind {
         ExpressionKind::Alt(es) | ExpressionKind::Sequence(es) => last_expr(es.last().unwrap()),
+        ExpressionKind::Cut(e) => last_expr(e),
         ExpressionKind::Grouped(_)
         | ExpressionKind::Optional(_)
         | ExpressionKind::NegativeLookahead(_)
@@ -79,7 +80,6 @@ fn last_expr(expr: &Expression) -> &ExpressionKind {
         | ExpressionKind::Comment(_)
         | ExpressionKind::Charset(_)
         | ExpressionKind::NegExpression(_)
-        | ExpressionKind::Cut(_)
         | ExpressionKind::Unicode(_) => &expr.kind,
     }
 }


### PR DESCRIPTION
This fixes a formatting issue with how the grammar is rendered in markdown when there is a cut operator. The Alt renderer was incorrectly missing a space on alternations that span multiple lines with a cut operator. This is because the Cut expression is essentially the same as a sequence, but the `last_expr` function was not treating it that way. The Cut was preventing it from seeing that the alternation had a Break at the end.