### PR TITLE
explicitly keep the door open for some but not all subobject provenance

### DIFF
--- a/src/behavior-considered-undefined.md
+++ b/src/behavior-considered-undefined.md
@@ -39,6 +39,18 @@ r[undefined.alias]
 
   All this also applies when values of these types are passed in a (nested) field of a compound type, but not behind pointer indirections.
 
+r[undefined.subobject]
+* Using a pointer or reference outside the subrange of memory it is allowed to access.
+
+  Generally, a reference may only access the memory it [points to].
+  This restriction also applies to all raw pointers derived from this reference.
+  The one exception is that a reference to an element of an array or slice may be used to access other elements of the same array or slice without immediately causing undefined behavior.
+  This exception also applies for nested arrays, but not for fields of values inside arrays.
+
+  Furthermore, a reference to a field of an enum may not be used to change the discriminant of said enum.
+  If the tag lies inside the range of memory accessible by the reference (as in the previous paragraph), then the reference may be used to *temporarily* change the discriminant of the enum without immediately causing undefined behavior, but the original discriminant must be restored before the lifetime of the reference ends.
+  This restriction also applies to all raw pointers derived from this reference.
+
 r[undefined.immutable]
 * Mutating immutable bytes. All bytes reachable through a [const-promoted] expression are immutable, as well as bytes reachable through borrows in `static` and `const` initializers that have been [lifetime-extended] to `'static`. The bytes owned by an immutable binding or immutable `static` are immutable, unless those bytes are part of an [`UnsafeCell<U>`].
 


### PR DESCRIPTION
Miri has enforced fairly strict subobject provenance by default since ~forever, but the Reference never explicitly called this out as UB. Let's fix that. This is the conservative choice; we document this as UB now and maybe lift the UB restriction again in the future.

This PR includes two commitments that @rust-lang/opsem (and maybe @rust-lang/lang) should FCP:
- While we generally keep the door open for subobject provenance, we explicitly say that there is no subobject provenance within arrays/slices. This is based on the observation that violations of such subobject provenance are the major kind of Stacked Borrows UB that Miri finds. I'd like to make Miri stop report this as UB, and for this I'd like to be sure that indeed we don't want to make this UB.
- While we generally keep the door open for ["discriminant protection"](https://github.com/rust-lang/unsafe-code-guidelines/issues/84), we do explicitly say that it is okay to *temporarily* change the discriminant of an enum via a field reference, and then change it back. This is needed to make [code like this](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=ad2ad66488f5ca9ba4b373bbaffdd604) sound, which came up multiple times in questions recently ([1](https://github.com/rust-lang/unsafe-code-guidelines/issues/618), [2](https://github.com/rust-lang/unsafe-code-guidelines/issues/621)).

I proposed for opsem to FCP these two choices in:
- https://github.com/rust-lang/unsafe-code-guidelines/issues/622
- https://github.com/rust-lang/unsafe-code-guidelines/issues/621

This PR should only be merged once both of those FCP completed.