### PR TITLE
Fix the grammar of generic arguments

### DIFF
--- a/src/paths.md
+++ b/src/paths.md
@@ -52,8 +52,14 @@ PathIdentSegment ->
     IDENTIFIER | `super` | `self` | `Self` | `crate` | `$crate`
 
 GenericArgs ->
-      `<` `>`
-    | `<` ( GenericArg `,` )* GenericArg `,`? `>`
+      `<` GenericArgList? `>`
+    | `(` TypeList? `)` (`->` TypeNoBounds)?
+
+GenericArgList ->
+    ( GenericArg `,` )* GenericArg `,`?
+
+TypeList ->
+    ( Type `,` )* Type `,`?
 
 GenericArg ->
     Lifetime | Type | GenericArgsConst | GenericArgsBinding | GenericArgsBounds
@@ -154,11 +160,7 @@ r[paths.type.syntax]
 ```grammar,paths
 TypePath -> `::`? TypePathSegment (`::` TypePathSegment)*
 
-TypePathSegment -> PathIdentSegment (`::`? (GenericArgs | TypePathFn))?
-
-TypePathFn -> `(` TypePathFnInputs? `)` (`->` TypeNoBounds)?
-
-TypePathFnInputs -> Type (`,` Type)* `,`?
+TypePathSegment -> PathIdentSegment (`::`? GenericArgs)?
 ```
 
 r[paths.type.intro]

--- a/src/paths.md
+++ b/src/paths.md
@@ -71,10 +71,10 @@ GenericArgsConst ->
     | SimplePathSegment
 
 GenericArgsBinding ->
-    IDENTIFIER GenericArgs? `=` Type
+    TypePathSegment `=` Type
 
 GenericArgsBounds ->
-    IDENTIFIER GenericArgs? `:` Bounds
+    TypePathSegment `:` Bounds
 ```
 
 r[paths.expr.intro]


### PR DESCRIPTION
Since PR https://github.com/rust-lang/rust/pull/43540 (2017) the grammar of paths in types, expressions & patterns has been somewhat unified.

Type paths are "now" basically identical to expression and pattern paths except that for the former, `::` before generic arg lists is optional whereas for the latter it is mandatory. Notably, the grammar of generic arg lists is the same across these three kinds, so parenthesized generic argument lists are intentionally legal in expression and pattern contexts, too, as long as they're preceded by `::`.

For example, the following is legal:

```rs
#[cfg(false)]
fn scope() {
    let F::() -> () = F::() -> ()::Y;
    // ^^^ to be understood as vvv
    let F::<(), Output = ()> = F::<(), Output = ()>::Y;
}
```

However, the Reference didn't reflect this fact and incorrectly claimed that parenthesized generic argument lists were exclusive to type paths. This PR rectifies this incongruity.

Context: Jonathan Brouwer and I stumbled upon this when discussing [their most recent RFC](https://github.com/rust-lang/rfcs/pull/3955).

Moreover, [*GenericArgsBinding*](https://doc.rust-lang.org/nightly/reference/paths.html#grammar-GenericArgsBinding) and [*GenericArgsBounds*](https://doc.rust-lang.org/nightly/reference/paths.html#grammar-GenericArgsBounds) use *GenericArgs*, meaning the Reference didn't correctly document that *parenthesized* generic arguments are legal there, too, like the following program:

```rs
#[cfg(false)]
fn scope() {
    let _: P<S<T> = T>;
    let _: P<S::<T>: B>; // wrongly deemed illegal by reference@master
    let _: P<S(T) = T>;  // similarly
    let _: P<S::(T): B>; // similarly
    let _: P<S<>: >; // similarly
    let _: P<crate<> = T>; // similarly
}
```

The new definition of *GenericArgs* provided in this PR automatically fixes this issue. Note that I still had to adjust *GenericArgsBinding* and *GenericArgsBounds* since in the past state it didn't admit turbofish or path segment keywords like `crate`. I just needed to replace `IDENTIFIER GenericArgs?` with `TypePathSegment` because that's what it is, exactly.

The Reference currently also incorrectly claims that type path `P<S<>: >` is invalid which it is not, bounds are intentionally Kleene star, not plus. I might fix that in a separate PR since this issue might occur in other places, too.

r? ehuss (lemme know if I should stop assigning you)