### PR TITLE
dangling pointers: turn some consequences of the definition into notes

### DIFF
--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -198,7 +198,7 @@ r[undefined.validity.undef]
 [`bool`]: types/boolean.md
 [`const`]: items/constant-items.md
 [abi]: items/external-blocks.md#abi
-[allocation]: ../std/ptr/index.html#allocation
+[allocation]: core::ptr#allocation
 [const contexts]: const-eval.const-context
 [`target_feature`]: attributes/codegen.md#the-target_feature-attribute
 [`UnsafeCell<U>`]: std::cell::UnsafeCell

--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -100,16 +100,13 @@ r[undefined.dangling]
 [dangling]: #dangling-pointers
 
 r[undefined.dangling.def]
-A reference/pointer is "dangling" if not all of the bytes it [points to] are part of the same live allocation (so in particular they all have to be part of *some* allocation).
+A reference/pointer is "dangling" if not all of the bytes it [points to] are part of the same live [allocation] (so in particular they all have to be part of *some* allocation).
 
-r[undefined.dangling.zero-size]
-If the [size is 0][zero-sized], then the pointer is trivially never "dangling" (even if it is a null pointer).
+> [!NOTE]
+> This implies that the dynamic size of a Rust value (as determined by `size_of_val`) must never exceed `isize::MAX`, since it is impossible for a single allocation to be larger than `isize::MAX`.
 
-r[undefined.dangling.dynamic-size]
-Note that dynamically sized types (such as slices and strings) point to their entire range, so it is important that the length [metadata] is never too large.
-
-r[undefined.dangling.alloc-limit]
-In particular, the dynamic size of a Rust value (as determined by `size_of_val`) must never exceed `isize::MAX`, since it is impossible for a single allocation to be larger than `isize::MAX`.
+> [!NOTE]
+> This also implies that if the [size is 0][zero-sized], then the pointer is trivially never "dangling" (even if it is a null pointer).
 
 r[undefined.validity]
 ## Invalid values
@@ -201,6 +198,7 @@ r[undefined.validity.undef]
 [`bool`]: types/boolean.md
 [`const`]: items/constant-items.md
 [abi]: items/external-blocks.md#abi
+[allocation]: ../std/ptr/index.html#allocation
 [const contexts]: const-eval.const-context
 [`target_feature`]: attributes/codegen.md#the-target_feature-attribute
 [`UnsafeCell<U>`]: std::cell::UnsafeCell


### PR DESCRIPTION
It seems to me that we have unnecessarily many normative clauses here. Most of this follows from the definitions of "points to" and allocations. Allocations are currently not defined in the Reference so I added a link to the standard library where we have a definition.