### PR TITLE
Update `derive` export locations

### DIFF
--- a/src/attributes/derive.md
+++ b/src/attributes/derive.md
@@ -43,7 +43,12 @@ r[attributes.derive.duplicates]
 The `derive` attribute may be used any number of times on an item. All derive macros listed in all attributes are invoked.
 
 r[attributes.derive.stdlib]
-The `derive` attribute is exported in the standard library prelude as [`core::prelude::v1::derive`].
+The `derive` attribute is exported in the standard library as:
+
+- [`core::derive`]
+- [`std::derive`]
+- [`core::prelude::v1::derive`]
+- [`std::prelude::v1::derive`]
 
 r[attributes.derive.built-in]
 Built-in derives are defined in the [language prelude][names.preludes.lang]. The list of built-in derives are:


### PR DESCRIPTION
The `derive` export locations were changed in https://github.com/rust-lang/rust/pull/154442.

I'm a little on the fence listing them out this way, but I think I would prefer to be explicit.