### PR TITLE
Restrict `TUPLE_INDEX` to only allow decimal digits

### DIFF
--- a/src/tokens.md
+++ b/src/tokens.md
@@ -563,7 +563,7 @@ r[lex.token.literal.int.tuple-field]
 
 r[lex.token.literal.int.tuple-field.syntax]
 ```grammar,lexer
-TUPLE_INDEX -> DEC_LITERAL | BIN_LITERAL | OCT_LITERAL | HEX_LITERAL
+TUPLE_INDEX -> DEC_DIGIT+
 ```
 
 r[lex.token.literal.int.tuple-field.intro]


### PR DESCRIPTION
I was rather confused after reading the current definition and trying out some code:

    struct Foo(u32);

    fn main() {
        let f = Foo(1);
        let _ = f.0;    // ok
        let _ = f.0_0   // DEC_LTIERAL: error[E0609]: no field `0_0` on type `Foo`
        let _ = f.0b0;  // BIN_LITERAL: error[E0609]: no field `0b0` on type `Foo`
        let _ = f.0o0;  // OCT_LTERAL:  error[E0609]: no field `0o0` on type `Foo`
        let _ = f.0x0;  // HEX_LITERAL: error[E0609]: no field `0x0` on type `Foo`
    }