### PR TITLE
Document that `#[inline]` is needed for inlining across crate boundaries

### DIFF
--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -10,6 +10,10 @@ r[attributes.codegen.inline]
 r[attributes.codegen.inline.intro]
 The *`inline` [attribute]* suggests whether a copy of the attributed function's code should be placed in the caller rather than generating a call to the function.
 
+r[attribute.codegen.inline.crate-boundaries]
+The attribute also makes it possible for the compiler to inline non-generic functions across crate boundaries.
+Non-generic functions without the *`inline`* [attribute] can not be inlined in another crate.
+
 > [!EXAMPLE]
 > ```rust
 > #[inline]


### PR DESCRIPTION
Adding an `#[inline]` hint may not be the right way<sup>TM</sup> to allow in-lining across crate boundaries, but as far as I'm aware it is the only way. It would be nice to document that, to have something to point at when people ask why I think this attribute should be added.

The current docs suggest it should almost never be used, unless you know better than the compiler (which I don't want to claim, normally). But using it to allow the compiler to be smart is a good thing.

Alternatively, if this is no longer necessary, it would be good to explicitly document *that* (to have something to point at).

If there are plans to change this behavior I suppose this could also be added as a note instead.