### PR TITLE
Fix the grammar of const param defaults by reusing rule for const args

### DIFF
--- a/src/items/generics.md
+++ b/src/items/generics.md
@@ -11,9 +11,7 @@ LifetimeParam -> Lifetime ( `:` LifetimeBounds )?
 
 TypeParam -> IDENTIFIER ( `:` Bounds? )? ( `=` Type )?
 
-ConstParam ->
-    `const` IDENTIFIER `:` Type
-    ( `=` ( BlockExpression | IDENTIFIER | `-`?LiteralExpression ) )?
+ConstParam -> `const` IDENTIFIER `:` Type ( `=` ConstArg )?
 ```
 
 r[items.generics.syntax.intro]

--- a/src/paths.md
+++ b/src/paths.md
@@ -62,12 +62,11 @@ TypeList ->
     ( Type `,` )* Type `,`?
 
 GenericArg ->
-    Lifetime | Type | GenericArgsConst | GenericArgsBinding | GenericArgsBounds
+    Lifetime | Type | ConstArg | GenericArgsBinding | GenericArgsBounds
 
-GenericArgsConst ->
+ConstArg ->
       BlockExpression
-    | LiteralExpression
-    | `-` LiteralExpression
+    | `-`? LiteralExpression
     | SimplePathSegment
 
 GenericArgsBinding ->


### PR DESCRIPTION
`struct T<const N: U = crate>;` is syntactically valid but the previous definition of rule *ConstParam* didn't capture that fact since it only listed *IDENTIFIER* while it needed to be *SimplePathSegment*.