### PR TITLE
Add a rule that enum discriminants may not use generic parameters

### DIFF
--- a/src/items/enumerations.md
+++ b/src/items/enumerations.md
@@ -199,21 +199,20 @@ enum OverflowingDiscriminantError2 {
 r[items.enum.discriminant.restrictions.generics]
 Explicit enum discriminants may not use generic parameters from the enclosing enum.
 
-> [!EXAMPLE]
-> ```rust,compile_fail
-> #[repr(u32)]
-> enum E<'a, T, const N: u32> {
->     Lifetime(&'a T) = {
->         let a: &'a (); // ERROR: generic parameters may not be used in enum discriminant
->         1
->     },
->     Type(T) = {
->         let x: T; // ERROR: generic parameters may not be used in enum discriminant
->         2
->     },
->     Const = N, // ERROR: generic parameters may not be used in enum discriminant
-> }
-> ```
+```rust,compile_fail
+#[repr(u32)]
+enum E<'a, T, const N: u32> {
+    Lifetime(&'a T) = {
+        let a: &'a (); // ERROR.
+        1
+    },
+    Type(T) = {
+        let x: T; // ERROR.
+        2
+    },
+    Const = N, // ERROR.
+}
+```
 
 ### Accessing discriminant
 

--- a/src/items/enumerations.md
+++ b/src/items/enumerations.md
@@ -196,6 +196,25 @@ enum OverflowingDiscriminantError2 {
 }
 ```
 
+r[items.enum.discriminant.restrictions.generics]
+Explicit enum discriminants may not use generic parameters from the enclosing enum.
+
+> [!EXAMPLE]
+> ```rust,compile_fail
+> #[repr(u32)]
+> enum E<'a, T, const N: u32> {
+>     Lifetime(&'a T) = {
+>         let a: &'a (); // ERROR: generic parameters may not be used in enum discriminant
+>         1
+>     },
+>     Type(T) = {
+>         let x: T; // ERROR: generic parameters may not be used in enum discriminant
+>         2
+>     },
+>     Const = N, // ERROR: generic parameters may not be used in enum discriminant
+> }
+> ```
+
 ### Accessing discriminant
 
 #### Via `mem::discriminant`

--- a/src/items/enumerations.md
+++ b/src/items/enumerations.md
@@ -197,7 +197,7 @@ enum OverflowingDiscriminantError2 {
 ```
 
 r[items.enum.discriminant.restrictions.generics]
-Explicit enum discriminants may not use generic parameters from the enclosing enum.
+Explicit enum discriminant initializers may not use generic parameters from the enclosing enum.
 
 ```rust,compile_fail
 #[repr(u32)]


### PR DESCRIPTION
This is implemented in the compiler with the diagnostic [`ParamInEnumDiscriminant`](https://github.com/rust-lang/rust/blob/3b1b0ef4d80d3117924d91352c8b6ca528708b3c/compiler/rustc_resolve/src/errors.rs#L651-L661) and [`NoConstantGenericsReason::IsEnumDiscriminant`](https://github.com/rust-lang/rust/blob/3b1b0ef4d80d3117924d91352c8b6ca528708b3c/compiler/rustc_resolve/src/late.rs#L160-L168).