### PR TITLE
ci: declare contents:read on CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
 env:
   MDBOOK_VERSION: 0.5.2
 
+permissions:
+  contents: read
+
 jobs:
   code-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins `main.yml` to `contents: read` at workflow scope. The `code-tests` job (and the rest of the matrix) only check out, install rust nightly + mdbook, and run the book's automated tests. No GitHub API write.

Defense-in-depth motivation is [CVE-2025-30066](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3) on `tj-actions/changed-files`: a compromised third-party action runs inside the existing job context and exfiltrates the workflow `GITHUB_TOKEN` via build logs.

Style matches the workflow-level block already in `dev-guide.yml`. YAML validated locally with `yaml.safe_load`.