### PR TITLE
Align attribute template with applied conventions

### DIFF
--- a/dev-guide/src/attributes.md
+++ b/dev-guide/src/attributes.md
@@ -50,7 +50,7 @@ The `example` attribute uses the [MetaNameValueStr] syntax. The value in the str
 
 ----
 
-The `example` attribute has the following forms:
+The `example` attribute has these forms:
 
 - [MetaWord]
   > [!EXAMPLE]
@@ -106,7 +106,7 @@ The `example` attribute may only be applied to the crate root.
 
 ----
 
-The `example` attribute is allowed anywhere attributes are allowed.
+The `example` attribute may be used anywhere attributes are allowed.
 
 ----
 
@@ -118,7 +118,7 @@ If there are unused attribute warnings, or if `rustc` is incorrectly accepting s
 ----
 
 r[PARENT.example.duplicates]
-Explain the behavior when the attribute is specified multiple times on an element. See [`AttributeDuplicates`](https://github.com/rust-lang/rust/blob/40d2563ea200f9327a8cb8b99a0fb82f75a7365c/compiler/rustc_feature/src/builtin_attrs.rs#L143) in the compiler. Examples:
+Explain the behavior when the attribute is used multiple times on an element. See [`AttributeDuplicates`](https://github.com/rust-lang/rust/blob/40d2563ea200f9327a8cb8b99a0fb82f75a7365c/compiler/rustc_feature/src/builtin_attrs.rs#L143) in the compiler. Examples:
 
 ----
 
@@ -155,7 +155,7 @@ Only the last use of `example` on an item is used to ...
 
 ----
 
-If the `example` attribute is used more than once on an item, then the combination of all the specified values is used as ...explain how they are merged.
+If the `example` attribute is used more than once on an item, then the combination of all listed values is used as ...explain how they are merged.
 
 ----
 


### PR DESCRIPTION
During review and revision of the PRs applying the attribute template to attributes in the Reference, we've established several standard phrasings.  We had earlier updated the attribute template for most of these.  But for some, we hadn't yet.  Let's align the template with four of these actual conventions.

cc @ehuss