### PR TITLE
Document diagostic attribute duplicates

### DIFF
--- a/src/attributes/diagnostics.md
+++ b/src/attributes/diagnostics.md
@@ -575,6 +575,9 @@ The `note` option can appear several times, which results in several note messag
 r[attributes.diagnostic.on_unimplemented.repetition]
 If any of the other options appears several times the first occurrence of the relevant option specifies the actually used value. Subsequent occurrences generates a warning.
 
+r[attributes.diagnostic.on_unimplemented.duplicates]
+The `diagnostic::on_unimplemented` attribute may be used any number of times. All keys from all uses of the attribute will be used and are subject to the repetition rules.
+
 r[attributes.diagnostic.on_unimplemented.unknown-keys]
 A warning is generated for any unknown keys.
 


### PR DESCRIPTION
You can stack these attributes, which I think is a cool little known fact. For example:
```
#[diagnostic::on_unimplemented(
    message = "pyclass `{Self}` cannot be subclassed",
    label = "required for `#[pyclass(extends={Self})]`",
    note = "`{Self}` must have `#[pyclass(subclass)]` to be eligible for subclassing"
)]
#[cfg_attr(
    Py_LIMITED_API,
    diagnostic::on_unimplemented(
        note = "with the `abi3` feature enabled, PyO3 does not support subclassing native types",
    )
)]
pub trait PyClassBaseType: Sized {
```

See https://github.com/rust-lang/rust/pull/155294 for the test this rule will link to.