### PR TITLE
Guarantee size and alignment of more integer primitives

### DIFF
--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -49,7 +49,7 @@ r[layout.primitive.size-align]
 `usize` and `isize` have the same size and alignment.
 
 r[layout.primitive.align]
-The alignment of primitives is platform-specific. In most cases, their alignment is equal to their size, but it may be less. In particular, `i128` and `u128` are often aligned to 4 or 8 bytes even though their size is 16, and on many 32-bit platforms, `i64`, `u64`, and `f64` are only aligned to 4 bytes, not 8. Alignment is guaranteed to be the same for signed and unsigned variants – that is, for a given `N`, `align_of::<uN>() == align_of::<iN>()`.
+The alignment of primitives is platform-specific. In most cases, their alignment is equal to their size, but it may be less. In particular, `i128` and `u128` are often aligned to 4 or 8 bytes even though their size is 16, and on many 32-bit platforms, `i64`, `u64`, and `f64` are only aligned to 4 bytes, not 8. Alignment is guaranteed to be the same for signed and unsigned variants -- that is, for a given `N`, `align_of::<uN>() == align_of::<iN>()`.
 
 r[layout.pointer]
 ## Pointers and references layout

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -49,7 +49,7 @@ r[layout.primitive.size-align]
 `usize` and `isize` have the same size and alignment.
 
 r[layout.primitive.align]
-The alignment of primitives is platform-specific. In most cases, their alignment is equal to their size, but it may be less. In particular, `i128` and `u128` are often aligned to 4 or 8 bytes even though their size is 16, and on many 32-bit platforms, `i64`, `u64`, and `f64` are only aligned to 4 bytes, not 8.
+The alignment of primitives is platform-specific. In most cases, their alignment is equal to their size, but it may be less. In particular, `i128` and `u128` are often aligned to 4 or 8 bytes even though their size is 16, and on many 32-bit platforms, `i64`, `u64`, and `f64` are only aligned to 4 bytes, not 8. Alignment is guaranteed to be the same for signed and unsigned variants – that is, for a given `N`, `align_of::<uN>() == align_of::<iN>()`.
 
 r[layout.pointer]
 ## Pointers and references layout

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -48,8 +48,11 @@ r[layout.primitive.size-minimum]
 r[layout.primitive.size-align]
 `usize` and `isize` have the same size and alignment.
 
-r[layout.primitive.align]
-The alignment of primitives is platform-specific. In most cases, their alignment is equal to their size, but it may be less. In particular, `i128` and `u128` are often aligned to 4 or 8 bytes even though their size is 16, and on many 32-bit platforms, `i64`, `u64`, and `f64` are only aligned to 4 bytes, not 8. Alignment is guaranteed to be the same for signed and unsigned variants -- that is, for a given `N`, `align_of::<uN>() == align_of::<iN>()`.
+r[layout.primitive.platform-specific-alignment]
+The alignment of primitives is platform-specific. In most cases, their alignment is equal to their size, but it may be less. In particular, `i128` and `u128` are often aligned to 4 or 8 bytes even though their size is 16, and on many 32-bit platforms, `i64`, `u64`, and `f64` are only aligned to 4 bytes, not 8.
+
+r[layout.primitive.integer-alignment]
+Alignment is guaranteed to be the same for signed and unsigned variants -- that is, for a given `N`, `align_of::<uN>() == align_of::<iN>()`.
 
 r[layout.pointer]
 ## Pointers and references layout

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -52,7 +52,7 @@ r[layout.primitive.platform-specific-alignment]
 The alignment of primitives is platform-specific. In most cases, their alignment is equal to their size, but it may be less. In particular, `i128` and `u128` are often aligned to 4 or 8 bytes even though their size is 16, and on many 32-bit platforms, `i64`, `u64`, and `f64` are only aligned to 4 bytes, not 8.
 
 r[layout.primitive.integer-alignment]
-Alignment is guaranteed to be the same for signed and unsigned variants -- that is, for a given `N`, `align_of::<uN>() == align_of::<iN>()`.
+Alignment is guaranteed to be the same for fixed-width signed and unsigned integer variants of the same indicated size --- that is, for a given size `N`, `align_of::<uN>() == align_of::<iN>()`.
 
 r[layout.pointer]
 ## Pointers and references layout


### PR DESCRIPTION
Follows up on https://github.com/rust-lang/reference/pull/2200#issuecomment-4040294894

As an optional extension, we could consider guaranteeing equality between the alignments of:
- `u32` and `char`
- `u32` and `f32`
- `u64` and `f64`

Those equalities strike me as less important, and I'm not sure if they're even valid (ie, whether they hold on all platforms).