### PR TITLE
Document RISC-V d, e, and f extensions

### DIFF
--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -270,6 +270,9 @@ r[attributes.codegen.target_feature.availability]
 
 The following is a list of the available feature names.
 
+r[attributes.codegen.target_feature.cfg-only]
+Target feature names marked as "(cfg only)" in this list may only be used with the [`target_feature`][cfg.target_feature] conditional compilation option, not with the `target_feature` attribute.
+
 r[attributes.codegen.target_feature.x86]
 #### `x86` or `x86_64`
 
@@ -514,6 +517,9 @@ Feature     | Implicitly Enables  | Description
 `a`         | `zaamo`, `zalrsc`   | [A][rv-a] --- Atomic instructions
 `b`         | `zba`, `zbc`, `zbs` | [B][rv-b] --- Bit Manipulation instructions
 `c`         | `zca`               | [C][rv-c] --- Compressed instructions
+`d`         | `f`                 | [D][rv-d] --- [(cfg only)] Double-Precision Floating-Point
+`e`         |                     | [E][rv-e] --- [(cfg only)] Embedded Instruction Set with 16 GPRs
+`f`         | `zicsr`             | [F][rv-f] --- [(cfg only)] Single-Precision Floating-Point
 `m`         |                     | [M][rv-m] --- Integer Multiplication and Division instructions
 `za64rs`    | `za128rs`           | [Za64rs][rv-za64rs] --- Platform Behavior: Naturally aligned Reservation sets with ≦ 64 Bytes
 `za128rs`   |                     | [Za128rs][rv-za128rs] --- Platform Behavior: Naturally aligned Reservation sets with ≦ 128 Bytes
@@ -566,6 +572,9 @@ Feature     | Implicitly Enables  | Description
 [rv-a]: https://github.com/riscv/riscv-isa-manual/blob/20250508/src/a-st-ext.adoc
 [rv-b]: https://github.com/riscv/riscv-isa-manual/blob/20250508/src/b-st-ext.adoc
 [rv-c]: https://github.com/riscv/riscv-isa-manual/blob/20250508/src/c-st-ext.adoc
+[rv-d]: https://github.com/riscv/riscv-isa-manual/blob/20250508/src/d-st-ext.adoc
+[rv-e]: https://github.com/riscv/riscv-isa-manual/blob/20250508/src/rv32e.adoc
+[rv-f]: https://github.com/riscv/riscv-isa-manual/blob/20250508/src/f-st-ext.adoc
 [rv-m]: https://github.com/riscv/riscv-isa-manual/blob/20250508/src/m-st-ext.adoc
 [rv-za64rs]: https://github.com/riscv/riscv-profiles/blob/rva23-rvb23-ratified/src/rva23-profile.adoc
 [rv-za128rs]: https://github.com/riscv/riscv-profiles/blob/v1.0/profiles.adoc
@@ -848,6 +857,7 @@ If the address of the function is taken as a function pointer, the low bit of th
 - For `arm::a32` ("ARM"), it will be 0.
 - For `arm::t32` ("Thumb"), it will be 1.
 
+[(cfg only)]: attributes.codegen.target_feature.cfg-only
 [`-C target-cpu`]: ../../rustc/codegen-options/index.html#target-cpu
 [`-C target-feature`]: ../../rustc/codegen-options/index.html#target-feature
 [`export_name`]: abi.export_name


### PR DESCRIPTION
These are being stabilized in https://github.com/rust-lang/rust/pull/156188 as cfg-only features. It is a little odd to list them here in the target_feature attribute section since they can't be used with the attribute, but I think it makes sense to keep things together. Perhaps in the future we may consider breaking these lists out into a separate section and rearrange things.