### PR TITLE
Rename grammar rule `TypeParamBounds` to just `Bounds`

### DIFF
--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -9,7 +9,7 @@ GenericParam -> OuterAttribute* ( LifetimeParam | TypeParam | ConstParam )
 
 LifetimeParam -> Lifetime ( `:` LifetimeBounds )?
 
-TypeParam -> IDENTIFIER ( `:` TypeParamBounds? )? ( `=` Type )?
+TypeParam -> IDENTIFIER ( `:` Bounds? )? ( `=` Type )?
 
 ConstParam ->
     `const` IDENTIFIER `:` Type
@@ -236,7 +236,7 @@ WhereClauseItem ->
 
 LifetimeWhereClauseItem -> Lifetime `:` LifetimeBounds
 
-TypeBoundWhereClauseItem -> ForLifetimes? Type `:` TypeParamBounds?
+TypeBoundWhereClauseItem -> ForLifetimes? Type `:` Bounds?
 ```
 
 r[items.generics.where.intro]

--- a/src/items/traits.md
+++ b/src/items/traits.md
@@ -4,7 +4,7 @@ r[items.traits]
 r[items.traits.syntax]
 ```grammar,items
 Trait ->
-    `unsafe`? `trait` IDENTIFIER GenericParams? ( `:` TypeParamBounds? )? WhereClause?
+    `unsafe`? `trait` IDENTIFIER GenericParams? ( `:` Bounds? )? WhereClause?
     `{`
         InnerAttribute*
         AssociatedItem*

--- a/src/items/type-aliases.md
+++ b/src/items/type-aliases.md
@@ -4,7 +4,7 @@ r[items.type]
 r[items.type.syntax]
 ```grammar,items
 TypeAlias ->
-    `type` IDENTIFIER GenericParams? ( `:` TypeParamBounds )?
+    `type` IDENTIFIER GenericParams? ( `:` Bounds )?
         WhereClause?
         ( `=` Type WhereClause?)? `;`
 ```
@@ -33,13 +33,13 @@ let _ = TypeAlias(5); // Doesn't work
 ```
 
 r[items.type.associated-type]
-A type alias, when not used as an [associated type], must include a [Type][grammar-Type] and may not include [TypeParamBounds].
+A type alias, when not used as an [associated type], must include a [Type][grammar-Type] and may not include [Bounds].
 
 r[items.type.associated-trait]
-A type alias, when used as an [associated type] in a [trait], must not include a [Type][grammar-Type] specification but may include [TypeParamBounds].
+A type alias, when used as an [associated type] in a [trait], must not include a [Type][grammar-Type] specification but may include [Bounds].
 
 r[items.type.associated-impl]
-A type alias, when used as an [associated type] in a [trait impl], must include a [Type][grammar-Type] specification and may not include [TypeParamBounds].
+A type alias, when used as an [associated type] in a [trait impl], must include a [Type][grammar-Type] specification and may not include [Bounds].
 
 r[items.type.deprecated]
 Where clauses before the equals sign on a type alias in a [trait impl] (like `type TypeAlias<T> where T: Foo = Bar<T>`) are deprecated. Where clauses after the equals sign (like `type TypeAlias<T> = Bar<T> where T: Foo`) are preferred.

--- a/src/paths.md
+++ b/src/paths.md
@@ -68,7 +68,7 @@ GenericArgsBinding ->
     IDENTIFIER GenericArgs? `=` Type
 
 GenericArgsBounds ->
-    IDENTIFIER GenericArgs? `:` TypeParamBounds
+    IDENTIFIER GenericArgs? `:` Bounds
 ```
 
 r[paths.expr.intro]
@@ -162,7 +162,7 @@ TypePathFnInputs -> Type (`,` Type)* `,`?
 ```
 
 r[paths.type.intro]
-Type paths are used within type definitions, trait bounds, type parameter bounds, and qualified paths.
+Type paths are used within type definitions, trait bounds, and qualified paths.
 
 r[paths.type.turbofish]
 Although the `::` token is allowed before the generics arguments, it is not required because there is no ambiguity like there is in [PathInExpression].

--- a/src/trait-bounds.md
+++ b/src/trait-bounds.md
@@ -3,9 +3,9 @@ r[bound]
 
 r[bound.syntax]
 ```grammar,miscellaneous
-TypeParamBounds -> TypeParamBound ( `+` TypeParamBound )* `+`?
+Bounds -> Bound ( `+` Bound )* `+`?
 
-TypeParamBound -> Lifetime | TraitBound | UseBound
+Bound -> Lifetime | TraitBound | UseBound
 
 TraitBound ->
       ( `?` | ForLifetimes )? TypePath

--- a/src/types/impl-trait.md
+++ b/src/types/impl-trait.md
@@ -3,7 +3,7 @@ r[type.impl-trait]
 
 r[type.impl-trait.syntax]
 ```grammar,types
-ImplTraitType -> `impl` TypeParamBounds
+ImplTraitType -> `impl` Bounds
 
 ImplTraitTypeOneBound -> `impl` TraitBound
 ```

--- a/src/types/trait-object.md
+++ b/src/types/trait-object.md
@@ -3,7 +3,7 @@ r[type.trait-object]
 
 r[type.trait-object.syntax]
 ```grammar,types
-TraitObjectType -> `dyn`? TypeParamBounds
+TraitObjectType -> `dyn`? Bounds
 
 TraitObjectTypeOneBound -> `dyn`? TraitBound
 ```


### PR DESCRIPTION
I take issue with the name of grammar rule *TypeParamBounds*. Bounds aren't inherently tied to type parameters, they can perfectly exist without them. This name stems from an ancient time when where-clauses didn't exist yet and bounds could only be put on type parameters. Today, that is no longer true.

Consider the following program which contains bounds that aren't associated with type parameters in any way:

```rs
fn f0() where i32: Copy {}
fn f1() where [&'static str; 10]: std::fmt::Debug {}
fn f2<const N: usize>() where [String; N]: Copy {}
fn f3<'a>() where &'a (): Sized {}
```

Bounds can be placed on any type. I'd also be fine with renaming it to *TypeBounds*, just anything but *TypeParamBounds* :)