### PR TITLE
Order grammar summary deterministically

### DIFF
--- a/tools/grammar/src/lib.rs
+++ b/tools/grammar/src/lib.rs
@@ -259,7 +259,7 @@ pub static GRAMMAR_RE: LazyLock<Regex> =
 pub fn load_grammar(diag: &mut Diagnostics) -> Grammar {
     let mut grammar = Grammar::default();
     let base = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../src");
-    for entry in WalkDir::new(&base) {
+    for entry in WalkDir::new(&base).sort_by_file_name() {
         let entry = entry.unwrap();
         let path = entry.path();
         if path.extension().and_then(|s| s.to_str()) != Some("md") {


### PR DESCRIPTION
In `load_grammar`, we were walking files in directory-entry order. This may not be the same order in two places, leading to sections and rules sorted in different orders in the grammar summary.  Let's sort by file name so as to produce deterministic results.
