### PR TITLE
Use authentication for linkcheck

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,8 @@ jobs:
         SPEC_RUST_ROOT: ${{ github.workspace }}/rust
       run: mdbook build
     - name: Check for broken links
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         curl -sSLo linkcheck.sh \
           https://raw.githubusercontent.com/rust-lang/rust/master/src/tools/linkchecker/linkcheck.sh


### PR DESCRIPTION
This adds the use of GITHUB_TOKEN to download the linkcheck script due to IP-based rate limiting.

https://github.com/rust-lang/rust/pull/158995 contains more detail.