### PR TITLE
Document metadata of ptrs to indirectly unsized types

### DIFF
--- a/src/dynamically-sized-types.md
+++ b/src/dynamically-sized-types.md
@@ -11,6 +11,7 @@ r[dynamic-sized.pointer-types]
 * [Pointer types] to <abbr title="dynamically sized types">DSTs</abbr> are sized but have twice the size of pointers to sized types, since they also store *metadata*:
     * Pointers to slices store the number of elements; pointers to `str` store the length in bytes.
     * Pointers to trait objects store a pointer to a vtable.
+    * Pointers to a struct or tuple with an [unsized tail] store the same metadata as a pointer to that tail.
 
 r[dynamic-sized.question-sized]
 * <abbr title="dynamically sized types">DSTs</abbr> can be provided as type arguments to generic type parameters having the special `?Sized` bound. They can also be used for associated type definitions when the corresponding associated type declaration has a `?Sized` bound. By default, any type parameter or associated type has a `Sized` bound, unless it is relaxed using `?Sized`.
@@ -30,6 +31,7 @@ The *unsized tail* of a type is the dynamically sized component that the [metada
 
 [metadata]: dynamic-sized.pointer-types
 [sized]: special-types-and-traits.md#sized
+[unsized tail]: dynamic-sized.tail
 [Slices]: types/slice.md
 [slice]: types/slice.md
 [str]: types/str.md


### PR DESCRIPTION
We say that pointers to DSTs store metadata and what that metadata is for pointers to slices, `str`, and trait objects.  But a struct or tuple with an unsized tail is itself a DST, and we hadn't said what the metadata is for pointers to these unsized types.

Now that we've defined *metadata* and *unsized tail*, let's complete this enumeration.

---

I'm breaking this out from https://github.com/rust-lang/reference/pull/2282 so that we can merge the prerequisites before  considering the new lang guarantees.

This is stacked on https://github.com/rust-lang/reference/pull/2286 and https://github.com/rust-lang/reference/pull/2287 and https://github.com/rust-lang/reference/pull/2288 and https://github.com/rust-lang/reference/pull/2290 (yes, that one is out of order) and those should be merged first.

cc @ehuss @RalfJung @Mark-Simulacrum
