### PR TITLE
Fix test failure on macOS with link_section

### DIFF
--- a/src/abi.md
+++ b/src/abi.md
@@ -98,9 +98,11 @@ The `link_section` attribute uses the [MetaNameValueStr] syntax to specify the s
 
 <!-- no_run: don't link. The format of the section name is platform-specific. -->
 ```rust,no_run
+# #[cfg(target_os = "linux")] {
 #[unsafe(no_mangle)]
 #[unsafe(link_section = ".example_section")]
 pub static VAR1: u32 = 1;
+# }
 ```
 
 r[abi.link_section.unsafe]


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/155065 recently added validation for link_section on macOS. I'm working around it here by just limiting this test to linux.

Alternatives:
- Show different syntaxes for different targets (but I would prefer to keep the example as plain as possible).
- Mark it as `ignore` (want to avoid this if at all possible).

Fixes https://github.com/rust-lang/reference/issues/2245