### PR TITLE
Fix grammar for block comments

### DIFF
--- a/src/comments.md
+++ b/src/comments.md
@@ -17,13 +17,9 @@ LINE_COMMENT ->
     | `//` _immediately followed by LF_
 
 BLOCK_COMMENT ->
-      `/**/`
-    | `/***/`
-    | `/*`
-        ^
-        ( ~[`*` `!`] | `**` | BLOCK_COMMENT_OR_DOC )
-        ( BLOCK_COMMENT_OR_DOC | ~`*/` )*
-      `*/`
+    `/*`
+      ^ ( BLOCK_COMMENT_OR_DOC | (!`*/` CHAR) )*
+    `*/`
 
 INNER_LINE_DOC ->
     `//!` ^ LINE_DOC_COMMENT_CONTENT (LF | EOF)
@@ -46,9 +42,9 @@ OUTER_BLOCK_DOC ->
 BLOCK_CHAR -> (!(`*/` | CR) CHAR)
 
 BLOCK_COMMENT_OR_DOC ->
-      BLOCK_COMMENT
+      INNER_BLOCK_DOC
     | OUTER_BLOCK_DOC
-    | INNER_BLOCK_DOC
+    | BLOCK_COMMENT
 ```
 
 r[comments.normal]

--- a/src/comments.md
+++ b/src/comments.md
@@ -17,8 +17,8 @@ LINE_COMMENT ->
     | `//` _immediately followed by LF_
 
 BLOCK_COMMENT ->
-    `/*`
-      ^ ( BLOCK_COMMENT_OR_DOC | (!`*/` CHAR) )*
+    `/*` ^
+      ( BLOCK_COMMENT_OR_DOC | (!`*/` CHAR) )*
     `*/`
 
 INNER_LINE_DOC ->


### PR DESCRIPTION
This fixes an issue with the block comment grammar with nested block comments. For example, this would fail to match `/*/* test */*/` because of the following:

The open slash of the inner block comment matches `~[`*` `!`]` which then misinterprets the rest of the inner block comment as being normal characters, and prevents the nesting from working correctly.

The original intent with this formulation was to prevent it from matching an inner or outer block doc comment. This is no longer needed because we are now defining the order with the COMMENT production, and the doc comments come before block comments.

This also changes the order of BLOCK_COMMENT_OR_DOC, but that is not strictly necessary because once inside a block comment, everything is comment text. rustc does not expose nested comments as being distinct. I mainly ordered them to be consistent with COMMENT (and in case I forgot anything).

The implementation for this is at [`Cursor::block_comment`](https://github.com/rust-lang/rust/blob/859951e3c7c9d0322c39bad49221937455bdffcd/compiler/rustc_lexer/src/lib.rs#L782-L817).