### PR TITLE
allow references to point to invalid values

### DIFF
--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -148,7 +148,7 @@ r[undefined.validity.union]
 * For a `union`, the exact validity requirements are not decided yet. Obviously, all values that can be created entirely in safe code are valid. If the union has a [zero-sized] field, then every possible value is valid. Further details are [still being debated](https://github.com/rust-lang/unsafe-code-guidelines/issues/438).
 
 r[undefined.validity.reference-box]
-* A reference or [`Box<T>`] must be aligned and non-null, it cannot be [dangling], and it must point to a valid value (in case of dynamically sized types, using the actual dynamic type of the pointee as determined by the [metadata]). Note that the last point (about pointing to a valid value) remains a subject of some debate.
+* A reference or [`Box<T>`] must be aligned and non-null, and cannot be [dangling].
 
 r[undefined.validity.wide]
 * The [metadata] of a wide reference, [`Box<T>`], or raw pointer must match the type of the [unsized tail]:


### PR DESCRIPTION
Per @rust-lang/opsem FCP in https://github.com/rust-lang/unsafe-code-guidelines/issues/414#issuecomment-4096685918, partially unblocking https://github.com/rust-lang/rust/pull/161452. This would mean invalid references are downgraded to being library UB (but invalid values are still lang UB).