### PR TITLE
Revert "Document RISC-V d, e, and f extensions"

### DIFF
--- a/src/attributes/codegen.md
+++ b/src/attributes/codegen.md
@@ -323,9 +323,6 @@ r[attributes.codegen.target_feature.availability]
 
 The following is a list of the available feature names.
 
-r[attributes.codegen.target_feature.cfg-only]
-Target feature names marked as "(cfg only)" in this list may only be used with the [`target_feature`][cfg.target_feature] conditional compilation option, not with the `target_feature` attribute.
-
 r[attributes.codegen.target_feature.x86]
 #### `x86` or `x86_64`
 
@@ -570,9 +567,6 @@ Feature     | Implicitly Enables  | Description
 `a`         | `zaamo`, `zalrsc`   | [A][rv-a] --- Atomic instructions
 `b`         | `zba`, `zbc`, `zbs` | [B][rv-b] --- Bit Manipulation instructions
 `c`         | `zca`               | [C][rv-c] --- Compressed instructions
-`d`         | `f`                 | [D][rv-d] --- [(cfg only)] Double-Precision Floating-Point
-`e`         |                     | [E][rv-e] --- [(cfg only)] Embedded Instruction Set with 16 GPRs
-`f`         | `zicsr`             | [F][rv-f] --- [(cfg only)] Single-Precision Floating-Point
 `m`         |                     | [M][rv-m] --- Integer Multiplication and Division instructions
 `za64rs`    | `za128rs`           | [Za64rs][rv-za64rs] --- Platform Behavior: Naturally aligned Reservation sets with ≦ 64 Bytes
 `za128rs`   |                     | [Za128rs][rv-za128rs] --- Platform Behavior: Naturally aligned Reservation sets with ≦ 128 Bytes
@@ -625,9 +619,6 @@ Feature     | Implicitly Enables  | Description
 [rv-a]: https://github.com/riscv/riscv-isa-manual/blob/20250508/src/a-st-ext.adoc
 [rv-b]: https://github.com/riscv/riscv-isa-manual/blob/20250508/src/b-st-ext.adoc
 [rv-c]: https://github.com/riscv/riscv-isa-manual/blob/20250508/src/c-st-ext.adoc
-[rv-d]: https://github.com/riscv/riscv-isa-manual/blob/20250508/src/d-st-ext.adoc
-[rv-e]: https://github.com/riscv/riscv-isa-manual/blob/20250508/src/rv32e.adoc
-[rv-f]: https://github.com/riscv/riscv-isa-manual/blob/20250508/src/f-st-ext.adoc
 [rv-m]: https://github.com/riscv/riscv-isa-manual/blob/20250508/src/m-st-ext.adoc
 [rv-za64rs]: https://github.com/riscv/riscv-profiles/blob/rva23-rvb23-ratified/src/rva23-profile.adoc
 [rv-za128rs]: https://github.com/riscv/riscv-profiles/blob/v1.0/profiles.adoc
@@ -910,7 +901,6 @@ If the address of the function is taken as a function pointer, the low bit of th
 - For `arm::a32` ("ARM"), it will be 0.
 - For `arm::t32` ("Thumb"), it will be 1.
 
-[(cfg only)]: attributes.codegen.target_feature.cfg-only
 [`-C target-cpu`]: ../../rustc/codegen-options/index.html#target-cpu
 [`-C target-feature`]: ../../rustc/codegen-options/index.html#target-feature
 [`export_name`]: abi.export_name


### PR DESCRIPTION
This stabilization was reverted in rust-lang/rust#161064.  Let's revert the Reference changes.

This reverts commit a61431c116d6d050613a6dd6b80997f3d27e8fd2.

cc @ehuss