### PR TITLE
Make definition of fragment specifier `path` more precise

### DIFF
--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -116,7 +116,7 @@ Valid fragment specifiers are:
   * `meta`: an [Attr], the contents of an attribute
   * `pat`: a [Pattern] (see [macro.decl.meta.edition2021])
   * `pat_param`: a [PatternNoTopAlt]
-  * `path`: a [TypePath] style path
+  * `path`: a [TypePath]
   * `stmt`: a [Statement][grammar-Statement] without the trailing semicolon (except for item statements that require semicolons)
   * `tt`: a [TokenTree]&nbsp;(a single [token] or tokens in matching delimiters `()`, `[]`, or `{}`)
   * `ty`: a [Type][grammar-Type]


### PR DESCRIPTION
The wording "a `TypePath` style path" is confusing and strictly speaking meaningless since the document never defines "`Rule`-style" where `Rule` is a grammar rule. Obviously, the original author meant "a type-style path (as defined by `TypePath`)". I've replaced it with "a `TypePath`" which is consistent with the other definitions above & below.

To prove that `path` truly is `TypePath` and not something more than that, [see the definition in rustc](https://github.com/rust-lang/rust/blob/8275de8cdd126d39676519a45a90d63f5ed747f2/compiler/rustc_parse/src/parser/nonterminal.rs#L185).

Fixes rust-lang/reference#2219.