### PR TITLE
Fix an EN grammar error & add an item to place expr context list

### DIFF
--- a/src/expressions.md
+++ b/src/expressions.md
@@ -167,6 +167,7 @@ The following contexts are *place expression* contexts:
 * The operand of a unary [borrow], [raw borrow] or [dereference][deref] operator.
 * The operand of a field expression.
 * The indexed operand of an array indexing expression.
+* The tuple operand of a tuple indexing expression.
 * The operand of any [implicit borrow].
 * The initializer of a [let statement].
 * The [scrutinee] of an [`if let`], [`match`][match], or [`while let`] expression.

--- a/src/expressions.md
+++ b/src/expressions.md
@@ -165,9 +165,9 @@ The following contexts are *place expression* contexts:
 
 * The left operand of a [compound assignment] expression.
 * The operand of a unary [borrow], [raw borrow] or [dereference][deref] operator.
-* The operand of a field expression.
-* The indexed operand of an array indexing expression.
-* The tuple operand of a tuple indexing expression.
+* The operand of a [field expression].
+* The indexed operand of an [array indexing expression].
+* The tuple operand of a [tuple indexing expression].
 * The operand of any [implicit borrow].
 * The initializer of a [let statement].
 * The [scrutinee] of an [`if let`], [`match`][match], or [`while let`] expression.
@@ -378,6 +378,7 @@ They are never allowed before:
 [`while let`]:          expressions/loop-expr.md#while-let-patterns
 [array expressions]:    expressions/array-expr.md
 [array indexing]:       expressions/array-expr.md#array-and-slice-indexing-expressions
+[array indexing expression]: expr.array.index
 [assign]:               expressions/operator-expr.md#assignment-expressions
 [block expressions]:    expressions/block-expr.md
 [borrow]:               expressions/operator-expr.md#borrow-operators
@@ -391,6 +392,7 @@ They are never allowed before:
 [extending expression]: destructors.scope.lifetime-extension.exprs
 [extending expressions]: destructors.scope.lifetime-extension.exprs
 [field]:                expressions/field-expr.md
+[field expression]:     expr.field
 [functional update]:    expressions/struct-expr.md#functional-update-syntax
 [implicit borrow]:      #implicit-borrows
 [implicitly borrowed]:  expr.implicit-borrow
@@ -417,6 +419,7 @@ They are never allowed before:
 [temporary scopes]:     destructors.scope.temporary
 [Temporary values]:     #temporaries
 [tuple expressions]:    expressions/tuple-expr.md
+[tuple indexing expression]: expr.tuple-index
 [Tuple structs]:        items.struct.tuple
 [Tuples]:               expressions/tuple-expr.md
 [Underscores]:          expressions/underscore-expr.md

--- a/src/items/traits.md
+++ b/src/items/traits.md
@@ -31,7 +31,7 @@ r[items.traits.impls]
 Traits are implemented for specific types through separate [implementations].
 
 r[items.traits.associated-item-decls]
-Trait functions may omit the function body by replacing it with a semicolon. This indicates that the implementation must define the function. If the trait function defines a body, this definition acts as a default for any implementation which does not override it. Similarly, associated constants may omit the equals sign and expression to indicate implementations must define the constant value. Associated types must never define the type, the type may only be specified in an implementation.
+Trait functions may omit the function body by replacing it with a semicolon. This indicates that the implementation must define the function. If the trait function defines a body, this definition acts as a default for any implementation which does not override it. Similarly, associated constants may omit the equal sign and expression to indicate implementations must define the constant value. Associated types must never define the type, the type may only be specified in an implementation.
 
 ```rust
 // Examples of associated trait items with and without definitions.


### PR DESCRIPTION
The reference calls tuple components **field**s at some places, but the syntax distinguishes between **FieldExprssion**, IndexExpression and **TupleIndexingExpression**.

Not sure whether this adding is a redundancy.