### PR TITLE
Document attributes on closures and method calls

### DIFF
--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -42,17 +42,14 @@ The `inline` attribute may only be applied to functions with [bodies] --- [closu
 > `rustc` ignores use in other positions but lints against it. This may become an error in the future.
 
 > [!NOTE]
-> Though the attribute can be applied to [closures] and [async blocks], the usefulness of this is limited as we do not yet support attributes on expressions.
+> Attributes are supported on closure expressions, but remain restricted on other
+> expressions such as [async blocks].
 >
 > ```rust
-> // We allow attributes on statements.
-> #[inline] || (); // OK
-> #[inline] async {}; // OK
-> ```
+> let f = #[inline] || (); // OK
 >
-> ```rust,compile_fail,E0658
-> // We don't yet allow attributes on expressions.
-> let f = #[inline] || (); // ERROR
+> // We also allow attributes on statements.
+> #[inline] async {}; // OK
 > ```
 
 r[attributes.codegen.inline.duplicates]
@@ -106,7 +103,8 @@ The `cold` attribute may only be applied to functions with [bodies] --- [closure
 > `rustc` ignores use in other positions but lints against it. This may become an error in the future.
 
 > [!NOTE]
-> Though the attribute can be applied to [closures] and [async blocks], the usefulness of this is limited as we do not yet support attributes on expressions.
+> Attributes are supported on closure expressions, but remain restricted on other
+> expressions such as [async blocks].
 
 <!-- TODO: rustc currently seems to allow cold on a trait function without a body, but it appears to be ignored. I think that may be a bug, and it should at least warn if not reject (like inline does). -->
 
@@ -872,7 +870,8 @@ The `instruction_set` attribute may only be applied to functions with [bodies] -
 > `rustc` ignores use in other positions but lints against it. This may become an error in the future.
 
 > [!NOTE]
-> Though the attribute can be applied to [closures] and [async blocks], the usefulness of this is limited as we do not yet support attributes on expressions.
+> Attributes are supported on closure expressions, but remain restricted on other
+> expressions such as [async blocks].
 
 r[attributes.codegen.instruction_set.duplicates]
 The `instruction_set` attribute may be used only once on a function.

--- a/src/expressions.md
+++ b/src/expressions.md
@@ -362,6 +362,9 @@ r[expr.attr.restriction]
 * Before an expression used as a [statement].
 * Elements of [array expressions], [tuple expressions], [call expressions], and tuple-style [struct] expressions.
 * The tail expression of [block expressions].
+* Before [closure expressions] and [method-call expressions]. An attribute before a
+  method-call expression applies to the complete method-call expression, including
+  any chained method calls.
 <!-- Keep list in sync with block-expr.md -->
 
 r[expr.attr.never-before]
@@ -385,6 +388,7 @@ They are never allowed before:
 [borrow]:               expressions/operator-expr.md#borrow-operators
 [call expressions]:     expressions/call-expr.md
 [comparison]:           expressions/operator-expr.md#comparison-operators
+[closure expressions]: expressions/closure-expr.md
 [compound assignment]:  expressions/operator-expr.md#compound-assignment-expressions
 [deref]:                expressions/operator-expr.md#the-dereference-operator
 [destructors]:          destructors.md
@@ -403,6 +407,7 @@ They are never allowed before:
 [macro invocations]:    macro.invocation
 [match]:                expressions/match-expr.md
 [method-call]:          expressions/method-call-expr.md
+[method-call expressions]: expressions/method-call-expr.md
 [Mutable `static` items]: items/static-items.md#mutable-statics
 [Outer attributes]:     attributes.md
 [paths]:                expressions/path-expr.md


### PR DESCRIPTION
Update the expression attribute documentation to cover attributes directly on closure and method-call expressions.

Document that an attribute before a method-call expression applies to the complete method-call chain.

This accompanies the rust-lang/rust stabilization of these expression attribute positions.

Stabilization PR: https://github.com/rust-lang/rust/pull/159581