### PR TITLE
Fix grammar rules pertaining to obsolete range patterns

### DIFF
--- a/src/patterns.md
+++ b/src/patterns.md
@@ -6,10 +6,10 @@ r[patterns.syntax]
 Pattern -> `|`? PatternNoTopAlt  ( `|` PatternNoTopAlt )*
 
 PatternNoTopAlt ->
-      PatternWithoutRange
-    | RangePattern
+      PatternWithoutModernRange
+    | ModernRangePattern
 
-PatternWithoutRange ->
+PatternWithoutModernRange ->
       LiteralPattern
     | IdentifierPattern
     | WildcardPattern
@@ -22,7 +22,10 @@ PatternWithoutRange ->
     | SlicePattern
     | PathPattern
     | MacroInvocation
+    | ObsoleteRangePattern[^obsolete-range-edition]
 ```
+
+[^obsolete-range-edition]: The [ObsoleteRangePattern] syntax is semantically invalid in the 2021 edition and beyond.
 
 r[patterns.intro]
 Patterns are used to match values against structures and to, optionally, bind variables to values inside these structures. They are also used in variable declarations and parameters for functions and closures.
@@ -464,13 +467,12 @@ r[patterns.range]
 
 r[patterns.range.syntax]
 ```grammar,patterns
-RangePattern ->
+ModernRangePattern ->
       RangeExclusivePattern
     | RangeInclusivePattern
     | RangeFromPattern
     | RangeToExclusivePattern
     | RangeToInclusivePattern
-    | ObsoleteRangePattern[^obsolete-range-edition]
 
 RangeExclusivePattern ->
       RangePatternBound `..` RangePatternBound
@@ -494,8 +496,6 @@ RangePatternBound ->
       LiteralPattern
     | PathExpression
 ```
-
-[^obsolete-range-edition]: The [ObsoleteRangePattern] syntax has been removed in the 2021 edition.
 
 r[patterns.range.intro]
 *Range patterns* match scalar values within the range defined by their bounds. They comprise a *sigil* (`..` or `..=`) and a bound on one or both sides.
@@ -659,7 +659,7 @@ r[patterns.ref]
 
 r[patterns.ref.syntax]
 ```grammar,patterns
-ReferencePattern -> (`&`|`&&`) `mut`? PatternWithoutRange
+ReferencePattern -> (`&`|`&&`) `mut`? PatternWithoutModernRange
 ```
 
 r[patterns.ref.intro]


### PR DESCRIPTION
reference@master incorrectly claims that the following patterns are syntactically invalid: `&0...0`, `&mut 0...0`. As a matter of fact, rustc specifically continues to accept obsolete range patterns as the "pointee" of reference patterns; it only rejects modern range patterns in this position (e.g., `&..1`, `&0..`, `&mut 0..1`, `&&0..=0`, `&&mut ..=0`).

Of course, the fact that pattern `&0...1` and expression `&0..=1` get interpreted differently wrt. precedence (`&(0...1)` and `(&0)..=1`, respectively) has been identified as a bug: https://github.com/rust-lang/rust/issues/48501 (2018).

It's unclear to me if people have run crater back then to see if rejecting patterns like `&0...0` would lead to any regressions. In any case, in PR https://github.com/rust-lang/rust/pull/47813 (2018) it was only made an error for modern range patterns.

I don't think I have the time and energy to issue a crater run for this since I've been issuing crater run after crater run as of late. So I don't plan on fixing https://github.com/rust-lang/rust/issues/48501 anytime soon. However, I figured it would make sense to update the Reference. As far as I understand it, the Reference is descriptive rather than prescriptive, so even though this is a bug in rustc, it's worth documenting it IMHO, esp. since it's so old.

Finally, the footnote for *ObsoleteRangePattern* made it sound like this grammar rule stopped being in effect in Rust 2021 and beyond whilst in reality `...` patterns have only become *semantically* invalid in Rust 2021 and following, not *syntactically*. So I've clarified it.