### PR TITLE
Grammar: Don't allow inner attrs in certain block expressions

### DIFF
--- a/src/expressions/block-expr.md
+++ b/src/expressions/block-expr.md
@@ -9,6 +9,11 @@ BlockExpression ->
         Statements?
     `}`
 
+BlockExpressionNoInnerAttributes ->
+    `{`
+        Statements?
+    `}`
+
 Statements ->
       Statement+
     | Statement+ ExpressionWithoutBlock

--- a/src/expressions/if-expr.md
+++ b/src/expressions/if-expr.md
@@ -4,8 +4,8 @@ r[expr.if]
 r[expr.if.syntax]
 ```grammar,expressions
 IfExpression ->
-    `if` Conditions BlockExpression
-    (`else` ( BlockExpression | IfExpression ) )?
+    `if` Conditions BlockExpressionNoInnerAttributes
+    (`else` ( BlockExpressionNoInnerAttributes | IfExpression ) )?
 
 Conditions ->
       Expression _except [StructExpression]_

--- a/src/macros-by-example.md
+++ b/src/macros-by-example.md
@@ -106,7 +106,7 @@ In the matcher, `$` _name_ `:` _fragment-specifier_ matches a Rust syntax fragme
 r[macro.decl.meta.specifier]
 Valid fragment specifiers are:
 
-  * `block`: a [BlockExpression]
+  * `block`: a [BlockExpressionNoInnerAttributes]
   * `expr`: an [Expression]
   * `expr_2021`: an [Expression] except [UnderscoreExpression] and [ConstBlockExpression] (see [macro.decl.meta.edition2024])
   * `ident`: an [IDENTIFIER_OR_KEYWORD] except `_`, [RAW_IDENTIFIER], or [`$crate`]

--- a/src/statements.md
+++ b/src/statements.md
@@ -58,7 +58,8 @@ LetStatement ->
     OuterAttribute* `let` PatternNoTopAlt ( `:` Type )?
     (
           `=` Expression
-        | `=` Expression _except [LazyBooleanExpression] or end with a `}`_ `else` BlockExpression
+        | `=` Expression _except [LazyBooleanExpression] or end with a `}`_
+              `else` BlockExpressionNoInnerAttributes
     )? `;`
 ```
 


### PR DESCRIPTION
rustc doesn't syntactically permit inner attributes (1) in the *consequent* & *alternate* blocks of if-expressions, (2) in the *alternate* block of let-statements (let/else) and (3) in blocks matched by macro metavariables of type `block`.

Intuitively that makes sense since inner attributes generally target the "owner" of the surrounding block (e.g., the overarching function item or while-expression), neither "the block itself" nor the sequence of statements in said block (so `fn f(_: Undef) { #![cfg(false)] }` = `#[cfg(false)] fn f(_: Undef) {}` and `while undef { #![cfg(false)] }` = `#[cfg(false)] while undef {}`) which would be very surprising for if-exprs and let/else stmts I feel like and straight up ill-defined in the MBE case.

Concretely, it would mean that `if undef { /*…*/ } else if undef { /*…*/ } else { #![cfg(false)] }` would be equivalent to `#[cfg(false)] if …`; similarly for `let self::undef = /*…*/ else { #![cfg(false)] };` / `#[cfg(false)] let …;`.

I'm not sure if that's the "official" reasoning, I've yet to find that out. As far as I can tell, inner attributes have been illegal in then/else blocks since version 1.0 *at least*[^1].

Fixes rust-lang/reference#2212.

[^1]: However, back in version 1.0 inner attributes weren't permitted in most expressions with blocks like in `while` expressions or "normal" block exprs either (but they *were* already allowed in the block of function items) which were all lifted at some point except for if-expressions, of course.