### PR TITLE
Avoid direct Drop::drop method link in destructor docs

### DIFF
--- a/src/destructors.md
+++ b/src/destructors.md
@@ -7,7 +7,7 @@ When an [initialized]&#32;[variable] or [temporary] goes out of [scope](#drop-sc
 r[destructors.operation]
 The destructor of a type `T` consists of:
 
-1. If `T: Drop`, calling [`<T as core::ops::Drop>::drop`](core::ops::Drop::drop)
+1. If `T:` [`Drop`](core::ops::Drop), calling `<T as core::ops::Drop>::drop`
 2. Recursively running the destructor of all of its fields.
     * The fields of a [struct] are dropped in declaration order.
     * The fields of the active [enum variant] are dropped in declaration order.


### PR DESCRIPTION
This avoids linking directly to `core::ops::Drop::drop` from the destructor docs.

That direct method link can resolve to a rustdoc method-fragment anchor such as `#tymethod.drop`. In rust-lang/rust#144537, `Drop::drop` becomes a provided/default method, so the old required-method anchor is no longer generated, and linkchecker fails for `reference/destructors.html` and `reference/print.html`.

The docs still mention `<T as core::ops::Drop>::drop`, but now link to the `Drop` trait page instead of relying on a method-specific fragment.

This is the Reference-side fix needed for the linkchecker failure in rust-lang/rust#144537.