### PR TITLE
Update link_name for updated restrictions

### DIFF
--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -406,7 +406,7 @@ r[items.extern.attributes.link_name.syntax]
 The `link_name` attribute uses the [MetaNameValueStr] syntax.
 
 r[items.extern.attributes.link_name.invalid-names]
-The symbol name must not be the empty string, and must not contain any `U+0000` (NUL) bytes.
+The symbol name must not be the empty string or contain any `U+0000` (NUL) bytes.
 
 r[items.extern.attributes.link_name.allowed-positions]
 The `link_name` attribute may only be applied to a function or static item in an `extern` block.

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -405,6 +405,9 @@ The *`link_name` [attribute][attributes]* may be applied to declarations inside 
 r[items.extern.attributes.link_name.syntax]
 The `link_name` attribute uses the [MetaNameValueStr] syntax.
 
+r[items.extern.attributes.link_name.invalid-names]
+The symbol name must not be the empty string, and must not contain any `U+0000` (NUL) bytes.
+
 r[items.extern.attributes.link_name.allowed-positions]
 The `link_name` attribute may only be applied to a function or static item in an `extern` block.
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/155817 added some restrictions on the symbol name in the `link_name` attribute. The name cannot be empty or contain null bytes.

cc @folkertdev