### PR TITLE
Clarify where `global_asm!` may be placed

### DIFF
--- a/src/inline-assembly.md
+++ b/src/inline-assembly.md
@@ -138,6 +138,8 @@ core::arch::naked_asm!("/* {} */", const 0);
 r[asm.scope.global_asm]
 With the `global_asm!` macro, the assembly code is emitted in a global scope, outside a function. This can be used to hand-write entire functions using assembly code, and generally provides much more freedom to use arbitrary registers and assembler directives.
 
+The `global_asm!` macro may only appear in [Item] position --- that is, in the crate root or a module, or as a statement.
+
 ```rust
 # fn main() {}
 # #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
The docs here were not clear about where `global_asm!` may be placed. It says the assembly is "emitted...outside a function", but doesn't exactly say where it is allowed.

The rules for this just changed in https://github.com/rust-lang/rust/pull/156582 which added the ability to place it in statement position.