### PR TITLE
remove broken text

### DIFF
--- a/src/types/closure.md
+++ b/src/types/closure.md
@@ -391,7 +391,7 @@ let c = || match x { // Does not capture `*x`.
     [..] => (),
 //   ^^ Rest pattern.
 };
-let _ = &mut *x; // OK: `*x` can be borrow here.
+let _ = &mut *x; // OK
 c();
 ```
 


### PR DESCRIPTION
It had a typo, but it should also not be needed since it should be clear from context what it explains