### PR TITLE
Document `must_implement_one_of`

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -283,6 +283,7 @@ The following is an index of all built-in attributes.
 
 - Type System
   - [`non_exhaustive`] --- Indicate that a type will have more fields/variants added in future.
+  - [`must_implement_one_of`] --- On a trait definition, specify that implementations of the trait must implement at least one of the specified methods.
 
 - Debugger
   - [`debugger_visualizer`] --- Embeds a file that specifies debugger output for a type.
@@ -319,6 +320,7 @@ The following is an index of all built-in attributes.
 [`link`]: items/external-blocks.md#the-link-attribute
 [`macro_export`]: macros-by-example.md#the-macro_export-attribute
 [`macro_use`]: macros-by-example.md#the-macro_use-attribute
+[`must_implement_one_of`]: attributes/type_system.md#the-must_implement_one_of-attribute
 [`must_use`]: attributes/diagnostics.md#the-must_use-attribute
 [`naked`]: attributes/codegen.md#the-naked-attribute
 [`no_builtins`]: attributes/codegen.md#the-no_builtins-attribute

--- a/src/attributes/type_system.md
+++ b/src/attributes/type_system.md
@@ -3,6 +3,52 @@ r[attributes.type-system]
 
 The following [attributes] are used for changing how a type can be used.
 
+r[attributes.type-system.must_implement_one_of]
+## The `must_implement_one_of` attribute
+
+r[attributes.type-system.must_implement_one_of.into]
+The *`must_implement_one_of` attribute* on a trait requires implementations of
+the trait to implement at least one of the specified methods. This is
+particularly useful for methods that can be implemented in terms of each other,
+but where the implementation must provide one of them to avoid mutual
+recursion.
+
+r[attributes.type-system.must_implement_one_of.syntax]
+The syntax for the `must_implement_one_of` attribute is:
+
+```grammar,attributes
+@root MustImplementOneOfAttribute ->
+      `must_implement_one_of` `(` IDENTIFIER `,` IDENTIFIER ( `,` IDENTIFIER )? `,`? `)`
+```
+
+r[attributes.type-system.must_implement_one_of.example]
+> [!EXAMPLE]
+> ```rust
+> #[must_implement_one_of(m1, m2)]
+> trait Trait {
+>     fn m1(&self) -> usize {
+>         self.m2() + 1
+>     }
+>
+>     fn m2(&self) -> usize {
+>         self.m1() + 1
+>     }
+> }
+>
+> struct S;
+>
+> impl Trait for S {
+>     // This impl will produce an error because it doesn't define either `m1` or `m2`.
+> }
+> ```
+
+r[attributes.type-system.must_implement_one_of.defaults]
+Every method named in the `must_implement_one_of` attribute must have a default
+method body in the trait definition.
+> [!NOTE]
+> Any method without a default method body must have an implementation, making
+> `must_implement_one_of` redundant.
+
 r[attributes.type-system.non_exhaustive]
 ## The `non_exhaustive` attribute
 

--- a/src/items/implementations.md
+++ b/src/items/implementations.md
@@ -101,6 +101,9 @@ The trait is known as the _implemented trait_. The implementing type implements 
 r[items.impl.trait.def-requirement]
 A trait implementation must define all non-default associated items declared by the implemented trait, may redefine default associated items defined by the implemented trait, and cannot define any other items.
 
+r[items.impl.trait.def-requirement.must-implement-one-of]
+If a trait definition uses the [`must_implement_one_of`] attribute, implementations of that trait must define at least one of the methods specified in that attribute.
+
 r[items.impl.trait.associated-item-path]
 The path to the associated items is `<` followed by a path to the implementing type followed by `as` followed by a path to the trait followed by `>` as a path component followed by the associated item's path component.
 
@@ -280,6 +283,7 @@ Implementations may contain outer [attributes] before the `impl` keyword and inn
 [`cfg`]: ../conditional-compilation.md
 [`deprecated`]: ../attributes/diagnostics.md#the-deprecated-attribute
 [`doc`]: ../../rustdoc/the-doc-attribute.html
+[`must_implement_one_of`]: ../attributes/type_system.md#the-must_implement_one_of-attribute
 [generic parameters]: generics.md
 [methods]: associated-items.md#methods
 [path]: ../paths.md


### PR DESCRIPTION
---

Draft, because this currently exists as the unstable `rustc_must_implement_one_of`. Providing a draft PR to support future stabilization.
