### PR TITLE
Empty repr(Rust) enums are ZSTs

### DIFF
--- a/src/glossary.md
+++ b/src/glossary.md
@@ -211,7 +211,8 @@ r[glossary.uninhabited]
 
 A type is uninhabited if it has no constructors and therefore can never be instantiated. An uninhabited type is "empty" in the sense that there are no values of the type. The canonical example of an uninhabited type is the [never type] `!`, or an enum with no variants `enum Never { }`. Opposite of [Inhabited](#inhabited).
 
-> [!NOTE] Uninhabited types are not necessarily [zero-sized][glossary.zst]. For example, `enum Never { }` is uninhabited and zero-sized, but `(u8, Never)` is uninhabited and not zero-sized.
+> [!NOTE]
+> Uninhabited types are not necessarily [zero-sized][glossary.zst]. For example, `enum Never { }` is uninhabited and zero-sized, but `(u8, Never)` is uninhabited and not zero-sized.
 
 r[glossary.zst]
 ### Zero-sized type (ZST)

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -223,6 +223,7 @@ A type is zero sized (a ZST) if its size is 0. Such types have at most one possi
 - `repr(Rust)` [structs] with no fields or where all fields are zero sized (see [layout.repr.rust.struct-zst]).
 - `repr(C)` [structs] with no fields or where all fields are zero-sized (see [layout.repr.c.struct.size-field-offset]).
 - `repr(transparent)` [structs] with no fields or where all fields are zero-sized (see [layout.repr.transparent.layout-abi]).
+- `repr(Rust)` [enums] (without a [primitive representation] specified) with no variants (see [layout.repr.rust.enum-empty-zst])
 - `repr(Rust)` [enums] (without a [primitive representation] specified) with a single [field-struct-like variant], a single [unit-struct-like variant], or a single [tuple-struct-like variant] and where the struct-like thing has no fields or where all of the fields are zero sized (see [layout.repr.rust.enum-struct-like-zst]).
 - [Arrays] of zero-sized types (see [layout.array]).
 - [Arrays] of length zero (see [layout.array]).
@@ -284,6 +285,8 @@ enum E5 {
 enum E6 {
     V1 (),
 }
+# /// An enum with no variants.
+enum E7 {}
 
 assert_eq!(0, size_of::<()>());
 assert_eq!(0, size_of_val(&f));
@@ -304,6 +307,7 @@ assert_eq!(0, size_of::<E3>());
 assert_eq!(0, size_of::<E4>());
 assert_eq!(0, size_of::<E5>());
 assert_eq!(0, size_of::<E6>());
+assert_eq!(0, size_of::<E7>());
 ```
 
 [`extern` blocks]: items.extern

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -211,6 +211,8 @@ r[glossary.uninhabited]
 
 A type is uninhabited if it has no constructors and therefore can never be instantiated. An uninhabited type is "empty" in the sense that there are no values of the type. The canonical example of an uninhabited type is the [never type] `!`, or an enum with no variants `enum Never { }`. Opposite of [Inhabited](#inhabited).
 
+> [!NOTE] Uninhabited types are not necessarily [zero-sized][glossary.zst]. For example, `enum Never { }` is uninhabited and zero-sized, but `(u8, Never)` is uninhabited and not zero-sized.
+
 r[glossary.zst]
 ### Zero-sized type (ZST)
 

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -226,7 +226,7 @@ A type is zero sized (a ZST) if its size is 0. Such types have at most one possi
 - `repr(Rust)` [structs] with no fields or where all fields are zero sized (see [layout.repr.rust.struct-zst]).
 - `repr(C)` [structs] with no fields or where all fields are zero-sized (see [layout.repr.c.struct.size-field-offset]).
 - `repr(transparent)` [structs] with no fields or where all fields are zero-sized (see [layout.repr.transparent.layout-abi]).
-- `repr(Rust)` [enums] (without a [primitive representation] specified) with no variants (see [layout.repr.rust.enum-empty-zst])
+- `repr(Rust)` [enums] (without a [primitive representation] specified) with no variants (see [layout.repr.rust.enum-empty-zst]).
 - `repr(Rust)` [enums] (without a [primitive representation] specified) with a single [field-struct-like variant], a single [unit-struct-like variant], or a single [tuple-struct-like variant] and where the struct-like thing has no fields or where all of the fields are zero sized (see [layout.repr.rust.enum-struct-like-zst]).
 - [Arrays] of zero-sized types (see [layout.array]).
 - [Arrays] of length zero (see [layout.array]).

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -212,7 +212,7 @@ r[glossary.uninhabited]
 A type is uninhabited if it has no constructors and therefore can never be instantiated. An uninhabited type is "empty" in the sense that there are no values of the type. The canonical example of an uninhabited type is the [never type] `!`, or an enum with no variants `enum Never { }`. Opposite of [Inhabited](#inhabited).
 
 > [!NOTE]
-> Uninhabited types are not necessarily [zero-sized][glossary.zst]. For example, `enum Never { }` is uninhabited and zero-sized, but `(u8, Never)` is uninhabited and not zero-sized.
+> Uninhabited types are not necessarily [zero sized]. For example, `enum Never { }` is uninhabited and zero sized, but `(u8, Never)` is uninhabited and not zero sized.
 
 r[glossary.zst]
 ### Zero-sized type (ZST)
@@ -365,3 +365,4 @@ assert_eq!(0, size_of::<E7>());
 [unit-struct-like variant]: EnumVariant
 [variable bindings]: patterns.md
 [visibility rules]: visibility-and-privacy.md
+[zero sized]: glossary.zst

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -186,6 +186,8 @@ For [structs] with no fields or where all fields are [zero sized], it is further
 r[layout.repr.rust.enum-empty-zst]
 For [enums] (without a [primitive representation] specified) with no variants, the enums themselves are [zero sized].
 
+Note that such enums are [uninhabited].
+
 r[layout.repr.rust.enum-struct-like-zst]
 For [enums] (without a [primitive representation] specified) with a single [field-struct-like variant], a single [unit-struct-like variant], or a single [tuple-struct-like variant] and where the struct-like thing has no fields or where all of the fields are [zero sized], the enums themselves are [zero sized].
 
@@ -651,3 +653,4 @@ Because this representation delegates type layout to another type, it cannot be 
 [tuple-struct-like variant]: EnumVariantTuple
 [unit-struct-like variant]: EnumVariant
 [`Layout`]: std::alloc::Layout
+[uninhabited]: glossary.uninhabited

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -186,7 +186,8 @@ For [structs] with no fields or where all fields are [zero sized], it is further
 r[layout.repr.rust.enum-empty-zst]
 For [enums] (without a [primitive representation] specified) with no variants, the enums themselves are [zero sized].
 
-Note that such enums are [uninhabited].
+> [!NOTE]
+> Such enums are [uninhabited].
 
 r[layout.repr.rust.enum-struct-like-zst]
 For [enums] (without a [primitive representation] specified) with a single [field-struct-like variant], a single [unit-struct-like variant], or a single [tuple-struct-like variant] and where the struct-like thing has no fields or where all of the fields are [zero sized], the enums themselves are [zero sized].

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -183,6 +183,9 @@ Be aware that this guarantee does not imply that the fields have distinct addres
 r[layout.repr.rust.struct-zst]
 For [structs] with no fields or where all fields are [zero sized], it is further guaranteed that the structs are themselves [zero sized].
 
+r[layout.repr.rust.enum-empty-zst]
+For [enums] (without a [primitive representation] specified) with no variants, the enums themselves are [zero sized].
+
 r[layout.repr.rust.enum-struct-like-zst]
 For [enums] (without a [primitive representation] specified) with a single [field-struct-like variant], a single [unit-struct-like variant], or a single [tuple-struct-like variant] and where the struct-like thing has no fields or where all of the fields are [zero sized], the enums themselves are [zero sized].
 

--- a/src/type-layout.md
+++ b/src/type-layout.md
@@ -184,7 +184,7 @@ r[layout.repr.rust.struct-zst]
 For [structs] with no fields or where all fields are [zero sized], it is further guaranteed that the structs are themselves [zero sized].
 
 r[layout.repr.rust.enum-empty-zst]
-For [enums] (without a [primitive representation] specified) with no variants, the enums themselves are [zero sized].
+[Enums] (without a [primitive representation] specified) with no variants are [zero sized].
 
 > [!NOTE]
 > Such enums are [uninhabited].


### PR DESCRIPTION
Guarantee that enums with Rust representation with no variants are ZSTs.

Followup to https://github.com/rust-lang/reference/pull/2262 , (which guaranteed the same for enums with Rust representation with a single variant whose fields are all ZSTs).