### PR TITLE
[type layout] usize and isize have the same size and alignment

### DIFF
--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -42,8 +42,10 @@ The size of most primitives is given in this table.
 | `f64`             | 8                  |
 | `char`            | 4                  |
 
-r[layout.primitive.size-int]
+r[layout.primitive.size-minimum]
 `usize` and `isize` have a size big enough to contain every address on the target platform. For example, on a 32 bit target, this is 4 bytes, and on a 64 bit target, this is 8 bytes.
+
+r[layout.primitive.size-align]
 `usize` and `isize` have the same size and alignment.
 
 r[layout.primitive.align]

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -44,6 +44,7 @@ The size of most primitives is given in this table.
 
 r[layout.primitive.size-int]
 `usize` and `isize` have a size big enough to contain every address on the target platform. For example, on a 32 bit target, this is 4 bytes, and on a 64 bit target, this is 8 bytes.
+`usize` and `isize` have the same size and alignment.
 
 r[layout.primitive.align]
 The alignment of primitives is platform-specific. In most cases, their alignment is equal to their size, but it may be less. In particular, `i128` and `u128` are often aligned to 4 or 8 bytes even though their size is 16, and on many 32-bit platforms, `i64`, `u64`, and `f64` are only aligned to 4 bytes, not 8.


### PR DESCRIPTION
Everybody assumes this to be true, and I assume it was intended to be guaranteed to be true.