### PR TITLE
Add more example target_arch values

### DIFF
--- a/src/conditional-compilation.md
+++ b/src/conditional-compilation.md
@@ -97,15 +97,25 @@ r[cfg.target_arch.def]
 Key-value option set once with the target's CPU architecture. The value is similar to the first element of the platform's target triple, but not identical.
 
 r[cfg.target_arch.values]
-Example values:
+Example values (Note that not all of these are available on stable rust):
 
 * `"x86"`
 * `"x86_64"`
+* `"arm"`
+* `"aarch64"`
+* `"amdgpu"`
+* `"hexagon"`
+* `"riscv32"`
+* `"riscv64"`
 * `"mips"`
 * `"powerpc"`
 * `"powerpc64"`
-* `"arm"`
-* `"aarch64"`
+* `"nvptx"`
+* `"wasm"`
+* `"loongarch32"`
+* `"loongarch64"`
+* `"s390x"`
+
 
 r[cfg.target_feature]
 ### `target_feature`


### PR DESCRIPTION
These have been collected from
https://doc.rust-lang.org/stable/core/arch/index.html

Since mips was already on the list I figured I would add all target arch options have been added (even ones not available on stable Rust) and add a note to help the reader have the right expectations.

I found this when trying to figure out what the target_arch for riscv would be. I guess I kinda assumed it would be `riscv64gc`. If there is a different authoritative document somewhere, maybe this should link to that instead. But I figured the reference _was_ that authoritative document.