### PR TITLE
Fix the nightly grammar validation job

### DIFF
--- a/.github/workflows/daily-grammar-check.yml
+++ b/.github/workflows/daily-grammar-check.yml
@@ -39,7 +39,7 @@ jobs:
       continue-on-error: true
       run: |
         cargo run --release -p grammar-check -- lex-compare --path rust
-        cargo run --release -p grammar-check -- lex-compare --permute Token
+        cargo run --release -p grammar-check -- lex-compare --permute Token --tool rustc_parse
 
     - name: Check for existing open issues
       if: steps.grammar-check.outcome == 'failure'

--- a/.github/workflows/daily-grammar-check.yml
+++ b/.github/workflows/daily-grammar-check.yml
@@ -40,6 +40,7 @@ jobs:
       run: |
         cargo run --release -p grammar-check -- lex-compare --path rust
         cargo run --release -p grammar-check -- lex-compare --permute Token --tool rustc_parse
+        cargo run --release -p grammar-check -- lex-compare --permute three
 
     - name: Check for existing open issues
       if: steps.grammar-check.outcome == 'failure'


### PR DESCRIPTION
This includes a fix for the nightly validation job. It also adds a test (the "three" iterator) that I intended to include but forgot.

Closes rust-lang/reference#2332