### PR TITLE
Bump railroad-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,9 +263,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "railroad"
-version = "0.3.3"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5b8e8a7c20c600f9b98cbf46b64e63d5c9e69deb98cee1ff264de9f1dda5d"
+checksum = "813b53dbe6d583f1ac0c3fb394e0ce3b613530adff8265c274fcdfcd82cc6da5"
 dependencies = [
  "unicode-width",
 ]

--- a/tools/mdbook-spec/Cargo.toml
+++ b/tools/mdbook-spec/Cargo.toml
@@ -16,7 +16,7 @@ mdbook-markdown = "0.5.1"
 mdbook-preprocessor = "0.5.1"
 once_cell = "1.19.0"
 pathdiff = "0.2.1"
-railroad = { version = "0.3.2", default-features = false }
+railroad = { version = "0.3.7", default-features = false }
 regex = "1.12.2"
 semver = "1.0.21"
 serde_json = "1.0.113"

--- a/tools/mdbook-spec/src/grammar/render_railroad.rs
+++ b/tools/mdbook-spec/src/grammar/render_railroad.rs
@@ -9,6 +9,12 @@ use regex::Regex;
 use std::fmt::Write;
 use std::sync::LazyLock;
 
+/// Maximum number of rows per column in a `ExpressionKind::Alt`/`ExpressionKind::Charset`
+const CHOICE_MAX_ROWS_PER_COLUMN: usize = 5;
+/// Maximum number of columns in a `ExpressionKind::Alt`/`ExpressionKind::Charset`. Above that, we give up and
+/// use as many rows as necessary
+const CHOICE_MAX_COLUMNS: usize = 4;
+
 pub fn render_railroad(
     grammar: &Grammar,
     cx: &RenderCtx,
@@ -92,7 +98,7 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, stack: bool) -> Option<B
                         .map(|e| render_expression(e, cx, stack))
                         .filter_map(|n| n)
                         .collect();
-                    Box::new(Choice::<Box<dyn Node>>::new(choices))
+                    Box::new(bounded_multichoice(choices))
                 }
                 ExpressionKind::Sequence(es) => {
                     let es: Vec<_> = es.iter().collect();
@@ -290,7 +296,7 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, stack: bool) -> Option<B
                 ExpressionKind::Comment(_) => return None,
                 ExpressionKind::Charset(set) => {
                     let ns: Vec<_> = set.iter().map(|c| render_characters(c, cx)).collect();
-                    Box::new(Choice::<Box<dyn Node>>::new(ns))
+                    Box::new(bounded_multichoice(ns))
                 }
                 ExpressionKind::NegExpression(e) => {
                     let n = render_expression(e, cx, stack)?;
@@ -327,6 +333,20 @@ fn render_expression(expr: &Expression, cx: &RenderCtx, stack: bool) -> Option<B
     // on a vertical stack or a LabeledBox or something like that, but I
     // don't feel like bothering.
     Some(n)
+}
+
+fn bounded_multichoice(inp: Vec<Box<dyn Node>>) -> MultiChoice<Box<dyn Node>> {
+    let hard_max_columns = std::cmp::min(
+        CHOICE_MAX_COLUMNS,
+        inp.len().div_ceil(CHOICE_MAX_ROWS_PER_COLUMN),
+    );
+    let soft_max_rows = inp.len().div_ceil(hard_max_columns);
+    let mut choices_iter = inp.into_iter();
+    let groups = std::iter::from_fn(move || {
+        let group: Vec<_> = choices_iter.by_ref().take(soft_max_rows).collect();
+        (!group.is_empty()).then_some(group)
+    });
+    MultiChoice::new(groups.collect())
 }
 
 fn render_characters(chars: &Characters, cx: &RenderCtx) -> Box<dyn Node> {


### PR DESCRIPTION
This would bump the `railroad`-dependency - used in `mdbook-spec` to render the syntax-diagrams  - to the current version. [Changes made](https://github.com/lukaslueg/railroad/compare/0.3.2...0.3.7) to `railroad` include geometry correctness fixes, user-defined text escaping into the surrounding markup (should not be that much of a problem here), exponential runtime with deeply nested structures (also, since the SVGs are pre-rendered, not much of a problem), and addition of new `Node`-type which renders _many_-alternatives in a more space-friendly manner. This PR also changes the rendering of `ExpressionKind::Alt` and `ExpressionKind::Charset` to use this new `Node`-type to limit the vertical expanse in some cases.

Please be aware that some code-changes made in [`0.3.2...0.3.7`](https://github.com/lukaslueg/railroad/compare/0.3.2...0.3.7) were made with assistance of an LLM, especially around getting the geometry-calculations correct for caching. I'm not sure how to interpret [the LLM-policy](https://github.com/jyn514/rust-forge/blob/llm-policy/src/policies/llm-usage.md) around LLMs usage seeping in due to tooling dependencies. I'd be fine with closing this PR and/or comment-fixing the dependency to the current version, in case you want to reject this.

<img width="769" height="826" alt="1_before" src="https://github.com/user-attachments/assets/c5c4d13d-1b55-47e7-8ef9-a97ff9f57c1c" />
<img width="659" height="682" alt="1_after" src="https://github.com/user-attachments/assets/ae0a3285-f5d8-4adf-a3d9-963ddc336e25" />
<img width="529" height="742" alt="3_before" src="https://github.com/user-attachments/assets/97164d1d-b250-4df5-a622-16edb61f3cb4" />
<img width="789" height="523" alt="3_after" src="https://github.com/user-attachments/assets/32b552b9-9a23-4216-ae28-49fc9af84917" />
