### PR TITLE
Document prohibition on inner attribute macros

### DIFF
--- a/src/procedural-macros.md
+++ b/src/procedural-macros.md
@@ -317,6 +317,9 @@ Attribute macros can only be used on:
 - Inherent and trait [implementations]
 - [Trait definitions]
 
+r[macro.proc.attribute.inner]
+Attribute macros cannot be used as an [inner attribute].
+
 r[macro.proc.attribute.outline-mod]
 For any [outline modules] present in the macro's input, only the tokens of the module declaration are passed; the file contents of the module are not loaded or included in the input.
 
@@ -397,6 +400,7 @@ Note that neither declarative nor procedural macros support doc comment tokens (
 [function]: items/functions.md
 [implementations]: items/implementations.md
 [inert]: attributes.md#active-and-inert-attributes
+[inner attribute]: attributes.inner
 [item]: items.md
 [items]: items.md
 [macro namespace]: names/namespaces.md


### PR DESCRIPTION
Proc macro attributes as inner attributes are currently unstable via the `custom_inner_attributes` feature gate (https://github.com/rust-lang/rust/issues/54726).