### PR TITLE
Fix rule ordering of trait object lifetime elision

### DIFF
--- a/src/lifetime-elision.md
+++ b/src/lifetime-elision.md
@@ -94,17 +94,8 @@ These default object lifetime bounds are used instead of the lifetime parameter 
 r[lifetime-elision.trait-object.explicit-placeholder]
 If `'_` is used as the lifetime bound then the bound follows the usual elision rules.
 
-r[lifetime-elision.trait-object.containing-type]
-If the trait object is used as a type argument of a generic type then the containing type is first used to try to infer a bound.
-
-r[lifetime-elision.trait-object.containing-type-unique]
-* If there is a unique bound from the containing type then that is the default.
-
-r[lifetime-elision.trait-object.containing-type-explicit]
-* If there is more than one bound from the containing type then an explicit bound must be specified.
-
 r[lifetime-elision.trait-object.trait-bounds]
-If neither of those rules apply, then the bounds on the trait are used:
+The bounds on the trait are used:
 
 r[lifetime-elision.trait-object.trait-unique]
 * If the trait is defined with a single lifetime _bound_ then that bound is used.
@@ -112,8 +103,17 @@ r[lifetime-elision.trait-object.trait-unique]
 r[lifetime-elision.trait-object.static-lifetime]
 * If `'static` is used for any lifetime bound then `'static` is used.
 
+r[lifetime-elision.trait-object.containing-type]
+If neither of those rules apply and the trait object is used as a type argument of a generic type then the containing type is first used to try to infer a bound.
+
+r[lifetime-elision.trait-object.containing-type-unique]
+* If there is a unique bound from the containing type then that is the default.
+
+r[lifetime-elision.trait-object.containing-type-explicit]
+* If there is more than one bound from the containing type then an explicit bound must be specified.
+
 r[lifetime-elision.trait-object.default]
-* If the trait has no lifetime bounds, then the lifetime is inferred in expressions and is `'static` outside of expressions.
+* If there is no such container, then the lifetime is inferred in expressions and is `'static` outside of expressions.
 
 ```rust
 // For the following trait...


### PR DESCRIPTION
Part of a series which aims to address rust-lang/reference#1407 step by step.

This PR fixes the worst and most dominant issue of section [Default trait object lifetimes](https://doc.rust-lang.org/reference/lifetime-elision.html#default-trait-object-lifetimes). 

---

Ever since that section was added by PR rust-lang/reference#187, the Reference wrongly claimed that outlives-bounds on the *type containing the trait object type* took precedence over the outlives-bounds on the (principal) trait. That's exactly opposite to what rustc is doing!

For context, [here the is relevant part of rustc's source code](https://github.com/rust-lang/rust/blob/09a371361240e42b0d69438fd1179efcf212e576/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs#L456-L471). To explain a bit what's going on: To determine the lifetime bound of a trait object type we **first** consult `compute_object_lifetime_bound` which returns the unique lifetime that (directly or transitively) bounds the principal trait if extant (that function internally consults [`object_region_bounds`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_trait_selection/traits/wf/fn.object_region_bounds.html)). If there's no such bound, it lowers the lifetime normally using [`lower_lifetime`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_analysis/hir_ty_lowering/trait.HirTyLowerer.html#method.lower_lifetime). That procedure queries `named_bound_var` which gets computed in module [RBV](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_analysis/collect/resolve_bound_vars/index.html) which among other things computes the entire "scope tree" of trait object lifetime defaults for the local crate as deduced by "type containers" only.

---

**I don't intend for the scope of this PR to grow past what's declared now**. I'd like to split this whole endeavor into quite small pieces to prevent it from becoming unmanageable. There are *a lot* of issues with the current section as rust-lang/reference#1407 highlights.

I'm of course very open to non-normative / editorial changes!

r? @traviscross (since you've shown some interest in this area, namely in https://github.com/rust-lang/rust/pull/129543)