### PR TITLE
Fix the grammar of function pointer types

### DIFF
--- a/src/items/functions.md
+++ b/src/items/functions.md
@@ -9,9 +9,9 @@ Function ->
         FunctionReturnType? WhereClause?
         ( BlockExpression | `;` )
 
-FunctionQualifiers -> `const`? `async`?[^async-edition] ItemSafety?[^extern-qualifiers] (`extern` Abi?)?
+FunctionQualifiers -> `const`? `async`?[^async-edition] Safety?[^extern-qualifiers] (`extern` Abi?)?
 
-ItemSafety -> `safe`[^extern-safe] | `unsafe`
+Safety -> `safe`[^safe-semantics] | `unsafe`
 
 Abi -> STRING_LITERAL | RAW_STRING_LITERAL
 
@@ -34,11 +34,11 @@ FunctionReturnType -> `->` Type
 
 [^async-edition]: The `async` qualifier is not allowed in the 2015 edition.
 
-[^extern-safe]: The `safe` function qualifier is only allowed semantically within `extern` blocks.
-
-[^extern-qualifiers]: *Relevant to editions earlier than Rust 2024*: Within `extern` blocks, the `safe` or `unsafe` function qualifier is only allowed when the `extern` is qualified as `unsafe`.
+[^extern-qualifiers]: The `safe` or `unsafe` qualifiers are only allowed semantically within `extern` blocks. *Relevant to editions earlier than Rust 2024*: More specifically within `extern` blocks that are qualified as `unsafe`.
 
 [^fn-param-2015]: Function parameters with only a type are only allowed in an associated function of a [trait item] in the 2015 edition.
+
+[^safe-semantics]: The `safe` qualifier is only allowed semantically on functions within `extern` blocks.
 
 r[items.fn.intro]
 A _function_ consists of a [block] (that's the _body_ of the function), along with a name, a set of parameters, and an output type. Other than a name, all these are optional.

--- a/src/items/static-items.md
+++ b/src/items/static-items.md
@@ -4,10 +4,10 @@ r[items.static]
 r[items.static.syntax]
 ```grammar,items
 StaticItem ->
-    ItemSafety?[^extern-safety] `static` `mut`? IDENTIFIER `:` Type ( `=` Expression )? `;`
+    Safety?[^extern-qualifiers] `static` `mut`? IDENTIFIER `:` Type ( `=` Expression )? `;`
 ```
 
-[^extern-safety]: The `safe` and `unsafe` function qualifiers are only allowed semantically within `extern` blocks.
+[^extern-qualifiers]: The `safe` and `unsafe` qualifiers are only allowed semantically within `extern` blocks. *Relevant to editions earlier than Rust 2024*: More specifically within `extern` blocks that are qualified as `unsafe`.
 
 r[items.static.intro]
 A *static item* is similar to a [constant], except that it represents an allocation in the program that is initialized with the initializer expression. All references and raw pointers to the static refer to the same allocation.

--- a/src/types/function-pointer.md
+++ b/src/types/function-pointer.md
@@ -7,7 +7,7 @@ BareFunctionType ->
     ForLifetimes? FunctionTypeQualifiers `fn`
        `(` FunctionParametersMaybeNamedVariadic? `)` BareFunctionReturnType?
 
-FunctionTypeQualifiers -> `unsafe`? (`extern` Abi?)?
+FunctionTypeQualifiers -> Safety? (`extern` Abi?)?
 
 BareFunctionReturnType -> `->` TypeNoBounds
 

--- a/src/types/function-pointer.md
+++ b/src/types/function-pointer.md
@@ -5,23 +5,17 @@ r[type.fn-pointer.syntax]
 ```grammar,types
 BareFunctionType ->
     ForLifetimes? FunctionTypeQualifiers `fn`
-       `(` FunctionParametersMaybeNamedVariadic? `)` BareFunctionReturnType?
+       `(` MaybeNamedFunctionParameters? `)` BareFunctionReturnType?
 
 FunctionTypeQualifiers -> Safety? (`extern` Abi?)?
 
 BareFunctionReturnType -> `->` TypeNoBounds
 
-FunctionParametersMaybeNamedVariadic ->
-    MaybeNamedFunctionParameters | MaybeNamedFunctionParametersVariadic
-
 MaybeNamedFunctionParameters ->
     MaybeNamedParam ( `,` MaybeNamedParam )* `,`?
 
 MaybeNamedParam ->
-    OuterAttribute* ( ( IDENTIFIER | `_` ) `:` )? Type
-
-MaybeNamedFunctionParametersVariadic ->
-    ( MaybeNamedParam `,` )* MaybeNamedParam `,` OuterAttribute* `...`
+    OuterAttribute* ( ( IDENTIFIER | `_` ) `:` )? ( Type | `...` )
 ```
 
 r[type.fn-pointer.intro]

--- a/src/types/function-pointer.md
+++ b/src/types/function-pointer.md
@@ -16,7 +16,10 @@ MaybeNamedFunctionParameters ->
     | (SelfParam `,`)? MaybeNamedParam ( `,` MaybeNamedParam )* `,`?
 
 MaybeNamedParam ->
-    OuterAttribute* ( ( IDENTIFIER | `_` ) `:` )? ( Type | `...` )
+    OuterAttribute* ( MaybeNamedPattern `:` )? ( Type | `...` )
+
+MaybeNamedPattern ->
+    `mut`? IDENTIFIER | ( `&` | `&&` )? ( `_` | `false` | `true` | IDENTIFIER )
 ```
 
 r[type.fn-pointer.intro]

--- a/src/types/function-pointer.md
+++ b/src/types/function-pointer.md
@@ -12,7 +12,8 @@ FunctionTypeQualifiers -> Safety? (`extern` Abi?)?
 BareFunctionReturnType -> `->` TypeNoBounds
 
 MaybeNamedFunctionParameters ->
-    MaybeNamedParam ( `,` MaybeNamedParam )* `,`?
+      SelfParam `,`?
+    | (SelfParam `,`)? MaybeNamedParam ( `,` MaybeNamedParam )* `,`?
 
 MaybeNamedParam ->
     OuterAttribute* ( ( IDENTIFIER | `_` ) `:` )? ( Type | `...` )


### PR DESCRIPTION
The grammar of function pointer types on master drastically diverges from reality.
Please read the individual commit messages for details (changes, motivation).

For example, according to the grammar on master, the following snippets are syntactically illegal but that is in conflict with rustc which deems them syntactically well-formed:

1. `safe fn()`
2. `fn(...)`, `fn(...,)`, `fn(_: ...)`, `fn(v: ...)`, `fn(..., ())`
3. `fn(&self)`, `fn(&'static mut self, ())`
4. `fn(mut x: ())`, `fn(false: bool)`, `fn(&_: ())`, `fn(&&true: ())`

Context: [#t-lang > Naming arguments in Fn traits](https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/Naming.20arguments.20in.20Fn.20traits/with/590761828) and https://github.com/rust-lang/rfcs/pull/3955 where this was quite relevant.