### PR TITLE
Move shebang into its own subchapter

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -6,6 +6,7 @@
 
 - [Lexical structure](lexical-structure.md)
     - [Input format](input-format.md)
+    - [Shebang](shebang.md)
     - [Keywords](keywords.md)
     - [Identifiers](identifiers.md)
     - [Comments](comments.md)

--- a/src/crates-and-source-files.md
+++ b/src/crates-and-source-files.md
@@ -137,6 +137,6 @@ The crate name must not be empty, and must only contain [Unicode alphanumeric] o
 [module]: items/modules.md
 [module path]: paths.md
 [panic-docs]: panic.md#unwinding-across-ffi-boundaries
-[shebang]: input-format.md#shebang-removal
+[shebang]: shebang.md
 [trait or lifetime bounds]: trait-bounds.md
 [where clauses]: items/generics.md#where-clauses

--- a/src/input-format.md
+++ b/src/input-format.md
@@ -41,33 +41,8 @@ Other occurrences of the character `U+000D` (CR) are left in place (they are tre
 r[input.shebang]
 ## Shebang removal
 
-r[input.shebang.intro]
-A *[shebang]* is an optional line that is typically used in Unix-like systems to specify an interpreter for executing the file.
-
-> [!EXAMPLE]
-> <!-- ignore: tests don't like shebang -->
-> ```rust,ignore
-> #!/usr/bin/env rustx
->
-> fn main() {
->     println!("Hello!");
-> }
-> ```
-
-r[input.shebang.syntax]
-```grammar,lexer
-@root SHEBANG ->
-    `#!` !((WHITESPACE | LINE_COMMENT | BLOCK_COMMENT)* `[`)
-    ~LF* (LF | EOF)
-```
-
-The shebang starts with the characters `#!` and extends through the first `U+000A` (LF) or through EOF if no LF is present. If the `#!` characters are followed by `[` (ignoring any intervening [comments] or [whitespace]), the line is not considered a shebang (to avoid ambiguity with an [inner attribute]).
-
-r[input.shebang.position]
-The shebang may appear immediately at the start of the file or after the optional [byte order mark].
-
 r[input.shebang.removal]
-The shebang is removed from the input sequence (and is therefore ignored).
+If a [shebang] is present, it is removed from the input sequence (and is therefore ignored).
 
 r[input.tokenization]
 ## Tokenization
@@ -83,9 +58,7 @@ The resulting sequence of characters is then converted into tokens as described 
 >
 > The [`include_str!`] and [`include_bytes!`] macros do not apply these transformations.
 
-[inner attribute]: attributes.md
 [BYTE ORDER MARK]: https://en.wikipedia.org/wiki/Byte_order_mark#UTF-8
-[comments]: comments.md
 [Crates and source files]: crates-and-source-files.md
-[shebang]: https://en.wikipedia.org/wiki/Shebang_(Unix)
+[shebang]: shebang.md
 [whitespace]: whitespace.md

--- a/src/shebang.md
+++ b/src/shebang.md
@@ -1,0 +1,34 @@
+r[shebang]
+# Shebang
+
+r[shebang.intro]
+A *[shebang]* is an optional line that is typically used in Unix-like systems to specify an interpreter for executing the file.
+
+> [!EXAMPLE]
+> <!-- ignore: tests don't like shebang -->
+> ```rust,ignore
+> #!/usr/bin/env rustx
+>
+> fn main() {
+>     println!("Hello!");
+> }
+> ```
+
+r[shebang.syntax]
+```grammar,lexer
+@root SHEBANG ->
+    `#!` !((WHITESPACE | LINE_COMMENT | BLOCK_COMMENT)* `[`)
+    ~LF* (LF | EOF)
+```
+
+r[shebang.syntax-description]
+The shebang starts with the characters `#!` and extends through the first `U+000A` (LF) or through EOF if no LF is present. If the `#!` characters are followed by `[` (ignoring any intervening [comments] or [whitespace]), the line is not considered a shebang (to avoid ambiguity with an [inner attribute]).
+
+r[shebang.position]
+The shebang may appear immediately at the start of the file or after the optional [byte order mark].
+
+[byte order mark]: https://en.wikipedia.org/wiki/Byte_order_mark#UTF-8
+[comments]: comments.md
+[inner attribute]: attributes.md
+[shebang]: https://en.wikipedia.org/wiki/Shebang_(Unix)
+[whitespace]: whitespace.md


### PR DESCRIPTION
In rust-lang/reference#2192, we extended our documentation about shebangs but kept it in Input Format under a section on shebang removal.  But really, this section is mostly now about documenting what a shebang is, for our purposes.

Let's separate this out into a new subchapter.

We'll keep the rule about shebang removal in Input Format; it can link to Shebang for a description of what a shebang is, its grammar, etc.

This follows the pattern that we'll similarly be using for frontmatter.

cc @ehuss