### PR TITLE
Fix nested block comment grammar

### DIFF
--- a/.github/workflows/daily-grammar-check.yml
+++ b/.github/workflows/daily-grammar-check.yml
@@ -41,6 +41,7 @@ jobs:
         cargo run --release -p grammar-check -- lex-compare --path rust
         cargo run --release -p grammar-check -- lex-compare --permute Token --tool rustc_parse
         cargo run --release -p grammar-check -- lex-compare --permute three
+        cargo run --release -p grammar-check -- lex-compare --tool rustc_parse
 
     - name: Check for existing open issues
       if: steps.grammar-check.outcome == 'failure'

--- a/src/comments.md
+++ b/src/comments.md
@@ -35,7 +35,7 @@ OUTER_LINE_DOC ->
 OUTER_BLOCK_DOC ->
     `/**` ![`*` `/`]
       ^
-      ( ~[`*` CR] | NESTED_BLOCK_DOC_COMMENT )
+      ~[`*` CR]
       ( NESTED_BLOCK_DOC_COMMENT | DOC_BLOCK_CHAR )*
     `*/`
 

--- a/src/comments.md
+++ b/src/comments.md
@@ -18,7 +18,7 @@ LINE_COMMENT ->
 
 BLOCK_COMMENT ->
     `/*` !(`!` | `*` ![`*` `/`]) ^
-      ( BLOCK_COMMENT_OR_DOC | (!`*/` CHAR) )*
+      ( BLOCK_COMMENT_OR_DOC | BLOCK_CHAR )*
     `*/`
 
 INNER_LINE_DOC ->
@@ -27,7 +27,7 @@ INNER_LINE_DOC ->
 LINE_DOC_COMMENT_CONTENT -> (!CR ~LF)*
 
 INNER_BLOCK_DOC ->
-    `/*!` ^ ( BLOCK_COMMENT_OR_DOC | BLOCK_CHAR )* `*/`
+    `/*!` ^ ( BLOCK_COMMENT_OR_DOC | DOC_BLOCK_CHAR )* `*/`
 
 OUTER_LINE_DOC ->
     `///` ^ LINE_DOC_COMMENT_CONTENT (LF | EOF)
@@ -36,10 +36,12 @@ OUTER_BLOCK_DOC ->
     `/**` ![`*` `/`]
       ^
       ( ~[`*` CR] | BLOCK_COMMENT_OR_DOC )
-      ( BLOCK_COMMENT_OR_DOC | BLOCK_CHAR )*
+      ( BLOCK_COMMENT_OR_DOC | DOC_BLOCK_CHAR )*
     `*/`
 
-BLOCK_CHAR -> (!(`*/` | CR) CHAR)
+BLOCK_CHAR -> !`*/` CHAR
+
+DOC_BLOCK_CHAR -> (!(`*/` | CR) CHAR)
 
 BLOCK_COMMENT_OR_DOC ->
       INNER_BLOCK_DOC

--- a/src/comments.md
+++ b/src/comments.md
@@ -44,7 +44,7 @@ BLOCK_CHAR -> !`*/` CHAR
 DOC_BLOCK_CHAR -> (!(`*/` | CR) CHAR)
 
 NESTED_BLOCK_DOC_COMMENT ->
-    `/*` (NESTED_BLOCK_DOC_COMMENT | DOC_BLOCK_CHAR)* `*/`
+    `/*` ( NESTED_BLOCK_DOC_COMMENT | DOC_BLOCK_CHAR )* `*/`
 ```
 
 r[comments.normal]

--- a/src/comments.md
+++ b/src/comments.md
@@ -17,7 +17,7 @@ LINE_COMMENT ->
     | `//` _immediately followed by LF_
 
 BLOCK_COMMENT ->
-    `/*` !(`!` | `*` ![`*` `/`]) ^
+    `/*` ^
       ( BLOCK_COMMENT_OR_DOC | BLOCK_CHAR )*
     `*/`
 

--- a/src/comments.md
+++ b/src/comments.md
@@ -18,7 +18,7 @@ LINE_COMMENT ->
 
 BLOCK_COMMENT ->
     `/*` ^
-      ( BLOCK_COMMENT_OR_DOC | BLOCK_CHAR )*
+      ( BLOCK_COMMENT | BLOCK_CHAR )*
     `*/`
 
 INNER_LINE_DOC ->
@@ -27,7 +27,7 @@ INNER_LINE_DOC ->
 LINE_DOC_COMMENT_CONTENT -> (!CR ~LF)*
 
 INNER_BLOCK_DOC ->
-    `/*!` ^ ( BLOCK_COMMENT_OR_DOC | DOC_BLOCK_CHAR )* `*/`
+    `/*!` ^ ( NESTED_BLOCK_DOC_COMMENT | DOC_BLOCK_CHAR )* `*/`
 
 OUTER_LINE_DOC ->
     `///` ^ LINE_DOC_COMMENT_CONTENT (LF | EOF)
@@ -35,18 +35,16 @@ OUTER_LINE_DOC ->
 OUTER_BLOCK_DOC ->
     `/**` ![`*` `/`]
       ^
-      ( ~[`*` CR] | BLOCK_COMMENT_OR_DOC )
-      ( BLOCK_COMMENT_OR_DOC | DOC_BLOCK_CHAR )*
+      ( ~[`*` CR] | NESTED_BLOCK_DOC_COMMENT )
+      ( NESTED_BLOCK_DOC_COMMENT | DOC_BLOCK_CHAR )*
     `*/`
 
 BLOCK_CHAR -> !`*/` CHAR
 
 DOC_BLOCK_CHAR -> (!(`*/` | CR) CHAR)
 
-BLOCK_COMMENT_OR_DOC ->
-      INNER_BLOCK_DOC
-    | OUTER_BLOCK_DOC
-    | BLOCK_COMMENT
+NESTED_BLOCK_DOC_COMMENT ->
+    `/*` (NESTED_BLOCK_DOC_COMMENT | DOC_BLOCK_CHAR)* `*/`
 ```
 
 r[comments.normal]

--- a/tools/grammar-check/src/main.rs
+++ b/tools/grammar-check/src/main.rs
@@ -419,6 +419,7 @@ fn translate_position(input: &str, index: usize) -> (&str, usize, usize) {
 
 fn display_line(src: &str, range: &Range<usize>) -> String {
     let (line, line_no, col_no) = translate_position(src, range.start);
+    let line = line.replace('\r', "␍");
     let prefix = format!("{line_no}: ");
     let indent = col_no.saturating_sub(1);
     let len = (range.end - range.start).min(line.len().saturating_sub(indent));

--- a/tools/grammar-check/src/test_cases.rs
+++ b/tools/grammar-check/src/test_cases.rs
@@ -43,6 +43,8 @@ cases! {
         "/** outer block doc */"
     comment::cr_starting_block_doc =>
         "/**\r CR starting block doc comment */"
+    comment::cr_starting_inner_block_doc =>
+        "/*!\r CR starting inner block doc comment */"
 
     comment::block::nested_cr1 =>
         "/* /**\r*/ */"
@@ -56,6 +58,10 @@ cases! {
         "/*! /*\r*/ */"
     comment::block::nested_cr6 =>
         "/** /* x\r y */ */"
+    comment::block::nested_cr7 =>
+        "/** /* /*\r*/ */ */"
+    comment::block::nested_cr8 =>
+        "/* /* /**\r*/ */ */"
 
     reserved::pounds =>
         "##"

--- a/tools/grammar-check/src/test_cases.rs
+++ b/tools/grammar-check/src/test_cases.rs
@@ -41,6 +41,8 @@ cases! {
         "/// ☃"
     comment::outer_block_doc =>
         "/** outer block doc */"
+    comment::cr_starting_block_doc =>
+        "/**\r CR starting block doc comment */"
 
     reserved::pounds =>
         "##"
@@ -54,6 +56,9 @@ cases! {
         "'x'"
     string =>
         "\"string\""
+    string::continuation::bare_carriage =>
+        "\"string\\\n\n\r\tcontinuation\""
+
     raw_string =>
         "r\"raw string\""
         "r#\"raw string\"#"
@@ -81,4 +86,7 @@ cases! {
     identifier =>
         "ident"
         "fn"
+
+    shebang::doc_comment =>
+        "#! /** doc */ [attr]\n"
 }

--- a/tools/grammar-check/src/test_cases.rs
+++ b/tools/grammar-check/src/test_cases.rs
@@ -44,6 +44,19 @@ cases! {
     comment::cr_starting_block_doc =>
         "/**\r CR starting block doc comment */"
 
+    comment::block::nested_cr1 =>
+        "/* /**\r*/ */"
+    comment::block::nested_cr2 =>
+        "/* /*!\r*/ */"
+    comment::block::nested_cr3 =>
+        "/* /** x\r y */ */"
+    comment::block::nested_cr4 =>
+        "/** /*\r*/ */"
+    comment::block::nested_cr5 =>
+        "/*! /*\r*/ */"
+    comment::block::nested_cr6 =>
+        "/** /* x\r y */ */"
+
     reserved::pounds =>
         "##"
         "###"


### PR DESCRIPTION
This fixes some issues with nested block comments, particularly with the way it handled CRs.

Fixes rust-lang/reference#2333