### PR TITLE
Fix some lexer rules

### DIFF
--- a/src/comments.md
+++ b/src/comments.md
@@ -35,7 +35,7 @@ OUTER_LINE_DOC ->
 OUTER_BLOCK_DOC ->
     `/**` ![`*` `/`]
       ^
-      ( ~`*` | BLOCK_COMMENT_OR_DOC )
+      ( ~[`*` CR] | BLOCK_COMMENT_OR_DOC )
       ( BLOCK_COMMENT_OR_DOC | BLOCK_CHAR )*
     `*/`
 

--- a/src/comments.md
+++ b/src/comments.md
@@ -17,7 +17,7 @@ LINE_COMMENT ->
     | `//` _immediately followed by LF_
 
 BLOCK_COMMENT ->
-    `/*` ^
+    `/*` !(`!` | `*` ![`*` `/`]) ^
       ( BLOCK_COMMENT_OR_DOC | (!`*/` CHAR) )*
     `*/`
 

--- a/src/tokens.md
+++ b/src/tokens.md
@@ -179,7 +179,7 @@ STRING_LITERAL ->
       | STRING_CONTINUE
     )* `"` SUFFIX?
 
-STRING_CONTINUE -> `\` LF
+STRING_CONTINUE -> `\` LF [TAB LF CR SP]*
 ```
 
 r[lex.token.literal.str.intro]

--- a/src/whitespace.md
+++ b/src/whitespace.md
@@ -21,6 +21,8 @@ TAB -> U+0009 // Horizontal tab, `'\t'`
 LF -> U+000A  // Line feed, `'\n'`
 
 CR -> U+000D  // Carriage return, `'\r'`
+
+SP -> U+0020  // Space, `' '`
 ```
 
 r[lex.whitespace.intro]


### PR DESCRIPTION
This fixes some issues with string continuations, comments, and shebang identified by @mattheww in https://github.com/rust-lang/reference/pull/2325#issuecomment-5309031418.

The SHEBANG grammar still has problems as identified in https://github.com/rust-lang/reference/pull/2325#issuecomment-5334049558 that are more difficult to fix. In particular, the cut operator in BLOCK_COMMENT is causing a parse error in the negative lookahead, but rustc ignores those. This might require more significant changes than I have time for at the moment.