### PR TITLE
Fix note for non_exhaustive enum read

### DIFF
--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -202,7 +202,7 @@ r[type.closure.capture.precision.wildcard.destructuring]
 Destructuring tuples, structs, and single-variant enums does not, by itself, cause a read or the place to be captured.
 
 > [!NOTE]
-> Enums marked with [`#[non_exhaustive]`][attributes.type-system.non_exhaustive] from other crates are always treated as having multiple variants. See *[type.closure.capture.precision.discriminants.non_exhaustive]*.
+> Enums marked with [`#[non_exhaustive]`][attributes.type-system.non_exhaustive] are always treated as having multiple variants. See *[type.closure.capture.precision.discriminants.non_exhaustive]*.
 
 ```rust,no_run
 struct S; // A non-`Copy` type.


### PR DESCRIPTION
Updating this note was missed in https://github.com/rust-lang/reference/pull/2162 which removed the external crate exception.

Fixes https://github.com/rust-lang/reference/issues/2210