### PR TITLE
document that extern statics may be bigger than the declared size

### DIFF
--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -61,6 +61,9 @@ r[undefined.invalid]
 r[undefined.asm]
 * Incorrect use of inline assembly. For more details, refer to the [rules] to follow when writing code that uses inline assembly.
 
+r[undefined.extern-static]
+* Declaring an `extern static` with some size/alignment/mutability, when the actual symbol this resolves to is smaller / less aligned / less mutable.
+
 r[undefined.runtime]
 * Violating assumptions of the Rust runtime. Most assumptions of the Rust runtime are currently not explicitly documented.
   * For assumptions specifically related to unwinding, see the [panic documentation][unwinding-ffi].

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -62,8 +62,8 @@ r[undefined.asm]
 * Incorrect use of inline assembly. For more details, refer to the [rules] to follow when writing code that uses inline assembly.
 
 r[undefined.extern-static]
-* Declaring an `extern static` with some size/alignment/mutability, when the actual symbol this resolves to is smaller / less aligned / less mutable.
-  For `extern static` with `raw-dylib` linkage, the actual symbol must have *exactly* the declared size.
+* Declaring an `extern static` with some size/alignment/mutability, when the actual memory the extern static resolves to is smaller / less aligned / less mutable.
+  For `extern static` with `raw-dylib` linkage, the actual memory must have *exactly* the declared size.
 
 r[undefined.runtime]
 * Violating assumptions of the Rust runtime. Most assumptions of the Rust runtime are currently not explicitly documented.

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -63,6 +63,7 @@ r[undefined.asm]
 
 r[undefined.extern-static]
 * Declaring an `extern static` with some size/alignment/mutability, when the actual symbol this resolves to is smaller / less aligned / less mutable.
+  For `extern static` with `raw-dylib` linkage, the actual symbol must have *exactly* the declared size.
 
 r[undefined.runtime]
 * Violating assumptions of the Rust runtime. Most assumptions of the Rust runtime are currently not explicitly documented.

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -74,6 +74,10 @@ Extern statics can be either immutable or mutable just like [statics] outside of
 r[items.extern.static.read-only]
 An immutable static *must* be initialized before any Rust code is executed. It is not enough for the static to be initialized before Rust code reads from it. Once Rust code runs, mutating an immutable static (from inside or outside Rust) is UB, except if the mutation happens to bytes inside of an `UnsafeCell`.
 
+r[items.extern.static.size]
+The actual memory that the extern static resolves to must have *at least* the size and alignment of the type that it was declared with in the extern block.
+If the actual memory is bigger, then it is permitted to access that extra memory.
+
 r[items.extern.abi]
 ## ABI
 

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -75,7 +75,7 @@ r[items.extern.static.read-only]
 An immutable static *must* be initialized before any Rust code is executed. It is not enough for the static to be initialized before Rust code reads from it. Once Rust code runs, mutating an immutable static (from inside or outside Rust) is UB, except if the mutation happens to bytes inside of an `UnsafeCell`.
 
 r[items.extern.static.size]
-The actual memory that the extern static resolves to must have *at least* the size and alignment of the type that it was declared with in the extern block.
+The actual memory that the extern static resolves to [must have][extern-static-ub] *at least* the size and alignment of the type that it was declared with in the extern block.
 If the actual memory is bigger, then it is permitted to access that extra memory.
 
 r[items.extern.abi]
@@ -470,6 +470,7 @@ Attributes on extern function parameters follow the same rules and restrictions 
 [`verbatim` documentation for rustc]: ../../rustc/command-line-arguments.html#linking-modifiers-verbatim
 [`whole-archive` documentation for rustc]: ../../rustc/command-line-arguments.html#linking-modifiers-whole-archive
 [attributes]: ../attributes.md
+[extern-static-ub]: ../behavior-considered-undefined.md#r-undefined.extern-static
 [functions]: functions.md
 [regular function parameters]: functions.md#attributes-on-function-parameters
 [statics]: static-items.md

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -373,7 +373,7 @@ r[items.extern.attributes.link.kind-raw-dylib.platform-specific]
 `raw-dylib` is only supported on Windows. Using it when targeting other platforms will result in a compiler error.
 
 r[items.extern.attributes.link.kind-raw-dylib.size]
-Unlike regular external statics, a `raw-dylib` static is *not* allowed to be bigger than its declared size.
+Unlike regular external statics, a `raw-dylib` static is *not* allowed to be bigger than its declared size. The size needs to match exactly.
 
 r[items.extern.attributes.link.import_name_type]
 #### The `import_name_type` key

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -372,6 +372,9 @@ Specifying `kind = "dylib"` instructs the Rust compiler to link an import librar
 r[items.extern.attributes.link.kind-raw-dylib.platform-specific]
 `raw-dylib` is only supported on Windows. Using it when targeting other platforms will result in a compiler error.
 
+r[items.extern.attributes.link.kind-raw-dylib.size]
+Unlike regular external statics, a `raw-dylib` static is *not* allowed to be bigger than its declared size.
+
 r[items.extern.attributes.link.import_name_type]
 #### The `import_name_type` key
 

--- a/src/items/external-blocks.md
+++ b/src/items/external-blocks.md
@@ -75,7 +75,7 @@ r[items.extern.static.read-only]
 An immutable static *must* be initialized before any Rust code is executed. It is not enough for the static to be initialized before Rust code reads from it. Once Rust code runs, mutating an immutable static (from inside or outside Rust) is UB, except if the mutation happens to bytes inside of an `UnsafeCell`.
 
 r[items.extern.static.size]
-The actual memory that the extern static resolves to [must have][extern-static-ub] *at least* the size and alignment of the type that it was declared with in the extern block.
+The actual memory that the extern static resolves to [must have][extern-static-ub] *at least* the size and alignment of the type that it was declared within the extern block.
 If the actual memory is bigger, then it is permitted to access that extra memory.
 
 r[items.extern.abi]


### PR DESCRIPTION
I am fairly sure we discussed at some point whether it's okay to access memory beyond the declared size of an `extern static`, and @nikic confirmed that this is fine. But I couldn't find any official place where we document this. So, let's add it to the Reference.

I wondered if we also need the converse on the UB page: it is UB to even start the program if an extern static ends up being backed by memory that is smaller or less-aligned than the declared type. What do you think?

Cc @rust-lang/opsem 
Fixes https://github.com/rust-lang/unsafe-code-guidelines/issues/259
Fixes https://github.com/rust-lang/unsafe-code-guidelines/issues/554