### PR TITLE
Add a rule for attribute macro outline modules

### DIFF
--- a/src/procedural-macros.md
+++ b/src/procedural-macros.md
@@ -317,6 +317,9 @@ Attribute macros can only be used on:
 - Inherent and trait [implementations]
 - [Trait definitions]
 
+r[macro.proc.attribute.outline-mod]
+For any [outline modules] present in the macro's input, only the tokens of the module declaration are passed; the file contents of the module are not loaded or included in the input.
+
 r[macro.proc.attribute.behavior]
 The first [`TokenStream`] parameter is the delimited token tree following the attribute's name but not including the outer delimiters. If the applied attribute contains only the attribute name or the attribute name followed by empty delimiters, the [`TokenStream`] is empty.
 
@@ -398,6 +401,7 @@ Note that neither declarative nor procedural macros support doc comment tokens (
 [items]: items.md
 [macro namespace]: names/namespaces.md
 [module]: items/modules.md
+[outline modules]: items.mod.outlined
 [patterns]: patterns.md
 [public]: visibility-and-privacy.md
 [statements]: statements.md


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/157857 stabilized the ability to use `#[my macro] mod foo;`. The reference never specified that this was not allowed, so it doesn't absolutely need to be changed for this. However, since this was something that the lang team considered deeply enough on its own, it seems worthy to be explicit about this behavior.

This is an alternative to https://github.com/rust-lang/reference/pull/2284. Since we already have a rule that specifies where the attributes are allowed, this follows more closely to that to specify the behavior when applied to one of these module items.
