### PR TITLE
rhs accepts place and value expressions

### DIFF
--- a/src/expressions/operator-expr.md
+++ b/src/expressions/operator-expr.md
@@ -912,7 +912,7 @@ r[expr.assign.intro]
 An *assignment expression* moves a value into a specified place.
 
 r[expr.assign.assignee]
-An assignment expression consists of a [mutable] [assignee expression], the *assignee operand*, followed by an equals sign (`=`) and a [value expression], the *assigned value operand*.
+An assignment expression consists of a [mutable] [assignee expression], the *assignee operand*, followed by an equals sign (`=`) and an *assigned value operand*.
 
 r[expr.assign.behavior-basic]
 In its most basic form, an assignee expression is a [place expression], and we discuss this case first.


### PR DESCRIPTION
From how I understand things, both place expressions and value expressions are accepted as *assigned value operands*. I assume this is the case because if I read Reference right...
```rust
// rhs is value expression
let foo = "value";

// rhs is place expression
let bar = foo;