### PR TITLE
Add more rules about when expressions diverge

### DIFF
--- a/dev-guide/src/rules/index.md
+++ b/dev-guide/src/rules/index.md
@@ -33,6 +33,7 @@ When assigning rules to new paragraphs or modifying rule names, use the followin
    - `intro`: The beginning paragraph of each section. It should explain the construct being defined overall.
    - `syntax`: Syntax definitions or explanations when BNF syntax definitions are not used.
    - `namespace`: For items only, specifies the namespace(s) the item introduces a name in. It may also be used elsewhere when defining a namespace (e.g., `r[attribute.diagnostic.namespace]`).
+   - `diverging`: The divergence behavior of an expression. Be sure to update the Divergence chapter, too.
 6. When a rule doesn't fall under the above keywords, or for section rule IDs, name the subrule as follows:
    - If the rule names a specific Rust language construct (e.g., an attribute, standard library type/function, or keyword-introduced concept), use the construct as named in the language, appropriately case-adjusted (but do not replace `_`s with `-`s).
    - Other than Rust language concepts with `_`s in the name, use `-` characters to separate words within a "subrule".

--- a/src/divergence.md
+++ b/src/divergence.md
@@ -17,17 +17,47 @@ fn example() {
 
 See the following rules for specific expression divergence behavior:
 
+- [asm.diverging.naked_asm] --- `naked_asm!`.
+- [asm.diverging.noreturn] --- `noreturn` in `asm!`.
+- [expr.arith-logic.diverging] --- Arithmetic and logic expressions.
+- [expr.array.diverging] --- Array expressions.
+- [expr.array.index.diverging] --- Index expressions.
+- [expr.as.diverging] --- `as` expressions.
+- [expr.assign.diverging] --- Assignment expressions.
+- [expr.await.diverging] --- `.await` expressions.
+- [expr.block.async.diverging] --- Async block expressions.
 - [expr.block.diverging] --- Block expressions.
+- [expr.bool-logic.diverging] --- Lazy boolean expressions.
+- [expr.borrow.diverging] --- Borrow expressions.
+- [expr.call.diverging] --- Call expressions.
+- [expr.closure.diverging] --- Closure expressions.
+- [expr.cmp.diverging] --- Comparison expressions.
+- [expr.compound-assign.diverging] --- Compound assignment expressions.
+- [expr.deref.diverging] --- Dereference expressions.
+- [expr.field.diverging] --- Field expressions.
 - [expr.if.diverging] --- `if` expressions.
+- [expr.literal.diverging] --- Literal expressions.
 - [expr.loop.block-labels.type] --- Labeled block expressions with `break`.
 - [expr.loop.break-value.diverging] --- `loop` expressions with `break`.
 - [expr.loop.break.diverging] --- `break` expressions.
 - [expr.loop.continue.diverging] --- `continue` expressions.
+- [expr.loop.for.diverging] --- `for` expressions.
 - [expr.loop.infinite.diverging] --- Infinite `loop` expressions.
+- [expr.loop.while.diverging] --- `while` expressions.
 - [expr.match.diverging] --- `match` expressions.
 - [expr.match.empty] --- Empty `match` expressions.
+- [expr.method.diverging] --- Method call expressions.
+- [expr.negate.diverging] --- Negation expressions.
+- [expr.paren.diverging] --- Parenthesized expressions.
+- [expr.path.diverging] --- Path expressions.
+- [expr.placeholder.diverging] --- Underscore expressions.
+- [expr.range.diverging] --- Range expressions.
 - [expr.return.diverging] --- `return` expressions.
-- [type.never.constraint] --- Function calls returning `!`.
+- [expr.struct.diverging] --- Struct expressions.
+- [expr.try.diverging] --- Try propagation expressions.
+- [expr.tuple-index.diverging] --- Tuple indexing expressions.
+- [expr.tuple.diverging] --- Tuple expressions.
+- [statement.let.diverging] --- `let` statements.
 
 > [!NOTE]
 > The [`panic!`] macro and related panic-generating macros like [`unreachable!`] also have the type [`!`] and are diverging.

--- a/src/expressions/array-expr.md
+++ b/src/expressions/array-expr.md
@@ -72,6 +72,9 @@ const EMPTY: Vec<i32> = Vec::new();
 [EMPTY; 2];
 ```
 
+r[expr.array.diverging]
+An array expression [diverges] if any of its operands diverges.
+
 r[expr.array.index]
 ## Array and slice indexing expressions
 
@@ -128,6 +131,35 @@ arr[10];                  // warning: index out of bounds
 r[expr.array.index.trait-impl]
 The array index expression can be implemented for types other than arrays and slices by implementing the [Index] and [IndexMut] traits.
 
+r[expr.array.index.diverging]
+An index expression [diverges] if either of its operands diverges, or if the type of the indexed element is the [never type] and the value is guaranteed to be read.
+
+> [!EXAMPLE]
+> ```rust
+> fn phantom_place<F: FnOnce() -> T, T>() -> [T; 1] { loop {} }
+>
+> fn diverging_place_read() -> ! {
+>     // Create an array with the never type.
+>     let x /* : [!; 1] */ = phantom_place::<fn() -> !, _>();
+>     // A read of a place expression produces a diverging block.
+>     x[0];
+> }
+> ```
+>
+> The following example contrasts with the above because it does not perform a read. This means it does not diverge, causing a compile error.
+>
+> ```rust,compile_fail,E0308
+> # fn phantom_place<F: FnOnce() -> T, T>() -> [T; 1] { loop {} }
+> #
+> fn diverging_place_no_read() -> ! {
+>     // Create an array with the never type.
+>     let x /* : [!; 1] */ = phantom_place::<fn() -> !, _>();
+>     // This does not constitute a read.
+>     let _ = x[0];
+>     // ERROR: Expected type !, found ()
+> }
+> ```
+
 [`Copy`]: ../special-types-and-traits.md#copy
 [IndexMut]: std::ops::IndexMut
 [Index]: std::ops::Index
@@ -136,9 +168,11 @@ The array index expression can be implemented for types other than arrays and sl
 [const block expression]: expr.block.const
 [constant expression]: ../const_eval.md#constant-expressions
 [constant item]: ../items/constant-items.md
+[diverges]: divergence
 [inferred const]: items.generics.const.inferred
 [literal]: ../tokens.md#literals
 [memory location]: ../expressions.md#place-expressions-and-value-expressions
+[never type]: type.never
 [panic]: ../panic.md
 [path]: path-expr.md
 [slice]: ../types/slice.md

--- a/src/expressions/await-expr.md
+++ b/src/expressions/await-expr.md
@@ -29,6 +29,9 @@ r[expr.await.edition2018]
 > [!EDITION-2018]
 > Await expressions are only available beginning with Rust 2018.
 
+r[expr.await.diverging]
+An await expression [diverges] if the future's output type is the [never type].
+
 r[expr.await.task]
 ## Task context
 
@@ -63,6 +66,8 @@ where the `yield` pseudo-code returns `Poll::Pending` and, when re-invoked, resu
 [`poll::Pending`]: std::task::Poll::Pending
 [`poll::Ready`]: std::task::Poll::Ready
 [async context]: ../expressions/block-expr.md#async-context
+[diverges]: divergence
 [future]: std::future::Future
+[never type]: type.never
 [`IntoFuture`]: std::future::IntoFuture
 [`IntoFuture::into_future`]: std::future::IntoFuture::into_future

--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -196,6 +196,9 @@ The actual data format for this type is unspecified.
 > [!NOTE]
 > The future type that rustc generates is roughly equivalent to an enum with one variant per `await` point, where each variant stores the data needed to resume from its corresponding point.
 
+r[expr.block.async.diverging]
+An async block expression does not itself [diverge], but evaluating the future (such as through `await`) diverges if the output type is the [never type].
+
 r[expr.block.async.edition2018]
 > [!EDITION-2018]
 > Async blocks are only available beginning with Rust 2018.
@@ -357,6 +360,7 @@ fn is_unix_platform() -> bool {
 [call expressions]: call-expr.md
 [capture modes]: ../types/closure.md#capture-modes
 [constant items]: ../items/constant-items.md
+[diverge]: divergence
 [diverges]: expr.block.diverging
 [final operand]: expr.block.inner-attributes
 [free item]: ../glossary.md#free-item

--- a/src/expressions/call-expr.md
+++ b/src/expressions/call-expr.md
@@ -32,6 +32,9 @@ let three: i32 = add(1i32, 2i32);
 let name: &'static str = (|| "Rust")();
 ```
 
+r[expr.call.diverging]
+A call expression [diverges] if any of its operands diverges, or if the return type of the function is the [never type].
+
 r[expr.call.desugar]
 ## Disambiguating function calls
 
@@ -103,5 +106,7 @@ Refer to [RFC 132] for further details and motivations.
 [`default()`]: std::default::Default::default
 [`size_of()`]: std::mem::size_of
 [automatically dereferenced]: field-expr.md#automatic-dereferencing
+[diverges]: divergence
 [fully-qualified syntax]: ../paths.md#qualified-paths
+[never type]: type.never
 [non-function types]: ../types/function-item.md

--- a/src/expressions/closure-expr.md
+++ b/src/expressions/closure-expr.md
@@ -31,6 +31,9 @@ A closure expression denotes a function that maps a list of parameters onto the 
 r[expr.closure.unique-type]
 Each closure expression has a unique, anonymous type.
 
+r[expr.closure.diverging]
+A closure expression itself does not [diverge]. However, calling the closure diverges if the return type is the [never type].
+
 r[expr.closure.captures]
 Significantly, closure expressions _capture their environment_, which regular [function definitions] do not.
 
@@ -105,6 +108,8 @@ Attributes on closure parameters follow the same rules and restrictions as [regu
 [block]: block-expr.md
 [call traits and coercions]: ../types/closure.md#call-traits-and-coercions
 [closure type]: ../types/closure.md
+[diverge]: divergence
 [function definitions]: ../items/functions.md
+[never type]: type.never
 [patterns]: ../patterns.md
 [regular function parameters]: ../items/functions.md#attributes-on-function-parameters

--- a/src/expressions/field-expr.md
+++ b/src/expressions/field-expr.md
@@ -42,6 +42,43 @@ foo().x;
 (mystruct.function_field)() // Call expression containing a field expression
 ```
 
+r[expr.field.diverging]
+A field expression [diverges] if its expression operand diverges or if the type of the field is the [never type] and the value is guaranteed to be read.
+
+> [!EXAMPLE]
+> ```rust
+> struct S<T> {
+>     f: T
+> }
+>
+> fn phantom_place<F: FnOnce() -> T, T>() -> S<T> { loop {} }
+>
+> fn diverging_place_read() -> ! {
+>     // Create a struct with a field with the never type.
+>     let x /* : S<!> */ = phantom_place::<fn() -> !, _>();
+>     // A read of a place expression produces a diverging block.
+>     x.f;
+> }
+> ```
+>
+> The following example contrasts with the above because it does not perform a read. This means it does not diverge, causing a compile error.
+>
+> ```rust,compile_fail,E0308
+> # struct S<T> {
+> #     f: T
+> # }
+> #
+> # fn phantom_place<F: FnOnce() -> T, T>() -> S<T> { loop {} }
+> #
+> fn diverging_place_no_read() -> ! {
+>     // Create a struct with a field with the never type.
+>     let x /* : S<!> */ = phantom_place::<fn() -> !, _>();
+>     // This does not constitute a read.
+>     let _ = x.f;
+>     // ERROR: Expected type !, found ()
+> }
+> ```
+
 r[expr.field.autoref-deref]
 ## Automatic dereferencing
 
@@ -71,8 +108,10 @@ let d: String = x.f3;           // Move out of x.f3
 [`drop`]: ../special-types-and-traits.md#drop
 [identifier]: ../identifiers.md
 [call expression]: call-expr.md
+[diverges]: divergence
 [method call expression]: method-call-expr.md
 [mutable]: ../expressions.md#mutability
+[never type]: type.never
 [parenthesized expression]: grouped-expr.md
 [place expression]: ../expressions.md#place-expressions-and-value-expressions
 [struct]: ../items/structs.md

--- a/src/expressions/grouped-expr.md
+++ b/src/expressions/grouped-expr.md
@@ -44,4 +44,8 @@ assert_eq!( a.f (), "The method f");
 assert_eq!((a.f)(), "The field f");
 ```
 
+r[expr.paren.diverging]
+A parenthesized expression [diverges] if its operand diverges.
+
+[diverges]: divergence
 [place]: ../expressions.md#place-expressions-and-value-expressions

--- a/src/expressions/if-expr.md
+++ b/src/expressions/if-expr.md
@@ -73,6 +73,8 @@ assert_eq!(y, "Bigger");
 r[expr.if.diverging]
 An `if` expression [diverges] if either the condition expression diverges or if all arms diverge.
 
+The condition expression diverges if the leftmost condition in the `&&` chain diverges, where `let` patterns are considered to diverge if the scrutinee diverges.
+
 ```rust,no_run
 fn diverging_condition() -> ! {
     // Diverges because the condition expression diverges

--- a/src/expressions/literal-expr.md
+++ b/src/expressions/literal-expr.md
@@ -24,6 +24,9 @@ A _literal expression_ is an expression consisting of a single token, rather tha
 r[expr.literal.const-expr]
 A literal is a form of [constant expression], so is evaluated (primarily) at compile time.
 
+r[expr.literal.diverging]
+A literal expression does not [diverge].
+
 r[expr.literal.literal-token]
 Each of the lexical [literal][literal tokens] forms described earlier can make up a literal expression, as can the keywords `true` and `false`.
 
@@ -505,6 +508,7 @@ The expression's type is the primitive [boolean type], and its value is:
 [boolean type]: ../types/boolean.md
 [constant expression]: ../const_eval.md#constant-expressions
 [CStr]: core::ffi::CStr
+[diverge]: divergence
 [floating-point types]: ../types/numeric.md#floating-point-types
 [lint check]: ../attributes/diagnostics.md#lint-check-attributes
 [literal tokens]: ../tokens.md#literals

--- a/src/expressions/loop-expr.md
+++ b/src/expressions/loop-expr.md
@@ -80,6 +80,9 @@ while i < 10 {
 }
 ```
 
+r[expr.loop.while.diverging]
+A `while` loop does not [diverge].
+
 r[expr.loop.while.let]
 ### `while let` patterns
 
@@ -227,6 +230,9 @@ The variable names `next`, `iter`, and `val` are for exposition only, they do no
 
 > [!NOTE]
 > The outer `match` is used to ensure that any [temporary values] in `iter_expr` don't get dropped before the loop is finished. `next` is declared before being assigned because it results in types being inferred correctly more often.
+
+r[expr.loop.for.diverging]
+A `for` loop [diverges] if the iterator expression diverges.
 
 r[expr.loop.label]
 ## Loop labels
@@ -452,6 +458,7 @@ A `loop` with associated `break` expressions does not [diverge] if any of the br
 [`match` expression]: match-expr.md
 [boolean type]: ../types/boolean.md
 [diverge]: divergence
+[diverges]: divergence
 [diverging]: divergence
 [labeled block expression]: expr.loop.block-labels
 [least upper bound]: coerce.least-upper-bound

--- a/src/expressions/method-call-expr.md
+++ b/src/expressions/method-call-expr.md
@@ -83,12 +83,17 @@ r[expr.method.edition2021]
 > [!WARNING]
 > For [trait objects], if there is an inherent method of the same name as a trait method, it will give a compiler error when trying to call the method in a method call expression. Instead, you can call the method using [disambiguating function call syntax], in which case it calls the trait method, not the inherent method. There is no way to call the inherent method. Just don't define inherent methods on trait objects with the same name as a trait method and you'll be fine.
 
+r[expr.method.diverging]
+A method call expression [diverges] if any of its operands diverges, or if the return type of the method is the [never type].
+
 [visible]: ../visibility-and-privacy.md
 [array type]: ../types/array.md
 [trait objects]: ../types/trait-object.md
 [disambiguate call]: call-expr.md#disambiguating-function-calls
 [disambiguating function call syntax]: call-expr.md#disambiguating-function-calls
 [dereference]: operator-expr.md#the-dereference-operator
+[diverges]: divergence
 [methods]: ../items/associated-items.md#methods
+[never type]: type.never
 [unsized coercion]: ../type-coercions.md#unsized-coercions
 [`IntoIterator`]: std::iter::IntoIterator

--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -105,6 +105,9 @@ let a = && && mut 10;
 let a = & & & & mut 10;
 ```
 
+r[expr.borrow.diverging]
+A borrow expression [diverges] if its operand diverges.
+
 r[expr.borrow.raw]
 ### Raw borrow operators
 
@@ -203,6 +206,35 @@ let x = &*String::new();
 let y = &*std::ops::Deref::deref(&String::new()); // ERROR
 # y;
 ```
+
+r[expr.deref.diverging]
+A dereference expression [diverges] if its operand diverges, or if the type of the dereferenced value is the [never type] and the value is guaranteed to be read.
+
+> [!EXAMPLE]
+> ```rust
+> fn phantom_place<F: FnOnce() -> T, T>() -> &'static T { loop {} }
+>
+> fn diverging_place_read() -> ! {
+>     // Create a reference to the never type.
+>     let x /* : &! */ = phantom_place::<fn() -> !, _>();
+>     // A read of a place expression produces a diverging block.
+>     *x;
+> }
+> ```
+>
+> The following example contrasts with the above because it does not perform a read. This means it does not diverge, causing a compile error.
+>
+> ```rust,compile_fail,E0308
+> # fn phantom_place<F: FnOnce() -> T, T>() -> &T { loop {} }
+> #
+> fn diverging_place_no_read() -> ! {
+>     // Create a reference to the never type.
+>     let x /* : &! */ = phantom_place::<fn() -> !, _>();
+>     // This does not constitute a read.
+>     let _ = *x;
+>     // ERROR: Expected type !, found ()
+> }
+> ```
 
 r[expr.try]
 ## The try propagation expression
@@ -325,6 +357,9 @@ The try propagation operator can be applied to expressions with the type of:
     - `Poll::Ready(None)` evaluates to `Poll::Ready(None)`.
     - `Poll::Pending` evaluates to `Poll::Pending`.
 
+r[expr.try.diverging]
+A try propagation expression [diverges] if its operand diverges.
+
 r[expr.negate]
 ## Negation operators
 
@@ -356,6 +391,9 @@ assert_eq!(-x, -6);
 assert_eq!(!x, -7);
 assert_eq!(true, !false);
 ```
+
+r[expr.negate.diverging]
+A negation expression [diverges] if its operand diverges.
 
 r[expr.arith-logic]
 ## Arithmetic and logical binary operators
@@ -417,6 +455,9 @@ assert_eq!(13 << 3, 104);
 assert_eq!(-10 >> 2, -3);
 ```
 
+r[expr.arith-logic.diverging]
+An arithmetic or logical expression [diverges] if either of its operands diverges.
+
 r[expr.cmp]
 ## Comparison operators
 
@@ -475,6 +516,9 @@ assert!('A' <= 'B');
 assert!("World" >= "Hello");
 ```
 
+r[expr.cmp.diverging]
+A comparison expression [diverges] if either of its operands diverges.
+
 r[expr.bool-logic]
 ## Lazy boolean operators
 
@@ -495,6 +539,9 @@ They differ from `|` and `&` in that the right-hand operand is only evaluated wh
 let x = false || true; // true
 let y = false && panic!(); // false, doesn't evaluate `panic!()`
 ```
+
+r[expr.bool-logic.diverging]
+A lazy boolean expression [diverges] only if its left-hand operand diverges.
 
 r[expr.as]
 ## Type cast expressions
@@ -546,6 +593,9 @@ r[expr.as.coercions]
 [^lessmut]: Only when `m₁` is `mut` or `m₂` is `const`. Casting `mut` reference/pointer to `const` pointer is allowed.
 
 [^no-capture]: Only closures that do not capture (close over) any local variables can be cast to function pointers.
+
+r[expr.as.diverging]
+A type cast expression [diverges] if its expression operand diverges.
 
 ### Semantics
 
@@ -920,6 +970,9 @@ In its most basic form, an assignee expression is a [place expression], and we d
 r[expr.assign.behavior-destructuring]
 The more general case of destructuring assignment is discussed below, but this case always decomposes into sequential assignments to place expressions, which may be considered the more fundamental case.
 
+r[expr.assign.diverging]
+An assignment expression [diverges] if either of its operands diverges.
+
 r[expr.assign.basic]
 ### Basic assignments
 
@@ -1229,10 +1282,14 @@ As with normal assignment expressions, compound assignment expressions always pr
 > [!WARNING]
 > Avoid writing code that depends on the evaluation order of operands in compound assignments as it can be unusual and surprising.
 
+r[expr.compound-assign.diverging]
+A compound assignment expression [diverges] if either of its operands diverges.
+
 [`Box`]: ../special-types-and-traits.md#boxt
 [`Try`]: core::ops::Try
 [autoref]: expr.method.candidate-receivers-refs
 [copies or moves]: ../expressions.md#moved-and-copied-types
+[diverges]: divergence
 [dropping]: ../destructors.md
 [eval order test]: https://github.com/rust-lang/rust/blob/1.58.0/src/test/ui/expr/compound-assignment/eval-order.rs
 [explicit discriminants]: ../items/enumerations.md#explicit-discriminants
@@ -1247,6 +1304,7 @@ As with normal assignment expressions, compound assignment expressions always pr
 [metadata]: dynamic-sized.pointer-types
 [moved from]: expr.move.movable-place
 [mutable]: ../expressions.md#mutability
+[never type]: type.never
 [place expression]: ../expressions.md#place-expressions-and-value-expressions
 [assignee expression]: ../expressions.md#place-expressions-and-value-expressions
 [undefined behavior]: ../behavior-considered-undefined.md

--- a/src/expressions/path-expr.md
+++ b/src/expressions/path-expr.md
@@ -34,9 +34,14 @@ let slice_reverse = <[i32]>::reverse;
 r[expr.path.const]
 Evaluation of associated constants is handled the same way as [`const` blocks].
 
+r[expr.path.diverging]
+A path expression [diverges] if the path resolves to a value with the [never type] and it is a place expression that is guaranteed to be read.
+
+[diverges]: divergence
+[never type]: type.never
+[path]: paths
 [place expressions]: ../expressions.md#place-expressions-and-value-expressions
 [value expressions]: ../expressions.md#place-expressions-and-value-expressions
-[path]: ../paths.md
 [`static mut`]: ../items/static-items.md#mutable-statics
 [`unsafe` block]: block-expr.md#unsafe-blocks
 [`const` blocks]: block-expr.md#const-blocks

--- a/src/expressions/range-expr.md
+++ b/src/expressions/range-expr.md
@@ -65,3 +65,8 @@ for i in 1..11 {
     println!("{}", i);
 }
 ```
+
+r[expr.range.diverging]
+A range expression [diverges] if any of its operands diverges.
+
+[diverges]: divergence

--- a/src/expressions/struct-expr.md
+++ b/src/expressions/struct-expr.md
@@ -80,6 +80,9 @@ Enum::Variant {};
 > let d = ColorSpace::Oklch {};
 > ```
 
+r[expr.struct.diverging]
+A struct expression [diverges] if any of its operands diverges.
+
 r[expr.struct.field]
 ## Field struct expression
 
@@ -139,6 +142,7 @@ Point3d { x: x, y: y_value, z: z };
 Point3d { x, y: y_value, z };
 ```
 
+[diverges]: divergence
 [enum variant]: ../items/enumerations.md
 [if let]: if-expr.md#if-let-patterns
 [if]: if-expr.md#if-expressions

--- a/src/expressions/tuple-expr.md
+++ b/src/expressions/tuple-expr.md
@@ -40,6 +40,9 @@ Examples of tuple expressions and their types:
 | `("x".to_string(), )` | `(String, )`  |
 | `("a", 4usize, true)`| `(&'static str, usize, bool)` |
 
+r[expr.tuple.diverging]
+A tuple expression [diverges] if any of its operands diverges.
+
 r[expr.tuple-index]
 ## Tuple indexing expressions
 
@@ -85,9 +88,13 @@ assert_eq!(point.1, 0.0);
 > [!NOTE]
 > Although arrays and slices also have elements, you must use an [array or slice indexing expression] or a [slice pattern] to access their elements.
 
+r[expr.tuple-index.diverging]
+A tuple indexing expression [diverges] if its expression operand diverges.
+
 [array or slice indexing expression]: array-expr.md#array-and-slice-indexing-expressions
 [call expression]: ./call-expr.md
 [decimal literal]: ../tokens.md#integer-literals
+[diverges]: divergence
 [field access expressions]: ./field-expr.html#field-access-expressions
 [operands]: ../expressions.md
 [parenthetical expression]: grouped-expr.md

--- a/src/expressions/underscore-expr.md
+++ b/src/expressions/underscore-expr.md
@@ -37,3 +37,8 @@ _ = 2 + 2;
 // equivalent technique using a wildcard pattern in a let-binding
 let _ = 2 + 2;
 ```
+
+r[expr.placeholder.diverging]
+An underscore expression does not [diverge].
+
+[diverge]: divergence

--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -1726,3 +1726,14 @@ On ARM, the following additional directives are guaranteed to be supported:
 - `.code`
 - `.thumb`
 - `.thumb_func`
+
+## Divergence
+
+r[asm.diverging.noreturn]
+The `asm!` macro [diverges] if it uses the [`noreturn`] option and no `label` block returns unit.
+
+r[asm.diverging.naked_asm]
+The `naked_asm!` macro always [diverges].
+
+[`noreturn`]: asm.options.supported-options.noreturn
+[diverges]: divergence

--- a/src/statements.md
+++ b/src/statements.md
@@ -89,6 +89,9 @@ let [u, v] = [v[0], v[1]] else { // This pattern is irrefutable, so the compiler
 };
 ```
 
+r[statement.let.diverging]
+A let statement [diverges] if its initializer diverges.
+
 r[statement.expr]
 ## Expression statements
 
@@ -142,6 +145,7 @@ r[statement.attribute]
 Statements accept [outer attributes]. The attributes that have meaning on a statement are [`cfg`], and [the lint check attributes].
 
 [block]: expressions/block-expr.md
+[diverges]: divergence
 [expression]: expressions.md
 [function]: items/functions.md
 [item]: items.md


### PR DESCRIPTION
https://github.com/rust-lang/reference/pull/2067 added a chapter on divergence along with rules for some of the more subtle expressions like `if` or `match`. This adds rules for almost all the rest of the expressions.

Most of these are pretty straightforward propagation rules which could be left implicit. It may seem a little excessive to have a separate rule for each one, but I think the consistency is worth it because there are various subtleties. This also may help us be clear about these things when adding new expressions to the language to ensure we think about the divergence rules.

This does not cover const expressions (const blocks, static, const, array repeat, etc.) because I still do not yet fully know how those should be documented (see https://github.com/rust-lang/reference/issues/2153).

I'm not entirely excited by having the long list of rules in the divergence chapter, mostly because of the length. However, I think it is helpful to cross-index these kinds of things.

There are some interesting subtleties that I noticed:

- `while` loops cannot diverge. It's a little surprising to me (I would expect the condition to allow it to diverge). I suspect this is due to the desugaring to a loop expression using `break`, which does not diverge.
- Updated details for let-chains.

References for the implementation:
- Place expression with never must be read: https://github.com/rust-lang/rust/blob/59fd4ef94daa991e6797b5aa6127e824f3067def/compiler/rustc_hir_typeck/src/expr.rs#L318-L326
- `break` is never: https://github.com/rust-lang/rust/blob/59fd4ef94daa991e6797b5aa6127e824f3067def/compiler/rustc_hir_typeck/src/expr.rs#L819-L820
- `continue` is never: https://github.com/rust-lang/rust/blob/0376d43d443cba463a0b6a6ec9140ea17d7b7130/compiler/rustc_hir_typeck/src/expr.rs#L861
- `return` is never: https://github.com/rust-lang/rust/blob/0376d43d443cba463a0b6a6ec9140ea17d7b7130/compiler/rustc_hir_typeck/src/expr.rs#L921
- `if` divergence: https://github.com/rust-lang/rust/blob/59fd4ef94daa991e6797b5aa6127e824f3067def/compiler/rustc_hir_typeck/src/expr.rs#L1236-L1242
- `loop`: https://github.com/rust-lang/rust/blob/59fd4ef94daa991e6797b5aa6127e824f3067def/compiler/rustc_hir_typeck/src/expr.rs#L1450-L1456
- `asm!`: https://github.com/rust-lang/rust/blob/59fd4ef94daa991e6797b5aa6127e824f3067def/compiler/rustc_hir_typeck/src/expr.rs#L3684
- `match`: https://github.com/rust-lang/rust/blob/59fd4ef94daa991e6797b5aa6127e824f3067def/compiler/rustc_hir_typeck/src/_match.rs#L19-L178
- block break: https://github.com/rust-lang/rust/blob/59fd4ef94daa991e6797b5aa6127e824f3067def/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs#L1167-L1171
- lazy bool: https://github.com/rust-lang/rust/blob/0376d43d443cba463a0b6a6ec9140ea17d7b7130/compiler/rustc_hir_typeck/src/op.rs#L111

Closes https://github.com/rust-lang/reference/issues/2152
Closes https://github.com/rust-lang/reference/issues/2151