### PR TITLE
Specify the values of safely-constructed unions

### DIFF
--- a/src/types/union.md
+++ b/src/types/union.md
@@ -16,5 +16,8 @@ Union field types are also restricted to a subset of types which ensures that th
 r[type.union.layout]
 The memory layout of a `union` is undefined by default (in particular, fields do *not* have to be at offset 0), but the `#[repr(...)]` attribute can be used to fix a layout.
 
+r[type.union.safe-construction]
+Although unions have no validity requirements, the values of union types that can be created exclusively in safe contexts are limited. Specifically, safe contexts cannot create values of union types that have uninitialized bytes at an offset where none of the fields permit uninitialized bytes.
+
 [`Copy`]: ../special-types-and-traits.md#copy
 [item]: ../items/unions.md


### PR DESCRIPTION
This specifies that the operations for safely constructing and modifying union values are more limited than those for unsafely doing so. It adds the guarantee that safe contexts cannot create certain kinds of union values which are invalid at every field.

## Summary

This formalizes some very narrow guarantees about union initialization by updating the reference. My motivation is re-enabling some trait derives in zerocopy related to transmuting bytes to and from union types. I did some background research on the opsem stance towards union validity, and read through several discussions about union safety semantics here. Following the lang team change process flowchart, I am opening this PR and nominating it for lang team discussion. Given that there has been a lot of discussion about related topics in the past, I'd like to summarize some background information.

## Links

1. [Zerocopy: "Restrict support for #[derive(IntoBytes)] on unions, work to guarantee forwards-compatible soundness"](https://github.com/rust-lang/unsafe-code-guidelines/issues/533)
2. [UCG: "Minimum guarantees for union construction and typed copies?"](https://github.com/rust-lang/unsafe-code-guidelines/issues/533)
3. [t-lang: "Union field semantics and safety"](https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/union.20field.20semantics.20and.20safety/near/248632442)
4. [UCG: "What is the safety invariant, if any, for unions?"](https://github.com/rust-lang/unsafe-code-guidelines/issues/352)

## Motivation

Right now, safe Rust allows two operations on unions:
1. A value of a union type can be created with the value of a single field (i.e. `let u = MyUnion { f1: 1 }`)
2. Fields and subfields of a union value can be written (i.e. `u.f1 = 2`)

For some unions, this forms a guarantee about whether safe Rust can produce values of that union type with uninitialized bytes. Under these conditions:

- The union is `#[repr(C)]`
- The fields of the union are the same size (i.e. no trailing padding in the union)
- The field types of the union have no uninitialized bytes (e.g. padding)

... safe Rust cannot currently produce a value of the union that has any uninitialized bytes. One of the fields must be initialized to start (thus initializing all bytes of the union), and no subsequent subfield writes can de-initialize any bytes.

This set of guarantees allows us to [safely transmute](https://github.com/google/zerocopy/issues/1792) union values that meet these conditions. We'd like to be confident that the code we write that relies on this reasoning remains sound in the future as well.

## FAQ

### Is this a validity / safety requirement?

**No.** Per rust-lang/reference#2337, unions have no validity requirements. Safety requirements apply to all values of a type that are outside of an unsafe encapsulation boundary (e.g. returned from a public API). This change only applies to values that are created and modified exclusively within a safe context. It is 100% OK for those values to pass through an unsafe context and stop following this rule.

### Should this be a safety requirement?

There is no consensus as to whether unions should have safety requirements. This change avoids adding a safety requirement while also leaving the door open to safety requirements in the future.

### Why do we need to specify this if it's already true?

Even though it's true right now, we need this to remain true going forward.

### Why/how might we break this rule?

The only situation I could find was allowing wholly-uninitialized unions, like:

```rust
union Foo {
    a: u32,
}

fn main() {
    let x: Foo = unsafe { core::mem::MaybeUninit::<Foo>::uninit().assume_init() };
}
```

This specific example would still be allowed because it requires `unsafe`. I could not find any proposed uses for a safe version of this behavior. So I was unable to find examples of why we might want to break this rule.

### Why should we do this if reading any field of a union is `unsafe`?

This rule gives us permission to safely transmute values of certain kinds of unions. This is especially useful for generated bindings, where unions that fit the criteria outlined here are used extensively. Being able to guarantee this is sound with a derive macro prevents bespoke unsafe code from being written to do the same thing.

### Should this be more general? What if a byte can never be 0?

This change is intentionally narrow. Saying "safe Rust cannot write uninit bytes here" is much less restrictive than saying "safe Rust cannot write 0 here". Whether bytes are uninit or not are a purely compile-time property, but whether bytes are 0 or not may be a runtime property. This change does not preclude strengthening this guarantee in the future.