### PR TITLE
gitignore linkcheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /book
 /dev-guide/book
 /target
+/linkcheck.sh


### PR DESCRIPTION
Ignore linkcheck.sh, which is downloaded by the linkcheck test.