### PR TITLE
Fix `...diagnostics.deprecated...` rule ID

### DIFF
--- a/src/attributes/diagnostics.md
+++ b/src/attributes/diagnostics.md
@@ -321,7 +321,7 @@ The `deprecated` attribute has several forms:
     message. This is typically used to provide an explanation about the
     deprecation and preferred alternatives.
 
-r[attributes.diagnostic.deprecated.allowed-positions]
+r[attributes.diagnostics.deprecated.allowed-positions]
 The `deprecated` attribute may be applied to any [item], [trait item], [enum
 variant], [struct field], [external block item], or [macro definition]. It
 cannot be applied to [trait implementation items][trait-impl]. When applied to an item


### PR DESCRIPTION
In rust-lang/reference#1560, in commit 4ef5f5d93607f, we renamed the rule IDs in the diagnostics chapter, except those for the `diagnostic` tool attribute namespace, to the plural form, `attributes.diagnostics.*`.  But we missed one, `attributes.diagnostics.deprecated.allowed-positions` (as corrected).  Let's fix that.
