### PR TITLE
Define an unsized tail

### DIFF
--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -145,7 +145,7 @@ r[undefined.validity.reference-box]
 * A reference or [`Box<T>`] must be aligned and non-null, it cannot be [dangling], and it must point to a valid value (in case of dynamically sized types, using the actual dynamic type of the pointee as determined by the [metadata]). Note that the last point (about pointing to a valid value) remains a subject of some debate.
 
 r[undefined.validity.wide]
-* The [metadata] of a wide reference, [`Box<T>`], or raw pointer must match the type of the unsized tail:
+* The [metadata] of a wide reference, [`Box<T>`], or raw pointer must match the type of the [unsized tail]:
   * `dyn Trait` metadata must be a pointer to a compiler-generated vtable for `Trait`. (For raw pointers, this requirement remains a subject of some debate.)
   * Slice (`[T]`) metadata must be a valid `usize`. Furthermore, for wide references and [`Box<T>`], slice metadata is invalid if it makes the total size of the pointed-to value bigger than `isize::MAX`.
 
@@ -204,6 +204,7 @@ r[undefined.validity.undef]
 [project-field]: expressions/field-expr.md
 [project-tuple]: expressions/tuple-expr.md#tuple-indexing-expressions
 [project-slice]: expressions/array-expr.md#array-and-slice-indexing-expressions
+[unsized tail]: dynamic-sized.tail
 [unwinding-ffi]: panic.md#unwinding-across-ffi-boundaries
 [const-promoted]: destructors.md#constant-promotion
 [lifetime-extended]: destructors.md#temporary-lifetime-extension

--- a/src/dynamically-sized-types.md
+++ b/src/dynamically-sized-types.md
@@ -25,10 +25,17 @@ r[dynamic-sized.struct-field]
 > [!NOTE]
 > [Variables], function parameters, [const] items, and [static] items must be `Sized`.
 
+r[dynamic-sized.tail]
+The *unsized tail* of a type is the dynamically sized component that the [metadata] of a pointer to the type describes. A [slice] (`[T]`) and a [`str`] are each their own unsized tail, described by a length; a [trait object] (`dyn Trait`) is its own unsized tail, described by a pointer to a vtable. When a struct (per [dynamic-sized.struct-field]) or a tuple has an unsized last field, its unsized tail is the unsized tail of that field. A sized type has no unsized tail.
+
+[metadata]: dynamic-sized.pointer-types
 [sized]: special-types-and-traits.md#sized
 [Slices]: types/slice.md
+[slice]: types/slice.md
 [str]: types/str.md
+[`str`]: types/str.md
 [trait objects]: types/trait-object.md
+[trait object]: types/trait-object.md
 [Pointer types]: types/pointer.md
 [Variables]: variables.md
 [const]: items/constant-items.md


### PR DESCRIPTION
We refer to the unsized tail of a type, but we hadn't defined it.  Let's do that and link to the definition.

---

I'm breaking this out from https://github.com/rust-lang/reference/pull/2282 so that we can merge the prerequisites before  considering the new lang guarantees.

This is stacked on https://github.com/rust-lang/reference/pull/2286 and that should be merged first.

cc @ehuss @RalfJung @Mark-Simulacrum
